### PR TITLE
Windshaft error control

### DIFF
--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -350,6 +350,9 @@ export default class Windshaft {
         }
         const response = await fetch(endpoint(conf), this._getRequestConfig(mapConfigAgg));
         const layergroup = await response.json();
+        if (!response.ok) {
+            throw new Error(`Maps API error: ${JSON.stringify(layergroup)}`);
+        }
         this._subdomains = layergroup.cdn_url ? layergroup.cdn_url.templates.https.subdomains : [];
         return {
             url: getLayerUrl(layergroup, LAYER_INDEX, conf),


### PR DESCRIPTION
I detected a problem when asking for invalid property names in the `viz`. As expected, things failed, however, it left the status in a place where the map couldn't recover.

This happened because, after the next blendToViz, the previous `viz` was marked as `ok`, so it tried to create a blending between the invalid property and the new, valid, one. This cause another invalid reinstantiation.

The root cause of this is that when Maps API returned some error, the client didn't check the HTTP status code, and the returned error was in a JSON format compatible with the expected response (in the sense that no error was thrown at instantiation time). In fact, this created an MVT tile rule with a layergroupID of `undefined`.

This problem is deeply related with https://github.com/CartoDB/carto-vl/issues/210 but, that issue is focused on managing the errors with good user message, while this PR just detects the HTTP status code error and throws a not perfectly formatted error.

I think that for now, we could just live with this patch, and in the future, we should take a closer look at that issue and go case by case, error by error.

Note: this PR starts from https://github.com/CartoDB/carto-vl/pull/471 , wait for that merge before merging this.