### PR TITLE
Developer center

### DIFF
--- a/docs/support/01-support-options.md
+++ b/docs/support/01-support-options.md
@@ -1,0 +1,38 @@
+## Support Options
+
+Feeling stuck? There are many ways to find help.
+
+* Ask a question on [GIS StackExchange](https://gis.stackexchange.com/questions/tagged/carto) using the `CARTO` tag.
+* [Report an issue](https://github.com/CartoDB/cartodb.js/issues) in Github.
+* Engine Plan customers have additional access to enterprise-level support through CARTO's support representatives.
+
+If you just want to describe an issue or share an idea, just <a class="typeform-share" href="https://cartohq.typeform.com/to/mH6RRl" data-mode="popup" target="_blank"> send your feedback</a><script>(function() { var qs,js,q,s,d=document, gi=d.getElementById, ce=d.createElement, gt=d.getElementsByTagName, id="typef_orm_share", b="https://embed.typeform.com/"; if(!gi.call(d,id)){ js=ce.call(d,"script"); js.id=id; js.src=b+"embed.js"; q=gt.call(d,"script")[0]; q.parentNode.insertBefore(js,q) } })() </script>.
+
+### Issues on Github
+
+If you think you may have found a bug, or if you have a feature request that you would like to share with the CARTO VL team, please [open an issue](https://github.com/cartodb/cartodb.js/issues/new). 
+
+Before opening an issue, review the [contributing guidelines](https://github.com/CartoDB/cartodb.js/blob/develop/CONTRIBUTING.md#filling-a-ticket).
+
+
+### Community support on GIS Stack Exchange
+
+GIS Stack Exchange is the most popular community in the geospatial industry. This is a collaboratively-edited question and answer site for geospatial programmers and technicians. It is a fantastic resource for asking technical questions about developing and maintaining your application.
+
+Members of the CARTO VL team regularly monitor the `carto` tag. You can look for CARTO topics by adding `carto` or `cartodb.js` to your search query. You can also add additional tags to your question in order to attract the attention of experts in related technologies.
+
+
+When posting a new question, please consider the following:
+
+* Read the GIS Stack Exchange [help](https://gis.stackexchange.com/help) and [how to ask](https://gis.stackexchange.com/help/how-to-ask) pages for guidelines and tips about posting questions.
+* Be very clear about your question in the subject. A clear explanation helps those trying to answer your question, as well as those who may be looking for information in the future.
+* Be informative in your post. Details, code snippets, logs, screenshots, etc. help others to understand your problem.
+* Use code that demonstrates the problem. It is very hard to debug errors without sample code to reproduce the problem.
+
+### Engine Plan Customers
+
+Engine Plan customers have additional support options beyond general community support. As per your account Terms of Service, you have access to enterprise-level support through CARTO's support representatives available at [enterprise-support@carto.com](mailto:enterprise-support@carto.com)
+
+In order to speed up the resolution of your issue, provide as much information as possible (even if it is a link from community support). This allows our engineers to investigate your problem as soon as possible.
+
+If you are not yet CARTO customer, browse our [plans & pricing](https://carto.com/pricing/) and find the right plan for you.

--- a/docs/support/02-contribute.md
+++ b/docs/support/02-contribute.md
@@ -1,0 +1,36 @@
+## Contribute
+
+CARTO platform is an open-source ecosystem. You can read about the [fundamentals]({{site.fundamental_docs}}/components/) of CARTO architecture and its components.
+We are more than happy to receive your contributions to the code and the documentation as well.
+
+## Filling a ticket
+If you want to open a new issue in our repository, please follow these instructions:
+
+1. Descriptive title.
+2. Write a good description, it always helps.
+3. Include your browser, OS and CartoDB.js version (it shows up in the browser console).
+4. Specify the steps to reproduce the problem.
+5. Try to add an example showing the problem (using [JSFiddle](http://jsfiddle.net), [JSBin](http://jsbin.com),...).
+
+
+## Contributing code
+Best part of open source, collaborate in CARTO VL code!. We like hearing from you, so if you have any bug fixed, or a new feature ready to be merged, those are the steps you should follow:
+
+1. Fork the CartoDB.js repository.
+2. Create a new branch in your forked repository.
+3. Commit your changes. Add new tests if it is necessary (```grunt test```), remember to follow ["How to build"](https://github.com/CartoDB/cartodb.js/blob/master/README.md#how-to-build) steps.
+4. Open a pull request.
+5. Any of the CartoDB.js mantainers will take a look.
+6. If everything works, it will merged and released \o/.
+
+If you want more detailed information, this [GitHub guide](https://guides.github.com/activities/contributing-to-open-source/) is a must.
+
+
+## Completing documentation
+
+CARTO VL documentation is located in ```docs/```. That folder is the content that appears in the [Developer Center](http://carto.com/developer-center/carto-js/). 
+Just follow the instructions described in [contributing code](#contributing-code) and after accepting your pull request, we will make it appear online :).
+
+## Submitting contributions
+
+You will need to sign a Contributor License Agreement (CLA) before making a submission. [Learn more here](https://carto.com/contributions).

--- a/examples/examples.json
+++ b/examples/examples.json
@@ -1,6 +1,6 @@
 {
     "main": {
-        "file": "misc/guide.html"
+        "file": "expressions/ramp-category.html"
     },
     "categories": [
         {


### PR DESCRIPTION
We need to merge these changes in order to enable support page on the developer center, and set up a basic example for the overview page.