### PR TITLE
Improve startup time

### DIFF
--- a/src/api/layer.js
+++ b/src/api/layer.js
@@ -95,8 +95,8 @@ export default class Layer {
         source = source._clone();
         this._atomicChangeUID = this._atomicChangeUID + 1 || 1;
         const uid = this._atomicChangeUID;
-        await this._context;
         const metadata = await source.requestMetadata(viz);
+        await this._context;
         if (this._atomicChangeUID > uid) {
             throw new Error('Another atomic change was done before this one committed');
         }


### PR DESCRIPTION
Small change, but quite effective.

I checked 2 different examples and startup times were reduced: 3.8=> 2.1 and 4.5=>3.3

This improves the startup time since it avoids waiting for the context to request the metadata. Request metadata doesn't need the context, so the change should be safe.

We could even improve this by start requesting data without having the context, but in that case, we'll need to wait after the response since we need the context to upload the dataframes to the GPU.
