### PR TITLE
Rename package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
-  "private": true,
-  "name": "cartovl",
-  "version": "0.1.0",
+  "name": "@carto/carto-vl",
+  "version": "0.0.0-alpha-0",
   "description": "CARTO Vector library",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/carto-vl",
-  "version": "0.0.0-alpha-0",
+  "version": "0.2.0",
   "description": "CARTO Vector library",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Rename package (https://github.com/CartoDB/carto-vl/issues/28)
- Remove private flag ([only paid orgs can have private scope packages](https://docs.npmjs.com/misc/scope))
- Specify 0.0.0 version



