### PR TITLE
Use vendor file from https://github.com/CartoDB/mapbox-gl-js/commit/4…

### DIFF
--- a/test/integration/user/api/interactivity.test.js
+++ b/test/integration/user/api/interactivity.test.js
@@ -63,7 +63,7 @@ describe('Interactivity', () => {
         });
     });
 
-    fdescribe('when the user clicks on the map', () => {
+    describe('when the user clicks on the map', () => {
         let interactivity;
 
         describe('and the click is in a feature', () => {
@@ -128,8 +128,8 @@ describe('Interactivity', () => {
                 });
                 layer.on('loaded', () => {
                     // Move mouse inside a feature
-                    map.fire('click', { lngLat: { lng: -10, lat: -10 } });
-                    map.fire('mousemove', { lngLat: { lng: 10, lat: 10 } });
+                    map.fire({ type: 'click', lngLat: { lng: -10, lat: -10 } });
+                    map.fire({ type: 'mousemove', lngLat: { lng: 10, lat: 10 } });
                 });
             });
 
@@ -142,7 +142,7 @@ describe('Interactivity', () => {
                 });
                 layer.on('loaded', () => {
                     // Move mouse inside a feature
-                    map.fire('mousemove', { lngLat: { lng: 10, lat: 10 } });
+                    map.fire({ type: 'mousemove', lngLat: { lng: 10, lat: 10 } });
                 });
             });
 
@@ -151,14 +151,14 @@ describe('Interactivity', () => {
                 const featureClickOutSpy = jasmine.createSpy('featureClickOutSpy');
                 layer.on('loaded', () => {
                     // Move mouse inside a feature
-                    map.fire('mousemove', { lngLat: { lng: 10, lat: 10 } });
+                    map.fire({ type: 'mousemove', lngLat: { lng: 10, lat: 10 } });
                     interactivity.on('featureEnter', featureClickOutSpy);
                     interactivity.on('featureHover', () => {
                         expect(featureClickOutSpy).not.toHaveBeenCalled();
                         done();
                     });
                     // Move mouse inside the same feature
-                    map.fire('mousemove', { lngLat: { lng: 20, lat: 20 } });
+                    map.fire({ type: 'mousemove', lngLat: { lng: 20, lat: 20 } });
                 });
             });
         });
@@ -168,13 +168,13 @@ describe('Interactivity', () => {
                 interactivity = new carto.Interactivity(layer);
                 layer.on('loaded', () => {
                     // Move mouse inside a feature
-                    map.fire('mousemove', { lngLat: { lng: 10, lat: 10 } });
+                    map.fire({ type: 'mousemove', lngLat: { lng: 10, lat: 10 } });
                     interactivity.on('featureHover', event => {
                         expect(event.features.length).toEqual(0);
                         done();
                     });
                     // Move mouse outside any feature
-                    map.fire('mousemove', { lngLat: { lng: -10, lat: -10 } });
+                    map.fire({ type: 'mousemove', lngLat: { lng: -10, lat: -10 } });
                 });
             });
 
@@ -182,14 +182,14 @@ describe('Interactivity', () => {
                 interactivity = new carto.Interactivity(layer);
                 layer.on('loaded', () => {
                     // Move mouse inside a feature
-                    map.fire('mousemove', { lngLat: { lng: 10, lat: 10 } });
+                    map.fire({ type: 'mousemove', lngLat: { lng: 10, lat: 10 } });
                     interactivity.on('featureLeave', event => {
                         expect(event.features[0].id).toEqual(0);
                         expect(event.features[0].layerId).toEqual('layer');
                         done();
                     });
                     // Move mouse outside the feature
-                    map.fire('mousemove', { lngLat: { lng: -10, lat: -10 } });
+                    map.fire({ type: 'mousemove', lngLat: { lng: -10, lat: -10 } });
                 });
             });
 
