### PR TITLE
Support String API comments

### DIFF
--- a/src/core/viz/functions.js
+++ b/src/core/viz/functions.js
@@ -35,9 +35,18 @@
  * const viz = new carto.Viz({
  *   width: s.div(
  *     s.prop('population'),
- *     s.number(10000)  // Equivalent to 10000
+ *     10000
  *  )
  * });
+ * ```
+ *
+ * All these expressions can be used also from a String API. This API is a more compact way to create and use your expressions.
+ * It has shortcut notation to access your feature properties using the `$` symbol. It also allows inline comments using the JavaScript style.
+ *
+ * ```javascript
+ * const viz = new carto.Viz(`
+ *   width: $population / 10000  // Size proportional to the population for each feature
+ * `);
  * ```
  *
  * Although expression combination is very powerful, you must be aware of the different types to produce valid combinations.

--- a/src/core/viz/parser.js
+++ b/src/core/viz/parser.js
@@ -25,7 +25,7 @@ export function parseVizExpression(str) {
 
 export function parseVizDefinition(str) {
     prepareJsep();
-    const ast = jsep(str);
+    const ast = jsep(cleanComments(str));
     let vizSpec = { variables: {} };
     if (ast.type == 'Compound') {
         ast.body.map(node => parseVizNamedExpr(vizSpec, node));
@@ -178,4 +178,13 @@ function cleanJsep() {
     jsep.removeIdentifierChar('#');
     jsep.addLiteral('true');
     jsep.addLiteral('false');
+}
+
+/**
+ * Remove comments from string
+ * - // one line comments
+ */
+function cleanComments(str) {
+    return str
+        .replace(/\/\/.*/g, '');
 }

--- a/src/core/viz/parser.js
+++ b/src/core/viz/parser.js
@@ -182,9 +182,11 @@ function cleanJsep() {
 
 /**
  * Remove comments from string
- * - // one line comments
- */
+ * - // one-line comments
+ * - /* multi-line
+ *     comments */
 function cleanComments(str) {
     return str
-        .replace(/\/\/.*/g, '');
+        .replace(/\/\/.*/g, '')
+        .replace(/\/\*(\*(?!\/)|[^*])*\*\//g, '');
 }

--- a/src/core/viz/parser.js
+++ b/src/core/viz/parser.js
@@ -184,7 +184,7 @@ function cleanJsep() {
  * Remove comments from string
  * - // line comments
  * - /* block comments
- * - ' " Keep comments inside single and double quotes
+ * - Keep comments inside single and double quotes tracking escape chars
  * Based on: https://j11y.io/javascript/removing-comments-in-javascript/
  */
 export function cleanComments(str) {
@@ -192,7 +192,8 @@ export function cleanComments(str) {
         singleQuote: false,
         doubleQuote: false,
         blockComment: false,
-        lineComment: false
+        lineComment: false,
+        escape: 0
     };
 
     // Adding chars to avoid index checking
@@ -201,15 +202,21 @@ export function cleanComments(str) {
     for (var i = 0, l = str.length; i < l; i++) {
 
         if (mode.singleQuote) {
-            if (str[i] === '\'' && str[i-1] !== '\\') {
+            if (str[i] == '\\') {
+                mode.escape++;
+            } else if (str[i] === '\'' && mode.escape % 2 == 0) {
                 mode.singleQuote = false;
+                mode.escape = 0;
             }
             continue;
         }
 
         if (mode.doubleQuote) {
-            if (str[i] === '"' && str[i-1] !== '\\') {
+            if (str[i] == '\\') {
+                mode.escape++;
+            } else if (str[i] === '"' && mode.escape % 2 == 0) {
                 mode.doubleQuote = false;
+                mode.escape = 0;
             }
             continue;
         }

--- a/src/core/viz/parser.js
+++ b/src/core/viz/parser.js
@@ -182,11 +182,75 @@ function cleanJsep() {
 
 /**
  * Remove comments from string
- * - // one-line comments
- * - /* multi-line
- *     comments */
+ * - // line comments
+ * - /* block comments
+ * - ' " Keep comments inside single and double quotes
+ * Based on: https://j11y.io/javascript/removing-comments-in-javascript/
+ */
 export function cleanComments(str) {
-    return str
-        .replace(/\/\/.*/g, '')
-        .replace(/\/\*(\*(?!\/)|[^*])*\*\//g, '');
+    var mode = {
+        singleQuote: false,
+        doubleQuote: false,
+        blockComment: false,
+        lineComment: false
+    };
+
+    // Adding chars to avoid index checking
+    str = ('_' + str + '_').split('');
+
+    for (var i = 0, l = str.length; i < l; i++) {
+
+        if (mode.singleQuote) {
+            if (str[i] === '\'' && str[i-1] !== '\\') {
+                mode.singleQuote = false;
+            }
+            continue;
+        }
+
+        if (mode.doubleQuote) {
+            if (str[i] === '"' && str[i-1] !== '\\') {
+                mode.doubleQuote = false;
+            }
+            continue;
+        }
+
+        if (mode.blockComment) {
+            if (str[i] === '*' && str[i+1] === '/') {
+                str[i+1] = '';
+                mode.blockComment = false;
+            }
+            str[i] = '';
+            continue;
+        }
+
+        if (mode.lineComment) {
+            if (str[i+1] === '\n' || str[i+1] === '\r') {
+                mode.lineComment = false;
+            }
+            if (i+1 < l) {
+                str[i] = '';
+            }
+            continue;
+        }
+
+        mode.doubleQuote = str[i] === '"';
+        mode.singleQuote = str[i] === '\'';
+
+        if (str[i] === '/') {
+
+            if (str[i+1] === '*') {
+                str[i] = '';
+                mode.blockComment = true;
+                continue;
+            }
+            if (str[i+1] === '/') {
+                str[i] = '';
+                mode.lineComment = true;
+                continue;
+            }
+        }
+    }
+
+    // Remove chars added before
+    return str.join('').slice(1, -1);
 }

--- a/src/core/viz/parser.js
+++ b/src/core/viz/parser.js
@@ -185,7 +185,7 @@ function cleanJsep() {
  * - // one-line comments
  * - /* multi-line
  *     comments */
-function cleanComments(str) {
+export function cleanComments(str) {
     return str
         .replace(/\/\/.*/g, '')
         .replace(/\/\*(\*(?!\/)|[^*])*\*\//g, '');

--- a/test/unit/core/viz/parser.test.js
+++ b/test/unit/core/viz/parser.test.js
@@ -1,12 +1,28 @@
-import { parseVizDefinition } from '../../../../src/core/viz/parser';
+import { parseVizDefinition, cleanComments } from '../../../../src/core/viz/parser';
 
 describe('src/core/viz/parser', () => {
+
+    // TODO: missing lots of tests here
+
+    describe('.cleanComments', () => {
+        it('should remove the one-line comments', () => {
+            const str = 'width: 1// one-line comment';
+            expect(cleanComments(str)).toBe('width: 1');
+        });
+
+        it('should remove the multi-line comments', () => {
+            const str = 'width: 1/* multi-line \ncomment */\ncolor: blue';
+            expect(cleanComments(str)).toBe('width: 1\ncolor: blue');
+        });
+    });
+
     describe('and/or don\'t interfere with `ordering`', () => {
         it('`color: rgb(255,255,255) ordering: asc(width())` should not throw', () => {
             const str = 'color: rgb(255,255,255)\nordering: asc(width())';
             expect(() => parseVizDefinition(str)).not.toThrow();
         });
     });
+
     describe('and/or are accepted', () => {
         it('`color: rgb(255,255,255)\nfilter: 1 or 0` should not throw', () => {
             const str = 'color: rgb(255,255,255)\nfilter: 1 or 0';

--- a/test/unit/core/viz/parser.test.js
+++ b/test/unit/core/viz/parser.test.js
@@ -4,15 +4,45 @@ describe('src/core/viz/parser', () => {
 
     // TODO: missing lots of tests here
 
-    describe('.cleanComments', () => {
-        it('should remove the one-line comments', () => {
-            const str = 'width: 1// one-line comment';
+    fdescribe('.cleanComments', () => {
+        it('should remove line comments without endline', () => {
+            const str = 'width: 1// line comment';
             expect(cleanComments(str)).toBe('width: 1');
         });
 
-        it('should remove the multi-line comments', () => {
-            const str = 'width: 1/* multi-line \ncomment */\ncolor: blue';
-            expect(cleanComments(str)).toBe('width: 1\ncolor: blue');
+        it('should remove line comments with endline', () => {
+            const str = 'width: 1// line comment\n';
+            expect(cleanComments(str)).toBe('width: 1\n');
+        });
+
+        it('should keep line comments inside simple quotes', () => {
+            const str = '@var: \'// line comment\'';
+            expect(cleanComments(str)).toBe('@var: \'// line comment\'');
+        });
+
+        it('should keep line comments inside simple quotes', () => {
+            const str = '@var: "// line comment"';
+            expect(cleanComments(str)).toBe('@var: "// line comment"');
+        });
+
+        it('should remove block comments without endline', () => {
+            const str = 'width: 1/* block\ncomment */';
+            expect(cleanComments(str)).toBe('width: 1');
+        });
+
+        it('should remove block comments with endline', () => {
+            const str = 'width: 1/* block\ncomment */\n';
+            expect(cleanComments(str)).toBe('width: 1\n');
+        });
+
+        it('should keep block comments inside simple quotes', () => {
+            const str = '@var: \'/* block\ncomment */\'';
+            expect(cleanComments(str)).toBe('@var: \'/* block\ncomment */\'');
+        });
+
+        it('should keep block comments inside simple quotes', () => {
+            const str = '@var: "/* block\ncomment */"';
+            expect(cleanComments(str)).toBe('@var: "/* block\ncomment */"');
         });
     });
 

--- a/test/unit/core/viz/parser.test.js
+++ b/test/unit/core/viz/parser.test.js
@@ -1,3 +1,5 @@
+/* eslint quotes: "off" */
+
 import { parseVizDefinition, cleanComments } from '../../../../src/core/viz/parser';
 
 describe('src/core/viz/parser', () => {
@@ -6,43 +8,49 @@ describe('src/core/viz/parser', () => {
 
     describe('.cleanComments', () => {
         it('should remove line comments without endline', () => {
-            const str = 'width: 1// line comment';
-            expect(cleanComments(str)).toBe('width: 1');
+            expect(cleanComments('width: 1// line comment')).toBe('width: 1');
         });
 
         it('should remove line comments with endline', () => {
-            const str = 'width: 1// line comment\n';
-            expect(cleanComments(str)).toBe('width: 1\n');
+            expect(cleanComments('width: 1// line comment\n')).toBe('width: 1\n');
         });
 
-        it('should keep line comments inside simple quotes', () => {
-            const str = '@var: \'// line comment\'';
-            expect(cleanComments(str)).toBe('@var: \'// line comment\'');
+        it('should keep line comments inside single quotes', () => {
+            expect(cleanComments("@var: '// line comment'")).toBe("@var: '// line comment'");
         });
 
-        it('should keep line comments inside simple quotes', () => {
-            const str = '@var: "// line comment"';
-            expect(cleanComments(str)).toBe('@var: "// line comment"');
+        it('should keep line comments inside double quotes', () => {
+            expect(cleanComments('@var: "// line comment"')).toBe('@var: "// line comment"');
         });
 
         it('should remove block comments without endline', () => {
-            const str = 'width: 1/* block\ncomment */';
-            expect(cleanComments(str)).toBe('width: 1');
+            expect(cleanComments('width: 1/* block\ncomment */')).toBe('width: 1');
         });
 
         it('should remove block comments with endline', () => {
-            const str = 'width: 1/* block\ncomment */\n';
-            expect(cleanComments(str)).toBe('width: 1\n');
+            expect(cleanComments('width: 1/* block\ncomment */\n')).toBe('width: 1\n');
         });
 
-        it('should keep block comments inside simple quotes', () => {
-            const str = '@var: \'/* block\ncomment */\'';
-            expect(cleanComments(str)).toBe('@var: \'/* block\ncomment */\'');
+        it('should keep block comments inside single quotes', () => {
+            expect(cleanComments("@var: '/* block\ncomment */'")).toBe("@var: '/* block\ncomment */'");
         });
 
-        it('should keep block comments inside simple quotes', () => {
-            const str = '@var: "/* block\ncomment */"';
-            expect(cleanComments(str)).toBe('@var: "/* block\ncomment */"');
+        it('should keep block comments inside double quotes', () => {
+            expect(cleanComments('@var: "/* block\ncomment */"')).toBe('@var: "/* block\ncomment */"');
+        });
+
+        it('should manage properly the escape chars for single quotes', () => {
+            expect(cleanComments("@var: '\\' // comment'")).toBe("@var: '\\' // comment'");
+            expect(cleanComments("@var: '\\\\' // comment")).toBe("@var: '\\\\' ");
+            expect(cleanComments("@var: '\\\\\\' // comment'")).toBe("@var: '\\\\\\' // comment'");
+            expect(cleanComments("@var: '\\\\\\\\' // comment")).toBe("@var: '\\\\\\\\' ");
+        });
+
+        it('should manage properly the escape chars for double quotes', () => {
+            expect(cleanComments('@var: "\\" // comment"')).toBe('@var: "\\" // comment"');
+            expect(cleanComments('@var: "\\\\" // comment"')).toBe('@var: "\\\\" ');
+            expect(cleanComments('@var: "\\\\\\" // comment"')).toBe('@var: "\\\\\\" // comment"');
+            expect(cleanComments('@var: "\\\\\\\\" // comment"')).toBe('@var: "\\\\\\\\" ');
         });
     });
 

--- a/test/unit/core/viz/parser.test.js
+++ b/test/unit/core/viz/parser.test.js
@@ -4,7 +4,7 @@ describe('src/core/viz/parser', () => {
 
     // TODO: missing lots of tests here
 
-    fdescribe('.cleanComments', () => {
+    describe('.cleanComments', () => {
         it('should remove line comments without endline', () => {
             const str = 'width: 1// line comment';
             expect(cleanComments(str)).toBe('width: 1');


### PR DESCRIPTION
Related to https://github.com/CartoDB/carto-vl/issues/370

- Clean one-line comment in viz string
- Clean multi-line-comments in viz string
- Add unit tests