### PR TITLE
Remove buggy unnecessary code

### DIFF
--- a/src/core/viz/expressions/base.js
+++ b/src/core/viz/expressions/base.js
@@ -157,7 +157,6 @@ export default class Base {
         final = implicitCast(final);
         const parent = this.parent;
         const blender = blend(this, final, animate(duration));
-        this._metaBindings.map(m => blender._bind(m));
         parent.replaceChild(this, blender);
         blender.notify();
         return final;
@@ -167,7 +166,6 @@ export default class Base {
         final = implicitCast(final);
         const parent = this.parent;
         const blender = blend(final, this, animate(duration), interpolator);
-        this._metaBindings.map(m => blender._bind(m));
         parent.replaceChild(this, blender);
         blender.notify();
     }

--- a/test/integration/user/api/expressions.test.js
+++ b/test/integration/user/api/expressions.test.js
@@ -1,30 +1,26 @@
 import * as carto from '../../../../src/';
 import * as util from '../../util';
 
-describe('Layer', () => {
-    let source, div, viz, viz2, layer, map;
+describe('BaseExpression', () => {
+    let source, div, viz, layer, map;
 
     beforeEach(() => {
         const setup = util.createMap('map');
-        div = setup.div;
         map = setup.map;
+        div = setup.div;
 
         source = new carto.source.GeoJSON(featureJSON);
-        viz = new carto.Viz(`
-            @myColor: red
-            color: @myColor
-        `);
-        viz2 = new carto.Viz(`
-            color: blue
-        `);
+        viz = new carto.Viz('@var1: 0.5');
+
         layer = new carto.Layer('layer', source, viz);
         layer.addTo(map);
     });
 
-    describe('.blendToViz', () => {
+    describe('.blendTo', () => {
         it('should resolve the Promise with a valid viz', (done) => {
             layer.on('loaded', () => {
-                layer.blendToViz(viz2).then(done);
+                viz.filter.blendTo(carto.expressions.var('var1'));
+                done();
             });
         });
     });


### PR DESCRIPTION
The removed lines ` this._metaBindings.map(m => blender._bind(m));	` were throwing, but they shouldn't be necessary since `_bind` is called on `viz.js` in every case. This was quite legacy code.

Regression test added.

Layer test modified since it wasn't cleaning the DOM state.