@@ -198,14 +198,14 @@ describe('Interactivity', () => {
                 layer.on('loaded', () => {
                     const featureLeaveSpy = jasmine.createSpy('featureLeaveSpy');
                     // Move mouse outside any feature
-                    map.fire('mousemove', { lngLat: { lng: -10, lat: -10 } });
+                    map.fire({ type: 'mousemove', lngLat: { lng: -10, lat: -10 } });
                     interactivity.on('featureLeave', featureLeaveSpy);
                     interactivity.on('featureHover', () => {
                         expect(featureLeaveSpy).not.toHaveBeenCalled();
                         done();
                     });
                     // Move mouse outside any feature
-                    map.fire('mousemove', { lngLat: { lng: -20, lat: -20 } });
+                    map.fire({ type: 'mousemove', lngLat: { lng: -20, lat: -20 } });
                 });
             });
         });

--- a/test/integration/user/api/interactivity.test.js
+++ b/test/integration/user/api/interactivity.test.js
@@ -10,8 +10,10 @@ describe('Interactivity', () => {
         map = setup.map;
 
         source = new carto.source.GeoJSON(featureJson);
-        viz = new carto.Viz(`color: rgb(255, 0, 0)
-                                 @wadus: 123`);
+        viz = new carto.Viz(`
+            color: rgb(255, 0, 0)
+            @wadus: 123`
+        );
         layer = new carto.Layer('layer', source, viz);
         layer.addTo(map);
     });
@@ -76,10 +78,7 @@ describe('Interactivity', () => {
                     expect(event.features[0].layerId).toEqual('layer');
                     done();
                 });
-                layer.on('loaded', () => {
-                    // Click inside the feature
-                    click();
-                });
+                layer.on('loaded', click);
             });
 
             it('should not fire a featureClickOut event when the same feature is clicked twice', done => {
@@ -110,10 +109,7 @@ describe('Interactivity', () => {
                         expect(event.features[1].layerId).toEqual('layer2');
                         done();
                     });
-                    layer2.on('loaded', () => {
-                        // Click inside the features
-                        click();
-                    });
+                    layer2.on('loaded', click);
                 });
             });
         });

--- a/test/integration/user/api/interactivity.test.js
+++ b/test/integration/user/api/interactivity.test.js
@@ -113,183 +113,145 @@ describe('Interactivity', () => {
                 });
             });
         });
+    });
 
