### PR TITLE
Hide `order:` from the public API

### DIFF
--- a/src/api/viz.js
+++ b/src/api/viz.js
@@ -59,7 +59,7 @@ export default class Viz {
     * @property {carto.expressions.Base} strokeColor - stroke/border color of points and polygons, not applicable to lines
     * @property {carto.expressions.Base} strokeWidth - stroke width of points and polygons, not applicable to lines
     * @property {carto.expressions.Base} filter - filter features by removing from rendering and interactivity all the features that don't pass the test
-    * @property {carto.expressions.Base} order - rendering order of the features, only applicable to points
+    * @IGNOREproperty {carto.expressions.Base} order - rendering order of the features, only applicable to points
     * @property {number} resolution - resolution of the property-aggregation functions, a value of 4 means to produce aggregation on grid cells of 4x4 pixels, only applicable to points
     * @property {object} variables - An object describing the variables used.
     *

--- a/src/core/viz/expressions/ordering.js
+++ b/src/core/viz/expressions/ordering.js
@@ -21,7 +21,7 @@ import { checkInstance } from './utils';
  * @memberof carto.expressions
  * @name asc
  * @function
- * @api
+ * @IGNOREapi
  */
 export class Asc extends BaseExpression {
     constructor(by) {
@@ -51,7 +51,7 @@ export class Asc extends BaseExpression {
  * @memberof carto.expressions
  * @name desc
  * @function
- * @api
+ * @IGNOREapi
  */
 export class Desc extends BaseExpression {
     constructor(by) {
@@ -80,7 +80,7 @@ export class Desc extends BaseExpression {
  * @memberof carto.expressions
  * @name noOrder
  * @function
- * @api
+ * @IGNOREapi
  */
 export class NoOrder extends BaseExpression {
     constructor() {
@@ -108,7 +108,7 @@ export class NoOrder extends BaseExpression {
  * @memberof carto.expressions
  * @name width
  * @function
- * @api
+ * @IGNOREapi
  */
 export class Width extends BaseExpression {
     constructor() {

--- a/src/core/viz/functions.js
+++ b/src/core/viz/functions.js
@@ -6,7 +6,6 @@
  *  - **strokeColor**: stroke/border color of points and polygons, not applicable to lines
  *  - **width**: fill diameter of points, thickness of lines, not applicable to polygons
  *  - **strokeWidth**: stroke width of points and polygons, not applicable to lines
- *  - **order**: rendering order of the features, only applicable to points
  *  - **filter**: filter features by removing from rendering and interactivity all the features that don't pass the test
  *  - **resolution**: resolution of the property-aggregation functions, a value of 4 means to produce aggregation on grid cells of 4x4 pixels, only applicable to points
  *


### PR DESCRIPTION
https://github.com/CartoDB/carto-vl/issues/447