### PR TITLE
Fix cache buster problem with `_uid`

### DIFF
--- a/src/core/viz/expressions/base.js
+++ b/src/core/viz/expressions/base.js
@@ -2,8 +2,6 @@ import { implicitCast } from './utils';
 import { blend, animate } from '../functions';
 import * as schema from '../../schema';
 
-let uid = 0;
-
 /**
  * Abstract expression class
  *

--- a/src/core/viz/expressions/base.js
+++ b/src/core/viz/expressions/base.js
@@ -32,12 +32,16 @@ export default class Base {
         this._getChildren().map(child => child.parent = this);
         this.preface = '';
         this._shaderBindings = new Map();
-        this._uid = uid++;
     }
 
     _bind(metadata) {
         this._compile(metadata);
         return this;
+    }
+
+    _setUID(idGenerator){
+        this._uid = idGenerator.getID(this);
+        this._getChildren().map(child => child._setUID(idGenerator));
     }
 
     _prefaceCode(glslCode) {

--- a/src/core/viz/shader-compiler.js
+++ b/src/core/viz/shader-compiler.js
@@ -1,4 +1,19 @@
+class IDGenerator {
+    constructor() {
+        this._ids = new Map();
+    }
+    getID(expression) {
+        if (this._ids.has(expression)) {
+            return this._ids.get(expression);
+        }
+        const id = this._ids.size;
+        this._ids.set(expression, id);
+        return id;
+    }
+}
+
 export function compileShader(gl, vizRootExpr, shaderCreator) {
+    vizRootExpr._setUID(new IDGenerator());
     let tid = {};
     const colorModifier = vizRootExpr._applyToShaderSource(name => {
         if (tid[name] === undefined) {


### PR DESCRIPTION
The `_uid` property of the expression was busting the shader cache since the UID is used for shader code generation. That UID is needed on the shader, but the IDs don't need to be completely unique, they need to be unique for their shader. Therefore, this PR sets the ID at shader compilation time, this makes the IDs equals respect the same expression tree used in another moment. 

Example of the new generated GLSL code:
```


precision highp float;

varying vec2 uv;


/* Width */

// From pixels in [0.,255.] to [0.,1.] in exponential-like form
float encodeWidth(float x){
    if (x < 16.){
        x = x * 4.;
    } else if (x < 80.){
        x = (x - 16.) + 64.;
    } else{
        x = (x - 80.) * 0.5 + 128.;
    }
    return x / 255.;
}

        #ifndef DEF_0
        #define DEF_0
        
        #ifndef DEF_1
        #define DEF_1
        
        #ifndef DEF_2
        #define DEF_2
        
        #ifndef DEF_3
        #define DEF_3
        
        #ifndef DEF_5
        #define DEF_5
        uniform float number5;
        #endif
        
        #endif
        
        #endif
        
        #ifndef DEF_6
        #define DEF_6
        uniform float number6;
        #endif
        
        #endif
        
        #ifndef DEF_7
        #define DEF_7
        
        #ifndef DEF_8
        #define DEF_8
        
        #ifndef DEF_10
        #define DEF_10
        uniform float number10;
        #endif
        
        #endif
        
        #endif
        
        #ifndef DEF_11
        #define DEF_11
        
        #ifndef DEF_12
        #define DEF_12
        uniform float anim12;

        #endif
        
    #ifndef CUBIC
    #define CUBIC
    float cubicEaseInOut(float p){
        if (p < 0.5) {
            return 4. * p * p * p;
        }else {
            float f = ((2. * p) - 2.);
            return 0.5 * f * f * f + 1.;
        }
    }
    #endif

        #endif
        
        #endif
        uniform sampler2D propertyTex0;

void main(void) {
    vec2 featureID = uv;
    gl_FragColor = vec4(encodeWidth(mix((sqrt((texture2D(propertyTex0, featureID).a / number5)) + number6), sqrt((texture2D(propertyTex0, featureID).a / number10)), clamp(cubicEaseInOut(anim12), 0., 1.))));
}
```

Example of the previous generated GLSL code:
```


precision highp float;

varying vec2 uv;

/*Color*/
        #ifndef DEF_130
        #define DEF_130
        
        #ifndef DEF_87
        #define DEF_87
        
        #ifndef DEF_85
        #define DEF_85
        
        #ifndef DEF_84
        #define DEF_84
        
        #ifndef DEF_81
        #define DEF_81
        
        #ifndef DEF_80
        #define DEF_80
        uniform float number80;
        #endif
        
        #endif
        
        #ifndef DEF_82
        #define DEF_82
        uniform float number82;
        #endif
        
        #ifndef DEF_83
        #define DEF_83
        uniform float number83;
        #endif
        
        #endif
        
        uniform sampler2D texRamp85;
        uniform float keyMin85;
        uniform float keyWidth85;
        
        #endif
        
        #ifndef DEF_86
        #define DEF_86
        uniform float number86;
        #endif
        
        #endif
        
        #ifndef DEF_116
        #define DEF_116
        
        #ifndef DEF_114
        #define DEF_114
        
        #ifndef DEF_113
        #define DEF_113
        
        #ifndef DEF_110
        #define DEF_110
        
        #ifndef DEF_109
        #define DEF_109
        uniform float number109;
        #endif
        
        #endif
        
        #ifndef DEF_111
        #define DEF_111
        uniform float number111;
        #endif
        
        #ifndef DEF_112
        #define DEF_112
        uniform float number112;
        #endif
        
        #endif
        
        uniform sampler2D texRamp114;
        uniform float keyMin114;
        uniform float keyWidth114;
        
        #endif
        
        #ifndef DEF_115
        #define DEF_115
        uniform float number115;
        #endif
        
        #endif
        
        #ifndef DEF_129
        #define DEF_129
        
        #ifndef DEF_128
        #define DEF_128
        uniform float anim128;

        #endif
        
    #ifndef CUBIC
    #define CUBIC
    float cubicEaseInOut(float p){
        if (p < 0.5) {
            return 4. * p * p * p;
        }else {
            float f = ((2. * p) - 2.);
            return 0.5 * f * f * f + 1.;
        }
    }
    #endif

        #endif
        
        #endif
        uniform sampler2D propertyTex0;

void main(void) {
    vec2 featureID = uv;
    gl_FragColor = mix(vec4((texture2D(texRamp85, vec2((((pow(texture2D(propertyTex0, featureID).a, number80)-number82)/(number83-number82))-keyMin85)/keyWidth85, 0.5)).rgba).rgb, number86), vec4((texture2D(texRamp114, vec2((((pow(texture2D(propertyTex0, featureID).a, number109)-number111)/(number112-number111))-keyMin114)/keyWidth114, 0.5)).rgba).rgb, number115), clamp(cubicEaseInOut(anim128), 0., 1.));
}
```

I checked the performance and now I see the expected cache hits. However, we still get some not very good cache misses caused by the addition of extra blends when blending multiple times before the previous blends are finished. But that's... outside the scope of this :smile: