### PR TITLE
Allow setting the resolution directly

### DIFF
--- a/src/api/viz.js
+++ b/src/api/viz.js
@@ -59,7 +59,9 @@ export default class Viz {
         this._checkVizSpec(vizSpec);
 
         Object.keys(vizSpec).forEach(property => {
-            if (SUPPORTED_PROPERTIES.includes(property)) {
+            if (property == 'resolution') {
+                this._resolution = vizSpec[property];
+            } else if (SUPPORTED_PROPERTIES.includes(property)) {
                 this[property] = vizSpec[property];
             }
         });
@@ -75,6 +77,14 @@ export default class Viz {
 
         this._resolveAliases();
         this._validateAliasDAG();
+    }
+
+    get resolution(){
+        return this._resolution;
+    }
+    set resolution(x){
+        this._resolution = x;
+        this._changed();
     }
 
     _getRootExpressions() {

--- a/test/unit/api/viz.test.js
+++ b/test/unit/api/viz.test.js
@@ -245,9 +245,18 @@ describe('api/viz', () => {
         });
     });
 
+    describe('resolution changes', () => {
+        it('should be effective and notify observers', done => {
+            const viz = new Viz();
+            viz.onChange(done);
+            viz.resolution = 8;
+            expect(viz.resolution).toEqual(8);
+        });
+    });
+
     describe('aliases', () => {
         it('should throw an error when the graph is not a DAG', () => {
-            expect(()=>new Viz(`width: ramp(linear($numeric, 0, 10), [0.10,0.20,0.30]) * __cartovl_variable_ten
+            expect(() => new Viz(`width: ramp(linear($numeric, 0, 10), [0.10,0.20,0.30]) * __cartovl_variable_ten
                 __cartovl_variable_oneHundred: __cartovl_variable_ten * __cartovl_variable_ten
                 __cartovl_variable_ten: __cartovl_variable_oneHundred / 10
             `)).toThrowError('Viz contains a circular dependency');


### PR DESCRIPTION
Previously, the only way to change the resolution was to use `layer.blendToViz`. This allows to set it directly with `viz.resolution = 5`.

I thought about using `blendTo`, but it didn't make much sense since the resolution cannot be animated, so I decided to stick to the current way, but improve it.

Address: https://github.com/CartoDB/carto-vl/issues/384