### PR TITLE
Sample without geometry

### DIFF
--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -255,7 +255,7 @@ export default class Windshaft {
         return MNS.columns.some(column => R.schema.column.isAggregated(column));
     }
 
-    _generateAggregation(MRS, resolution) {
+    _generateAggregation(MNS, resolution) {
         let aggregation = {
             columns: {},
             dimensions: {},
@@ -264,7 +264,7 @@ export default class Windshaft {
             threshold: 1,
         };
 
-        MRS.columns
+        MNS.columns
             .forEach(name => {
                 if (name !== 'cartodb_id') {
                     if (R.schema.column.isAggregated(name)) {
@@ -281,8 +281,8 @@ export default class Windshaft {
         return aggregation;
     }
 
-    _buildSelectClause(MRS, dateFields = []) {
-        const columns = MRS.columns.map(name => R.schema.column.getBase(name)).map(
+    _buildSelectClause(MNS, dateFields = []) {
+        const columns = MNS.columns.map(name => R.schema.column.getBase(name)).map(
             name => dateFields.includes(name) ? name + '::text' : name
         ).concat(['the_geom', 'the_geom_webmercator', 'cartodb_id']);
         return columns.filter((item, pos) => columns.indexOf(item) == pos); // get unique values

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -282,14 +282,14 @@ export default class Windshaft {
     }
 
     _buildSelectClause(MRS, dateFields = []) {
-        return MRS.columns.map(name => R.schema.column.getBase(name)).map(
+        const columns = MRS.columns.map(name => R.schema.column.getBase(name)).map(
             name => dateFields.includes(name) ? name + '::text' : name
-        )
-            .concat(['the_geom', 'the_geom_webmercator', 'cartodb_id']);
+        ).concat(['the_geom', 'the_geom_webmercator', 'cartodb_id']);
+        return columns.filter((item, pos) => columns.indexOf(item) == pos); // get unique values
     }
 
     _buildQuery(select, filters) {
-        const columns = select.filter((item, pos) => select.indexOf(item) == pos).join();
+        const columns = select.join();
         const relation = this._source._query ? `(${this._source._query}) as _cdb_query_wrapper` : this._source._tableName;
         const condition = filters ? windshaftFiltering.getSQLWhere(filters) : '';
         return `SELECT ${columns} FROM ${relation} ${condition}`;


### PR DESCRIPTION
Geometry can get large easily (e.g. polygons) and we don't need it in the sample, so avoid it.

This requires [backend changes](https://github.com/CartoDB/Windshaft-cartodb/pull/968) to be deployed