### PR TITLE
Fix variable _resolveAliases method to avoid having repeated names

### DIFF
--- a/src/core/viz/expressions/basic/variable.js
+++ b/src/core/viz/expressions/basic/variable.js
@@ -47,6 +47,7 @@ export default class Variable extends BaseExpression {
     _resolveAliases(aliases) {
         if (aliases[this.name]) {
             this.childrenNames.push('alias');
+            this.childrenNames = [...(new Set(this.childrenNames))];
             this.alias = aliases[this.name];
         } else {
             throw new Error(`variable() name '${this.name}' doesn't exist`);


### PR DESCRIPTION
Easy fix, not so easy to debug problem. This was causing a major performance problem when using variables. Multiple repeated names were being added to `childrenNames`, which is used by almost all recursive methods in the expressions. This caused that something as trivial as an `isAnimated` method call cost 20 ms. By counting the number of visited nodes in those recursive calls I saw this: 55313 visited nodes!

Before fix profiling:
![perf-bug](https://user-images.githubusercontent.com/1692175/40549690-74433d2e-6038-11e8-8b7a-48d8ebf8bc91.png)

After fix profiling:
![perf-fix](https://user-images.githubusercontent.com/1692175/40549837-cb9788d2-6038-11e8-8177-3447ccd7b720.png)


After the fix, the map I was debugging (editor => ethnic example) recovered the 60fps :small_airplane: 