-        describe('when the user move the mouse on the map', () => {
-            let interactivity;
+    describe('when the user move the mouse on the map', () => {
+        let interactivity;
 
-            describe('and the mouse enters in a feature', () => {
-                it('should fire a featureHover event with a features list containing the entered feature', done => {
-                    interactivity = new carto.Interactivity(layer);
-                    interactivity.on('featureHover', event => {
-                        expect(event.features[0].id).toEqual(0);
-                        expect(event.features[0].layerId).toEqual('layer');
-                        done();
-                    });
-                    layer.on('loaded', () => {
-                        // Move mouse inside a feature
-                        map.fire('click', { lngLat: { lng: -10, lat: -10 } });
-                        map.fire('mousemove', { lngLat: { lng: 10, lat: 10 } });
-                    });
+        describe('and the mouse enters in a feature', () => {
+            it('should fire a featureHover event with a features list containing the entered feature', done => {
+                interactivity = new carto.Interactivity(layer);
+                interactivity.on('featureHover', event => {
+                    expect(event.features[0].id).toEqual(0);
+                    expect(event.features[0].layerId).toEqual('layer');
+                    done();
                 });
-
-                it('should fire a featureEnter event with a features list containing the entered feature', done => {
-                    interactivity = new carto.Interactivity(layer);
-                    interactivity.on('featureEnter', event => {
-                        expect(event.features[0].id).toEqual(0);
-                        expect(event.features[0].layerId).toEqual('layer');
-                        done();
-                    });
-                    layer.on('loaded', () => {
-                        // Move mouse inside a feature
-                        map.fire('mousemove', { lngLat: { lng: 10, lat: 10 } });
-                    });
-                });
-
-                it('should not fire a featureEnter event when the mouse is moved inside the same feature', done => {
-                    interactivity = new carto.Interactivity(layer);
-                    const featureClickOutSpy = jasmine.createSpy('featureClickOutSpy');
-                    layer.on('loaded', () => {
-                        // Move mouse inside a feature
-                        map.fire('mousemove', { lngLat: { lng: 10, lat: 10 } });
-                        interactivity.on('featureEnter', featureClickOutSpy);
-                        interactivity.on('featureHover', () => {
-                            expect(featureClickOutSpy).not.toHaveBeenCalled();
-                            done();
-                        });
-                        // Move mouse inside the same feature
-                        map.fire('mousemove', { lngLat: { lng: 20, lat: 20 } });
-                    });
+                layer.on('loaded', () => {
+                    // Move mouse inside a feature
+                    map.fire('click', { lngLat: { lng: -10, lat: -10 } });
+                    map.fire('mousemove', { lngLat: { lng: 10, lat: 10 } });
                 });
             });
 
-            describe('and the mouse leaves a feature', () => {
-                it('should fire a featureHover event with an empty features list', done => {
-                    interactivity = new carto.Interactivity(layer);
-                    layer.on('loaded', () => {
-                        // Move mouse inside a feature
-                        map.fire('mousemove', { lngLat: { lng: 10, lat: 10 } });
-                        interactivity.on('featureHover', event => {
-                            expect(event.features.length).toEqual(0);
-                            done();
-                        });
-                        // Move mouse outside any feature
-                        map.fire('mousemove', { lngLat: { lng: -10, lat: -10 } });
-                    });
+            it('should fire a featureEnter event with a features list containing the entered feature', done => {
+                interactivity = new carto.Interactivity(layer);
+                interactivity.on('featureEnter', event => {
+                    expect(event.features[0].id).toEqual(0);
+                    expect(event.features[0].layerId).toEqual('layer');
+                    done();
                 });
-
-                it('should fire a featureLeave event with a features list containing the previously entered feature', done => {
-                    interactivity = new carto.Interactivity(layer);
-                    layer.on('loaded', () => {
-                        // Move mouse inside a feature
-                        map.fire('mousemove', { lngLat: { lng: 10, lat: 10 } });
-                        interactivity.on('featureLeave', event => {
-                            expect(event.features[0].id).toEqual(0);
-                            expect(event.features[0].layerId).toEqual('layer');
-                            done();
-                        });
-                        // Move mouse outside the feature
-                        map.fire('mousemove', { lngLat: { lng: -10, lat: -10 } });
-                    });
+                layer.on('loaded', () => {
+                    // Move mouse inside a feature
+                    map.fire('mousemove', { lngLat: { lng: 10, lat: 10 } });
                 });
+            });
 
-                it('should not fire a featureLeave event when the mouse is moved outside any feature', done => {
-                    interactivity = new carto.Interactivity(layer);
-                    layer.on('loaded', () => {
-                        const featureLeaveSpy = jasmine.createSpy('featureLeaveSpy');
-                        // Move mouse outside any feature
-                        map.fire('mousemove', { lngLat: { lng: -10, lat: -10 } });
-                        interactivity.on('featureLeave', featureLeaveSpy);
-                        interactivity.on('featureHover', () => {
-                            expect(featureLeaveSpy).not.toHaveBeenCalled();
-                            done();
-                        });
-                        // Move mouse outside any feature
-                        map.fire('mousemove', { lngLat: { lng: -20, lat: -20 } });
+            it('should not fire a featureEnter event when the mouse is moved inside the same feature', done => {
+                interactivity = new carto.Interactivity(layer);
+                const featureClickOutSpy = jasmine.createSpy('featureClickOutSpy');
+                layer.on('loaded', () => {
+                    // Move mouse inside a feature
+                    map.fire('mousemove', { lngLat: { lng: 10, lat: 10 } });
+                    interactivity.on('featureEnter', featureClickOutSpy);
+                    interactivity.on('featureHover', () => {
+                        expect(featureClickOutSpy).not.toHaveBeenCalled();
+                        done();
                     });
+                    // Move mouse inside the same feature
+                    map.fire('mousemove', { lngLat: { lng: 20, lat: 20 } });
                 });
             });
         });
 
-        afterEach(() => {
-            document.body.removeChild(div);
+        describe('and the mouse leaves a feature', () => {
+            it('should fire a featureHover event with an empty features list', done => {
+                interactivity = new carto.Interactivity(layer);
+                layer.on('loaded', () => {
+                    // Move mouse inside a feature
+                    map.fire('mousemove', { lngLat: { lng: 10, lat: 10 } });
+                    interactivity.on('featureHover', event => {
+                        expect(event.features.length).toEqual(0);
+                        done();
+                    });
+                    // Move mouse outside any feature
+                    map.fire('mousemove', { lngLat: { lng: -10, lat: -10 } });
+                });
+            });
+
+            it('should fire a featureLeave event with a features list containing the previously entered feature', done => {
+                interactivity = new carto.Interactivity(layer);
+                layer.on('loaded', () => {
+                    // Move mouse inside a feature
+                    map.fire('mousemove', { lngLat: { lng: 10, lat: 10 } });
+                    interactivity.on('featureLeave', event => {
+                        expect(event.features[0].id).toEqual(0);
+                        expect(event.features[0].layerId).toEqual('layer');
+                        done();
+                    });
+                    // Move mouse outside the feature
+                    map.fire('mousemove', { lngLat: { lng: -10, lat: -10 } });
+                });
+            });
+
+            it('should not fire a featureLeave event when the mouse is moved outside any feature', done => {
+                interactivity = new carto.Interactivity(layer);
+                layer.on('loaded', () => {
+                    const featureLeaveSpy = jasmine.createSpy('featureLeaveSpy');
+                    // Move mouse outside any feature
+                    map.fire('mousemove', { lngLat: { lng: -10, lat: -10 } });
+                    interactivity.on('featureLeave', featureLeaveSpy);
+                    interactivity.on('featureHover', () => {
+                        expect(featureLeaveSpy).not.toHaveBeenCalled();
+                        done();
+                    });
+                    // Move mouse outside any feature
+                    map.fire('mousemove', { lngLat: { lng: -20, lat: -20 } });
+                });
+            });
         });
     });
 
-    function _setup(name) {
-        const div = document.createElement('div');
-        div.id = name;
-        div.style.width = '1000px';
-        div.style.height = '1000px';
-        document.body.appendChild(div);
-
-        const map = new mapboxgl.Map({
-            container: name,
-            style: { version: 8, sources: {}, layers: [] },
-            center: [30, 30],
-            zoom: 12
-        });
-
-        return { div, map };
-    }
-
-    function click() {
-        const mglInteractivity = document.querySelector('.mapboxgl-interactive');
-        const ev = new MouseEvent('click', {});
-        mglInteractivity.dispatchEvent(ev);
-    }
-
-    const featureJson = {
-        type: 'Feature',
-        geometry: {
-            type: 'Polygon',
-            coordinates: [
-                [
-                    [0, 0],
-                    [50, 0],
-                    [50, 50],
-                    [0, 50],
-                    [0, 0]
-                ]
-            ]
-        },
-        properties: {}
-    };
-
-    const featureCollectionJson = {
-        type: 'FeatureCollection',
-        features: [
-            {
-                type: 'Feature',
-                geometry: {
-                    type: 'Polygon',
-                    coordinates: [
-                        [
-                            [0, 0],
-                            [50, 0],
-                            [50, 50],
-                            [0, 50],
-                            [0, 0]
-                        ]
-                    ]
-                },
-                properties: {}
-            },
-            {
-                type: 'Feature',
-                geometry: {
-                    type: 'Polygon',
-                    coordinates: [
-                        [
-                            [0, 0],
-                            [55, 0],
-                            [55, 55],
-                            [0, 55],
-                            [0, 0]
-                        ]
-                    ]
-                },
-                properties: {}
-            }
-        ]
-    };
+    afterEach(() => {
+        document.body.removeChild(div);
+    });
 });
+
+function _setup(name) {
+    const div = document.createElement('div');
+    div.id = name;
+    div.style.width = '1000px';
+    div.style.height = '1000px';
+    document.body.appendChild(div);
+
+    const map = new mapboxgl.Map({
+        container: name,
+        style: { version: 8, sources: {}, layers: [] },
+        center: [30, 30],
+        zoom: 12
+    });
+
+    return { div, map };
+}
+
+function click() {
+    const mglInteractivity = document.querySelector('.mapboxgl-interactive');
+    const ev = new MouseEvent('click', {});
+    mglInteractivity.dispatchEvent(ev);
+}
+
+const featureJson = {
+    type: 'Feature',
+    geometry: {
+        type: 'Polygon',
+        coordinates: [
+            [
+                [0, 0],
+                [50, 0],
+                [50, 50],
+                [0, 50],
+                [0, 0]
+            ]
+        ]
+    },
+    properties: {}
+};

--- a/test/integration/user/api/interactivity.test.js
+++ b/test/integration/user/api/interactivity.test.js
@@ -61,7 +61,7 @@ describe('Interactivity', () => {
         });
     });
 
-    describe('when the user clicks on the map', () => {
+    fdescribe('when the user clicks on the map', () => {
         let interactivity;
 
         describe('and the click is in a feature', () => {
@@ -78,81 +78,41 @@ describe('Interactivity', () => {
                 });
                 layer.on('loaded', () => {
                     // Click inside the feature
-                    map.fire('click', { lngLat: { lng: 10, lat: 10 } });
+                    click();
                 });
-                layer.addTo(map);
             });
 
             it('should not fire a featureClickOut event when the same feature is clicked twice', done => {
                 interactivity = new carto.Interactivity(layer);
                 const featureClickOutSpy = jasmine.createSpy('featureClickOutSpy');
-                interactivity.on('featureClick', () => {
-                    expect(featureClickOutSpy).not.toHaveBeenCalled();
-                    done();
-                });
+                const featureClickSpy = jasmine.createSpy('featureClickSpy');
+                interactivity.on('featureClick', featureClickSpy);
                 interactivity.on('featureClickOut', featureClickOutSpy);
                 layer.on('loaded', () => {
                     // Click inside the feature
-                    map.fire('click', { lngLat: { lng: 10, lat: 10 } });
-                    // Move the mouse
-                    map.fire('mousemove', { lngLat: { lng: 15, lat: 15 } });
-                    // Click inside the same feature
-                    map.fire('click', { lngLat: { lng: 20, lat: 20 } });
+                    click();
+                    click();
+                    expect(featureClickOutSpy).not.toHaveBeenCalled();
+                    expect(featureClickSpy).toHaveBeenCalled();
+                    done();
                 });
-                layer.addTo(map);
             });
 
             describe('and multiple features are clicked', () => {
                 it('should return the right feature.id', done => {
-                    source = new carto.source.GeoJSON(featureCollectionJson);
-                    layer = new carto.Layer('layer', source, new carto.Viz());
-                    interactivity = new carto.Interactivity(layer);
+                    const layer2 = new carto.Layer('layer2', new carto.source.GeoJSON(featureJson), new carto.Viz());
+                    layer2.addTo(map);
+                    interactivity = new carto.Interactivity([layer, layer2]);
                     interactivity.on('featureClick', event => {
                         expect(event.features[0].id).toEqual(0);
                         expect(event.features[0].layerId).toEqual('layer');
-                        expect(event.features[1].id).toEqual(1);
-                        expect(event.features[1].layerId).toEqual('layer');
+                        expect(event.features[1].id).toEqual(0);
+                        expect(event.features[1].layerId).toEqual('layer2');
                         done();
                     });
-                    layer.on('loaded', () => {
+                    layer2.on('loaded', () => {
                         // Click inside the features
-                        map.fire('click', { lngLat: { lng: 10, lat: 10 } });
-                    });
-                    layer.addTo(map);
-                });
-            });
-
-            describe('and the click is not in a feature', () => {
-                it('should fire a featureClick event with an empty features list', done => {
-                    interactivity = new carto.Interactivity(layer);
-                    interactivity.on('featureClick', event => {
-                        expect(event.features.length).toEqual(0);
-                        done();
-                    });
-                    // Click outside the feature
-                    layer.on('loaded', () => {
-                        map.fire('click', { lngLat: { lng: -10, lat: -10 } });
-                    });
-                    layer.addTo(map);
-                });
-
-                describe('and a feature was previously clicked', () => {
-                    it('should fire a featureClickOut event with a features list containing the previously clicked feature', done => {
-                        interactivity = new carto.Interactivity(layer);
-                        interactivity.on('featureClickOut', event => {
-                            expect(event.features[0].id).toEqual(0);
-                            expect(event.features[0].layerId).toEqual('layer');
-                            done();
-                        });
-                        layer.on('loaded', () => {
-                            // Click inside the feature
-                            map.fire('click', { lngLat: { lng: 10, lat: 10 } });
-                            // Move the mouse
-                            map.fire('mousemove', { lngLat: { lng: 0, lat: 0 } });
-                            // Click outside the feature
-                            map.fire('click', { lngLat: { lng: -10, lat: -10 } });
-                        });
-                        layer.addTo(map);
+                        click();
                     });
                 });
             });
@@ -171,9 +131,9 @@ describe('Interactivity', () => {
                     });
                     layer.on('loaded', () => {
                         // Move mouse inside a feature
+                        map.fire('click', { lngLat: { lng: -10, lat: -10 } });
                         map.fire('mousemove', { lngLat: { lng: 10, lat: 10 } });
                     });
-                    layer.addTo(map);
                 });
 
                 it('should fire a featureEnter event with a features list containing the entered feature', done => {
@@ -187,7 +147,6 @@ describe('Interactivity', () => {
                         // Move mouse inside a feature
                         map.fire('mousemove', { lngLat: { lng: 10, lat: 10 } });
                     });
-                    layer.addTo(map);
                 });
 
                 it('should not fire a featureEnter event when the mouse is moved inside the same feature', done => {
@@ -204,7 +163,6 @@ describe('Interactivity', () => {
                         // Move mouse inside the same feature
                         map.fire('mousemove', { lngLat: { lng: 20, lat: 20 } });
                     });
-                    layer.addTo(map);
                 });
             });
 
@@ -221,7 +179,6 @@ describe('Interactivity', () => {
                         // Move mouse outside any feature
                         map.fire('mousemove', { lngLat: { lng: -10, lat: -10 } });
                     });
-                    layer.addTo(map);
                 });
 
                 it('should fire a featureLeave event with a features list containing the previously entered feature', done => {
@@ -237,7 +194,6 @@ describe('Interactivity', () => {
                         // Move mouse outside the feature
                         map.fire('mousemove', { lngLat: { lng: -10, lat: -10 } });
                     });
-                    layer.addTo(map);
                 });
 
                 it('should not fire a featureLeave event when the mouse is moved outside any feature', done => {
@@ -254,7 +210,6 @@ describe('Interactivity', () => {
                         // Move mouse outside any feature
                         map.fire('mousemove', { lngLat: { lng: -20, lat: -20 } });
                     });
-                    layer.addTo(map);
                 });
             });
         });
@@ -267,18 +222,24 @@ describe('Interactivity', () => {
     function _setup(name) {
         const div = document.createElement('div');
         div.id = name;
-        div.style.width = '100px';
-        div.style.height = '100px';
+        div.style.width = '1000px';
+        div.style.height = '1000px';
         document.body.appendChild(div);
 
         const map = new mapboxgl.Map({
             container: name,
             style: { version: 8, sources: {}, layers: [] },
-            center: [0, 30],
-            zoom: 2
+            center: [30, 30],
+            zoom: 12
         });
 
         return { div, map };
+    }
+
+    function click() {
+        const mglInteractivity = document.querySelector('.mapboxgl-interactive');
+        const ev = new MouseEvent('click', {});
+        mglInteractivity.dispatchEvent(ev);
     }
 
     const featureJson = {


### PR DESCRIPTION
Use vendor file from https://github.com/CartoDB/mapbox-gl-js/commit/4b58dc3ced816bb36199fc284ebe6f93e5f9e29c

Update MGL vendor file to get a fix for the same as https://github.com/CartoDB/carto-vl/pull/311

The problem was visible on the country borders of the basemap, particularly/usually in Africa, where many country borders disappeared.

The issue was that we were modifying one of the VAOs of MGL, and we weren't invalidating that. The patched version binds the default VAO to avoid modifying MGL VAOs