### PR TITLE
Minor performance improvement

### DIFF
--- a/src/core/shaders/geometry/line-glsl.js
+++ b/src/core/shaders/geometry/line-glsl.js
@@ -18,14 +18,15 @@ varying lowp vec4 color;
 
 // From [0.,1.] in exponential-like form to pixels in [0.,255.]
 float decodeWidth(float x){
-    x*=255.;
-    if (x < 64.){
-        return x*0.25;
-    }else if (x<128.){
-        return (x-64.)+16.;
-    }else{
-        return (x-127.)*2.+80.;
+    float w;
+    if (x < 0.25098039215686274){ // x < 64/255
+        w = 63.75 * x; // 255 * 0.25
+    }else if (x < 0.5019607843137255){ // x < 128/255
+        w = x*255. -48.;
+    }else {
+        w = x*510. -174.;
     }
+    return w;
 }
 
 void main(void) {

--- a/src/core/shaders/geometry/point-glsl.js
+++ b/src/core/shaders/geometry/point-glsl.js
@@ -72,14 +72,15 @@ varying highp float strokeScale;
 
 // From [0.,1.] in exponential-like form to pixels in [0.,255.]
 float decodeWidth(float x){
-    x*=255.;
-    if (x < 64.){
-        return x*0.25;
-    }else if (x<128.){
-        return (x-64.)+16.;
-    }else{
-        return (x-127.)*2.+80.;
+    float w;
+    if (x < 0.25098039215686274){ // x < 64/255
+        w = 63.75 * x; // 255 * 0.25
+    }else if (x < 0.5019607843137255){ // x < 128/255
+        w = x*255. -48.;
+    }else {
+        w = x*510. -174.;
     }
+    return w;
 }
 
 void main(void) {

--- a/src/core/shaders/geometry/triangle-glsl.js
+++ b/src/core/shaders/geometry/triangle-glsl.js
@@ -1,6 +1,6 @@
 export const VS = `
 
-precision highp float;
+precision mediump float;
 
 attribute vec2 vertexPosition;
 attribute vec2 featureID;
@@ -15,18 +15,19 @@ uniform sampler2D strokeColorTex;
 uniform sampler2D strokeWidthTex;
 uniform sampler2D filterTex;
 
-varying highp vec4 color;
+varying lowp vec4 color;
 
 // From [0.,1.] in exponential-like form to pixels in [0.,255.]
 float decodeWidth(float x){
-    x*=255.;
-    if (x < 64.){
-        return x*0.25;
-    }else if (x<128.){
-        return (x-64.)+16.;
-    }else{
-        return (x-127.)*2.+80.;
+    float w;
+    if (x < 0.25098039215686274){ // x < 64/255
+        w = 63.75 * x; // 255 * 0.25
+    }else if (x < 0.5019607843137255){ // x < 128/255
+        w = x*255. -48.;
+    }else {
+        w = x*510. -174.;
     }
+    return w;
 }
 
 void main(void) {
@@ -50,9 +51,9 @@ void main(void) {
 }`;
 
 export const FS = `
-precision highp float;
+precision lowp float;
 
-varying highp vec4 color;
+varying lowp vec4 color;
 
 void main(void) {
     gl_FragColor = color;

--- a/test/benchmark/benchmark.html
+++ b/test/benchmark/benchmark.html
@@ -36,7 +36,7 @@
     });
 
     carto.setDefaultAuth({
-      user: 'mamataakella',
+      user: 'cartovl',
       apiKey: 'default_public'
     });
 

--- a/test/benchmark/benchmark.html
+++ b/test/benchmark/benchmark.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <title>Animation | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -15,6 +16,7 @@
       margin: 0;
       padding: 0;
     }
+
     #map {
       position: absolute;
       height: 100%;
@@ -22,33 +24,34 @@
     }
   </style>
 </head>
+
 <body>
   <div id="map"></div>
   <script>
     const map = new mapboxgl.Map({
       container: 'map',
       style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
-      center: [0, 30],
-      zoom: 1
+      center: [-104.93637263263889, 39.72562104533162],
+      zoom: 11
     });
 
     carto.setDefaultAuth({
-      user: 'cartovl',
+      user: 'mamataakella',
       apiKey: 'default_public'
     });
 
-    const source = new carto.source.Dataset(`
-      wwi
-    `);
+    const source = new carto.source.Dataset('parcels');
     const s = carto.expressions;
-    const viz = new carto.Viz({
-        width: s.mul(s.blend(1, 2, s.near(s.prop('day'), s.mod(s.mul(25, s.now()), 1000), 0, 10), s.cubic), s.zoom()),
-        color: s.ramp(s.linear(s.clusterAvg(s.prop('temp')), 0, 30), s.palettes.TEALROSE),
-        filter: s.blend(0.005, 1, s.near(s.prop('day'), s.mod(s.mul(25, s.now()), 1000), 0, 10), s.cubic)
-    });
+    const viz = new carto.Viz(`
+    filter: ((  torque(linear($ccyrblt, 1873, 2018), 20, fade(0, 100000))  +0.1   ) and neq($ccyrblt, 0))
+    color: ramp(linear(($total_valu/$area ), 0, (globalPercentile($total_valu, 99))/1000    )  , ag_sunset)
+    strokeColor: rgba(255,255,255,0.2)
+    strokeWidth: 0
+  `);
     const layer = new carto.Layer('layer', source, viz);
 
     layer.addTo(map, 'watername_ocean');
   </script>
 </body>
+
 </html>

--- a/test/benchmark/benchmark.js
+++ b/test/benchmark/benchmark.js
@@ -23,19 +23,27 @@ puppeteer.launch({
                     window.requestAnimationFrame(metrics);
                 }
             });
-            page.waitFor(15000).then(() => {
+            page.waitFor(60000).then(() => {
                 page.evaluate(() => {
                     return Promise.resolve(window.times);
                 }).then(times => {
                     const sampleSize = times.length;
                     const avg = times.reduce((x, y) => x + y) / times.length;
+
+                    const diffs = times.map((value) => value - avg);
+                    const squareDiffs = diffs.map((diff) => diff * diff);
+                    const avgSquareDiff = squareDiffs.reduce((x, y) => x + y) / squareDiffs.length;
+                    const std = Math.sqrt(avgSquareDiff);
+
+                    const stderr = std / Math.sqrt(sampleSize);
+
                     times.sort((x, y) => x - y);
                     const p99 = times[Math.floor(times.length * 99 / 100)];
                     const p90 = times[Math.floor(times.length * 90 / 100)];
                     let over60FPS = 0;
                     times.map(t => over60FPS += t < 16.5 ? 1 / times.length : 0);
                     over60FPS = over60FPS * 100 + ' %';
-                    console.log({ sampleSize, avg, p90, p99, over60FPS });
+                    console.log({ sampleSize, avg, stderr, p90, p99, over60FPS });
                     browser.close();
                 });
             });


### PR DESCRIPTION
I tried to improve the performance in cases where there are many vertices.

The results are mediocre, to be honest. They are a 0.3%.

However, I think we should merge this anyway because the code is almost as simple as before and the improvement may be better in other circumstances (datasets, styles, and hardware).

This PR also includes a minor improvement to `benchmark.js` to show the standard error of the average, to be able to compare averages with some context. See http://www.stat.wmich.edu/s216/book/node81.html#zci2

Results (avg is in milliseconds, lower is better):
```
Before patch
avg: 21.851120473157415,
stderr: 0.07242037686506851

After patch
avg: 21.783982937012162,
stderr: 0.07237076023544146,
```