### PR TITLE
Fix getWidth() of null bug

### DIFF
--- a/src/api/layer.js
+++ b/src/api/layer.js
@@ -92,7 +92,7 @@ export default class Layer {
     async update(source, style) {
         this._checkSource(source);
         this._checkStyle(style);
-        source = source._clone();                
+        source = source._clone();
         this._atomicChangeUID = this._atomicChangeUID + 1 || 1;
         const uid = this._atomicChangeUID;
         await this._context;

--- a/src/core/renderLayer.js
+++ b/src/core/renderLayer.js
@@ -44,6 +44,9 @@ export default class RenderLayer {
     }
 
     getFeaturesAtPosition(pos) {
+        if (!this.style){
+            return [];
+        }
         return [].concat(...this.getActiveDataframes().map(df => df.getFeaturesAtPosition(pos, this.style))).map(feature => {
 
             const genReset = styleProperty =>


### PR DESCRIPTION
The issue was a race condition. The style property of the renderLayer is only set after initiating rendering (which is expected), but we never checked for that condition on the interactivity of renderLayer.

I think this is only triggered sometimes, and when an async source (like Windshaft) is used, and the user moved the cursor in the loading process of the source.