### PR TITLE
Refactor interactivity objects

### DIFF
--- a/src/api/feature.js
+++ b/src/api/feature.js
@@ -1,0 +1,43 @@
+import FeatureVizProperty from './featureVizProperty';
+
+/**
+ *
+ * Feature objects are provided by {@link FeatureEvent} events.
+ *
+ * @typedef {object} Feature
+ * @property {number} id - Unique identification code
+ * @property {FeatureVizProperty} color
+ * @property {FeatureVizProperty} width
+ * @property {FeatureVizProperty} colorStroke
+ * @property {FeatureVizProperty} widthStroke
+ * @property {FeatureVizProperty[]} variables - Declared variables in the viz object
+ * @property {function} reset - Reset custom feature vizs by fading out `duration` milliseconds, where `duration` is the first parameter to reset
+ * @api
+ */
+export default class Feature {
+    constructor(rawFeature, viz, customizedFeatures, trackFeatureViz) {
+        const variables = {};
+        Object.keys(viz.variables).map(varName => {
+            variables[varName] = new FeatureVizProperty(`__cartovl_variable_${varName}`, rawFeature, viz, customizedFeatures, trackFeatureViz);
+        });
+
+        this.id = rawFeature.id;
+        this.color = new FeatureVizProperty('color', rawFeature, viz, customizedFeatures, trackFeatureViz);
+        this.width = new FeatureVizProperty('width', rawFeature, viz, customizedFeatures, trackFeatureViz);
+        this.strokeColor = new FeatureVizProperty('strokeColor', rawFeature, viz, customizedFeatures, trackFeatureViz);
+        this.strokeWidth = new FeatureVizProperty('strokeWidth', rawFeature, viz, customizedFeatures, trackFeatureViz);
+        this.variables = variables;
+    }
+
+    reset(duration = 500) {
+        this.color.reset(duration);
+        this.width.reset(duration);
+        this.strokeColor.reset(duration);
+        this.strokeWidth.reset(duration);
+
+        for (let key in this.variables) {
+            this.variables[key].reset(duration);
+        }
+
+    }
+}

--- a/src/api/featureVizProperty.js
+++ b/src/api/featureVizProperty.js
@@ -1,5 +1,5 @@
-import { blend, property, animate, notEquals } from './viz/functions';
-import { parseVizExpression } from './viz/parser';
+import { blend, property, animate, notEquals } from '../core/viz/functions';
+import { parseVizExpression } from '../core/viz/parser';
 
 /**
  *
@@ -11,7 +11,7 @@ import { parseVizExpression } from './viz/parser';
  * @property {function} value - Getter that evaluates the property and returns the computed value
  * @api
  */
-export class VizProperty {
+export default class FeatureVizProperty {
     get value() {
         return this._viz[this._propertyName].eval(this._properties);
     }
@@ -22,12 +22,12 @@ export class VizProperty {
         this._viz = viz;
         this._properties = this._feature.properties;
 
-        this.blendTo = generateBlenderFunction(propertyName, feature, customizedFeatures, viz, trackFeatureViz);
-        this.reset = generateResetFunction(propertyName, feature, customizedFeatures, viz);
+        this.blendTo = _generateBlenderFunction(propertyName, feature, customizedFeatures, viz, trackFeatureViz);
+        this.reset = _generateResetFunction(propertyName, feature, customizedFeatures, viz);
     }
 }
 
-export function generateResetFunction(propertyName, feature, customizedFeatures, viz) {
+function _generateResetFunction(propertyName, feature, customizedFeatures, viz) {
     return function reset(duration = 500) {
         if (customizedFeatures[feature.id] && customizedFeatures[feature.id][propertyName]) {
             customizedFeatures[feature.id][propertyName].replaceChild(
@@ -42,7 +42,7 @@ export function generateResetFunction(propertyName, feature, customizedFeatures,
 }
 
 
-function generateBlenderFunction(propertyName, feature, customizedFeatures, viz, trackFeatureViz) {
+function _generateBlenderFunction(propertyName, feature, customizedFeatures, viz, trackFeatureViz) {
     return function generatedBlendTo(newExpression, duration = 500) {
         if (typeof newExpression == 'string') {
             newExpression = parseVizExpression(newExpression);

--- a/src/api/interactivity.js
+++ b/src/api/interactivity.js
@@ -30,18 +30,6 @@ import { wToR } from '../client/rsys';
  */
 
 /**
- *
- * FeatureVizProperty objects can be accessed through {@link Feature} objects.
- *
- * @typedef {object} FeatureVizProperty
- * @property {function} blendTo - Change the feature viz by blending to a destination viz expression `expr` in `duration` milliseconds, where `expr` is the first parameter and `duration` the last one
- * @property {function} reset - Reset custom feature viz property by fading out `duration` milliseconds, where `duration` is the first parameter to reset
- * @property {function} value - Getter that evaluates the property and returns the computed value
- * @api
- */
-
-
-/**
  * featureClick events are fired when the user clicks on features. The list of features behind the cursor is provided.
  *
  * @event featureClick

--- a/src/api/interactivity.js
+++ b/src/api/interactivity.js
@@ -15,21 +15,6 @@ import { wToR } from '../client/rsys';
  */
 
 /**
- *
- * Feature objects are provided by {@link FeatureEvent} events.
- *
- * @typedef {object} Feature
- * @property {number} id - Unique identification code
- * @property {FeatureVizProperty} color
- * @property {FeatureVizProperty} width
- * @property {FeatureVizProperty} colorStroke
- * @property {FeatureVizProperty} widthStroke
- * @property {FeatureVizProperty[]} variables - Declared variables in the viz object
- * @property {function} reset - Reset custom feature vizs by fading out `duration` milliseconds, where `duration` is the first parameter to reset
- * @api
- */
-
-/**
  * featureClick events are fired when the user clicks on features. The list of features behind the cursor is provided.
  *
  * @event featureClick

--- a/src/core/renderLayer.js
+++ b/src/core/renderLayer.js
@@ -1,4 +1,5 @@
-import { generateResetFunction, VizProperty } from './vizProperty';
+import Feature from '../api/feature';
+
 export default class RenderLayer {
     constructor() {
         this.dataframes = [];
@@ -45,30 +46,14 @@ export default class RenderLayer {
         if (!this.viz) {
             return [];
         }
-        return [].concat(...this.getActiveDataframes().map(df => df.getFeaturesAtPosition(pos, this.viz))).map(feature => {
-            const variables = {};
-            Object.keys(this.viz.variables).map(varName => {
-                variables[varName] = new VizProperty(`__cartovl_variable_${varName}`, feature, this.viz, this.customizedFeatures, this.trackFeatureViz);
-            });
+        return [].concat(...this.getActiveDataframes().map(df => df.getFeaturesAtPosition(pos, this.viz))).map(this._generateApiFeature.bind(this));
+    }
 
-            return {
-                id: feature.id,
-                color: new VizProperty('color', feature, this.viz, this.customizedFeatures, this.trackFeatureViz),
-                width: new VizProperty('width', feature, this.viz, this.customizedFeatures, this.trackFeatureViz),
-                strokeColor: new VizProperty('strokeColor', feature, this.viz, this.customizedFeatures, this.trackFeatureViz),
-                strokeWidth: new VizProperty('strokeWidth', feature, this.viz, this.customizedFeatures, this.trackFeatureViz),
-                variables,
-                reset: (duration = 500) => {
-                    generateResetFunction('color', feature, this.customizedFeatures, this.viz)(duration);
-                    generateResetFunction('width', feature, this.customizedFeatures, this.viz)(duration);
-                    generateResetFunction('strokeColor', feature, this.customizedFeatures, this.viz)(duration);
-                    generateResetFunction('strokeWidth', feature, this.customizedFeatures, this.viz)(duration);
-                    Object.keys(this.viz.variables).map(varName => {
-                        variables[varName] = generateResetFunction(`__cartovl_variable_${varName}`, feature, this.customizedFeatures, this.viz)(duration);
-                    });
-                }
-            };
-        });
+    /**
+     * Return a public `Feature` object from the internal feature object obtained from a dataframe.
+     */
+    _generateApiFeature(rawFeature) {
+        return new Feature(rawFeature, this.viz, this.customizedFeatures, this.trackFeatureViz);
     }
 
     trackFeatureViz(featureID, vizProperty, newViz, customizedFeatures) {

--- a/src/core/vizProperty.js
+++ b/src/core/vizProperty.js
@@ -1,0 +1,66 @@
+import { blend, property, animate, notEquals } from './viz/functions';
+import { parseVizExpression } from './viz/parser';
+
+/**
+ *
+ * FeatureVizProperty objects can be accessed through {@link Feature} objects.
+ *
+ * @typedef {object} FeatureVizProperty
+ * @property {function} blendTo - Change the feature viz by blending to a destination viz expression `expr` in `duration` milliseconds, where `expr` is the first parameter and `duration` the last one
+ * @property {function} reset - Reset custom feature viz property by fading out `duration` milliseconds, where `duration` is the first parameter to reset
+ * @property {function} value - Getter that evaluates the property and returns the computed value
+ * @api
+ */
+export class VizProperty {
+    get value() {
+        return this._viz[this._propertyName].eval(this._properties);
+    }
+
+    constructor(propertyName, feature, viz, customizedFeatures, trackFeatureViz) {
+        this._propertyName = propertyName;
+        this._feature = feature;
+        this._viz = viz;
+        this._properties = this._feature.properties;
+
+        this.blendTo = generateBlenderFunction(propertyName, feature, customizedFeatures, viz, trackFeatureViz);
+        this.reset = generateResetFunction(propertyName, feature, customizedFeatures, viz);
+    }
+}
+
+export function generateResetFunction(propertyName, feature, customizedFeatures, viz) {
+    return function reset(duration = 500) {
+        if (customizedFeatures[feature.id] && customizedFeatures[feature.id][propertyName]) {
+            customizedFeatures[feature.id][propertyName].replaceChild(
+                customizedFeatures[feature.id][propertyName].mix,
+                // animate(0) is used to ensure that blend._predraw() "GC" collects it
+                blend(notEquals(property('cartodb_id'), feature.id), animate(0), animate(duration))
+            );
+            viz[propertyName].notify();
+            customizedFeatures[feature.id][propertyName] = undefined;
+        }
+    };
+}
+
+
+function generateBlenderFunction(propertyName, feature, customizedFeatures, viz, trackFeatureViz) {
+    return function generatedBlendTo(newExpression, duration = 500) {
+        if (typeof newExpression == 'string') {
+            newExpression = parseVizExpression(newExpression);
+        }
+        if (customizedFeatures[feature.id] && customizedFeatures[feature.id][propertyName]) {
+            customizedFeatures[feature.id][propertyName].a.blendTo(newExpression, duration);
+            return;
+        }
+        const blendExpr = blend(
+            newExpression,
+            viz[propertyName],
+            blend(1, notEquals(property('cartodb_id'), feature.id), animate(duration))
+        );
+        trackFeatureViz(feature.id, propertyName, blendExpr, customizedFeatures);
+        viz.replaceChild(
+            viz[propertyName],
+            blendExpr,
+        );
+        viz[propertyName].notify();
+    };
+}


### PR DESCRIPTION
When trying to start #403 I found the interactivity code hard to follow.

This PR creates well-defined objects (`Feature`, `FeatureVizProperty`), reduces code duplication and adds functions depending of the parameters instead of scoped variables.

With this changes the `RenderLayer` code got simplified a lot since the feature-related logic was moved away.