### PR TITLE
Torque input and duration parameter support for variables

### DIFF
--- a/src/core/viz/expressions/aggregation/clusterAggregation.js
+++ b/src/core/viz/expressions/aggregation/clusterAggregation.js
@@ -28,7 +28,7 @@ import { checkInstance, checkType } from '../utils';
  * @function
  * @api
  */
-export const ClusterAvg = genAggregationOp('avg', 'number');
+export const ClusterAvg = genAggregationOp('clusterAvg', 'number');
 
 /**
  * Aggregate using the maximum. This operation disables the access to the property
@@ -55,7 +55,7 @@ export const ClusterAvg = genAggregationOp('avg', 'number');
  * @function
  * @api
  */
-export const ClusterMax = genAggregationOp('max', 'number');
+export const ClusterMax = genAggregationOp('clusterMax', 'number');
 
 /**
  * Aggregate using the minimum. This operation disables the access to the property
@@ -82,7 +82,7 @@ export const ClusterMax = genAggregationOp('max', 'number');
  * @function
  * @api
  */
-export const ClusterMin = genAggregationOp('min', 'number');
+export const ClusterMin = genAggregationOp('clusterMin', 'number');
 
 /**
  * Aggregate using the mode. This operation disables the access to the property
@@ -109,7 +109,7 @@ export const ClusterMin = genAggregationOp('min', 'number');
  * @function
  * @api
  */
-export const ClusterMode = genAggregationOp('mode', 'category');
+export const ClusterMode = genAggregationOp('clusterMode', 'category');
 
 /**
  * Aggregate using the sum. This operation disables the access to the property
@@ -136,12 +136,13 @@ export const ClusterMode = genAggregationOp('mode', 'category');
  * @function
  * @api
  */
-export const ClusterSum = genAggregationOp('sum', 'number');
+export const ClusterSum = genAggregationOp('clusterSum', 'number');
 
-function genAggregationOp(aggName, aggType) {
+function genAggregationOp(expressionName, aggType) {
+    const aggName = expressionName.replace('cluster', '').toLowerCase();
     return class AggregationOperation extends BaseExpression {
         constructor(property) {
-            checkInstance(aggName, 'property', 0, PropertyExpression, property);
+            checkInstance(expressionName, 'property', 0, PropertyExpression, property);
             super({ property });
             this._aggName = aggName;
             this.type = aggType;
@@ -161,7 +162,7 @@ function genAggregationOp(aggName, aggType) {
         //Override super methods, we don't want to let the property use the raw column, we must use the agg suffixed one
         _compile(metadata) {
             super._compile(metadata);
-            checkType(aggName, 'property', 0, aggType, this.property);
+            checkType(expressionName, 'property', 0, aggType, this.property);
         }
         _applyToShaderSource(getGLSLforProperty) {
             return {

--- a/src/core/viz/expressions/basic/variable.js
+++ b/src/core/viz/expressions/basic/variable.js
@@ -49,6 +49,7 @@ export default class Variable extends BaseExpression {
             this.childrenNames.push('alias');
             this.childrenNames = [...(new Set(this.childrenNames))];
             this.alias = aliases[this.name];
+            this.type = this.alias.type;
         } else {
             throw new Error(`variable() name '${this.name}' doesn't exist`);
         }

--- a/src/core/viz/expressions/basic/variable.js
+++ b/src/core/viz/expressions/basic/variable.js
@@ -29,7 +29,7 @@ import { checkString } from '../utils';
  */
 export default class Variable extends BaseExpression {
     constructor(name) {
-        checkString('name', 'name', 0, name);
+        checkString('variable', 'name', 0, name);
         if (name == '') {
             throw new Error('variable(): invalid parameter, zero-length string');
         }

--- a/src/core/viz/expressions/basic/variable.js
+++ b/src/core/viz/expressions/basic/variable.js
@@ -49,7 +49,6 @@ export default class Variable extends BaseExpression {
             this.childrenNames.push('alias');
             this.childrenNames = [...(new Set(this.childrenNames))];
             this.alias = aliases[this.name];
-            this.type = this.alias.type;
         } else {
             throw new Error(`variable() name '${this.name}' doesn't exist`);
         }

--- a/src/core/viz/expressions/belongs.js
+++ b/src/core/viz/expressions/belongs.js
@@ -75,7 +75,7 @@ function generateBelongsExpression(name, inlineMaker, jsEval) {
             checkExpression(name, 'list', 1, list);
 
             checkLooseType(name, 'value', 0, 'category', value);
-            checkType(name, 'list', 1, 'category-array', list);
+            checkLooseType(name, 'list', 1, 'category-array', list);
 
             let children = { value };
             list.elems.map((arg, index) => children[`arg${index}`] = arg);

--- a/src/core/viz/expressions/ramp.js
+++ b/src/core/viz/expressions/ramp.js
@@ -61,7 +61,7 @@ export default class Ramp extends BaseExpression {
 
         checkExpression('ramp', 'input', 0, input);
         checkLooseType('ramp', 'input', 0, ['number', 'category'], input);
-        checkType('ramp', 'palette', 1, ['palette', 'color-array', 'number-array'], palette);
+        checkLooseType('ramp', 'palette', 1, ['palette', 'color-array', 'number-array'], palette);
 
         super({ input: input });
         this.minKey = 0;

--- a/src/core/viz/expressions/torque.js
+++ b/src/core/viz/expressions/torque.js
@@ -123,7 +123,7 @@ export class Torque extends BaseExpression {
         duration = implicitCast(duration);
         if (input instanceof Property) {
             input = linear(input, globalMin(input), globalMax(input));
-        }else{
+        } else {
             input = implicitCast(input);
         }
 
@@ -135,7 +135,7 @@ export class Torque extends BaseExpression {
         super({ _input: input, _cycle, fade, duration });
         // TODO improve type check
         this.duration = duration;
-        this.type = 'number';        
+        this.type = 'number';
     }
     eval(feature) {
         const input = this.input.eval(feature);
@@ -180,13 +180,9 @@ export class Torque extends BaseExpression {
     }
     _compile(meta) {
         super._compile(meta);
+        checkType('torque', 'input', 0, 'number', this.input);
         checkType('torque', 'duration', 1, 'number', this.duration);
-        if (this.input.type != 'number') {
-            throw new Error('Torque(): invalid first parameter, input.');
-        } else if (this.fade.type != 'fade') {
-            throw new Error('Torque(): invalid third parameter, fade.');
-        }
-
+        checkType('torque', 'fade', 2, 'fade', this.fade);
         this.inlineMaker = (inline) =>
             `(1.- clamp(abs(${inline._input}-${inline._cycle})*(${inline.duration})/(${inline._input}>${inline._cycle}? ${inline.fade.in}: ${inline.fade.out}), 0.,1.) )`;
     }

--- a/src/core/viz/expressions/torque.js
+++ b/src/core/viz/expressions/torque.js
@@ -182,6 +182,6 @@ export class Torque extends BaseExpression {
         this.type = 'number';
 
         this.inlineMaker = (inline) =>
-            `(1.- clamp(abs(${inline.input}-${inline._cycle})*(${this.duration.toFixed(20)})/(${inline.input}>${inline._cycle}? ${inline.fade.in}: ${inline.fade.out}), 0.,1.) )`;
+            `(1.- clamp(abs(${inline._input}-${inline._cycle})*(${this.duration.toFixed(20)})/(${inline._input}>${inline._cycle}? ${inline.fade.in}: ${inline.fade.out}), 0.,1.) )`;
     }
 }

--- a/src/core/viz/expressions/torque.js
+++ b/src/core/viz/expressions/torque.js
@@ -2,6 +2,7 @@ import BaseExpression from './base';
 import { implicitCast, DEFAULT, clamp } from './utils';
 import { div, mod, now, linear, globalMin, globalMax } from '../functions';
 import Property from './basic/property';
+import Variable from './basic/variable';
 
 const DEFAULT_FADE = 0.15;
 
@@ -126,7 +127,7 @@ export class Torque extends BaseExpression {
             input = linear(input, globalMin(input), globalMax(input));
         }
         const _cycle = div(mod(now(), duration), duration);
-        super({ input, _cycle, fade });
+        super({ _input: input, _cycle, fade });
         // TODO improve type check
         this.duration = duration;
     }
@@ -167,6 +168,9 @@ export class Torque extends BaseExpression {
         date.setTime(tmix);
         return date;
 
+    }
+    get input() {
+        return this._input instanceof Variable ? this._input.alias : this._input;
     }
     _compile(meta) {
         super._compile(meta);

--- a/src/core/viz/expressions/torque.js
+++ b/src/core/viz/expressions/torque.js
@@ -121,14 +121,21 @@ export class Fade extends BaseExpression {
 export class Torque extends BaseExpression {
     constructor(input, duration = 10, fade = new Fade()) {
         duration = implicitCast(duration);
-        checkLooseType('torque', 'duration', 1, 'number', duration);
         if (input instanceof Property) {
             input = linear(input, globalMin(input), globalMax(input));
+        }else{
+            input = implicitCast(input);
         }
+
+        checkLooseType('torque', 'input', 0, 'number', input);
+        checkLooseType('torque', 'duration', 1, 'number', duration);
+        checkLooseType('torque', 'fade', 2, 'fade', fade);
+
         const _cycle = div(mod(now(), duration), duration);
         super({ _input: input, _cycle, fade, duration });
         // TODO improve type check
         this.duration = duration;
+        this.type = 'number';        
     }
     eval(feature) {
         const input = this.input.eval(feature);
@@ -179,7 +186,6 @@ export class Torque extends BaseExpression {
         } else if (this.fade.type != 'fade') {
             throw new Error('Torque(): invalid third parameter, fade.');
         }
-        this.type = 'number';
 
         this.inlineMaker = (inline) =>
             `(1.- clamp(abs(${inline._input}-${inline._cycle})*(${inline.duration})/(${inline._input}>${inline._cycle}? ${inline.fade.in}: ${inline.fade.out}), 0.,1.) )`;

--- a/src/core/viz/expressions/torque.js
+++ b/src/core/viz/expressions/torque.js
@@ -1,5 +1,5 @@
 import BaseExpression from './base';
-import { implicitCast, DEFAULT, clamp, checkType } from './utils';
+import { implicitCast, DEFAULT, clamp, checkType, checkLooseType } from './utils';
 import { div, mod, now, linear, globalMin, globalMax } from '../functions';
 import Property from './basic/property';
 import Variable from './basic/variable';
@@ -121,7 +121,7 @@ export class Fade extends BaseExpression {
 export class Torque extends BaseExpression {
     constructor(input, duration = 10, fade = new Fade()) {
         duration = implicitCast(duration);
-        checkType('torque', 'duration', 1, 'number', duration);
+        checkLooseType('torque', 'duration', 1, 'number', duration);
         if (input instanceof Property) {
             input = linear(input, globalMin(input), globalMax(input));
         }
@@ -173,6 +173,7 @@ export class Torque extends BaseExpression {
     }
     _compile(meta) {
         super._compile(meta);
+        checkType('torque', 'duration', 1, 'number', this.duration);
         if (this.input.type != 'number') {
             throw new Error('Torque(): invalid first parameter, input.');
         } else if (this.fade.type != 'fade') {

--- a/src/core/viz/expressions/utils.js
+++ b/src/core/viz/expressions/utils.js
@@ -104,14 +104,32 @@ export function throwInvalidString(expressionName, parameterName, parameterIndex
     '${str}' is not a string`);
 }
 
-// Try to check the type, but accept undefined types without throwing
+// Try to check the type, but accept undefined types without throwing, unless the expected type had to be known at constructor time
+// This condition happens with types like color or fade, see isArgConstructorTimeTyped for details
+//
 // This is useful to make constructor-time checks, at constructor-time some types can be already known and errors can be throw.
 // Constructor-time is the best time to throw, but metadata is not provided yet, therefore, the checks cannot be complete,
-// they must be loose
+// they must be loose, the unknown of variables aliases types makes, also, a point to reduce the strictness of the check
 export function checkLooseType(expressionName, parameterName, parameterIndex, expectedType, parameter) {
     checkExpression(expressionName, parameterName, parameterIndex, parameter);
-    if (parameter.type !== undefined) {
+    const constructorTimeTyped = Array.isArray(expectedType) ? expectedType.every(isArgConstructorTimeTyped) : isArgConstructorTimeTyped(expectedType);
+    if (parameter.type !== undefined || constructorTimeTyped) {
         checkType(expressionName, parameterName, parameterIndex, expectedType, parameter);
+    }
+}
+
+// Returns true if the argument is of a type that cannot be strictly checked at constructor time
+export function isArgConstructorTimeTyped(arg) {
+    switch (arg) {
+        case 'number':
+        case 'number-array':
+        case 'number-property':
+        case 'category':
+        case 'category-array':
+        case 'category-property':
+            return false;
+        default:
+            return true;
     }
 }
 

--- a/test/unit/core/viz/expressions/torque.test.js
+++ b/test/unit/core/viz/expressions/torque.test.js
@@ -1,38 +1,31 @@
 import * as s from '../../../../../src/core/viz/functions';
-import { Torque } from '../../../../../src/core/viz/expressions/torque';
+import { validateTypeErrors, validateStaticType } from './utils';
 
 describe('src/core/viz/expressions/torque', () => {
-    describe('constructor with valid inputs', () => {
-        it('should return valid Torque instances', () => {
-            expect(s.torque(0.5) instanceof Torque).toBeTruthy();
-            expect(s.torque(0.5, 21) instanceof Torque).toBeTruthy();
-            expect(s.torque(0.5, 21, s.fade(1, 1)) instanceof Torque).toBeTruthy();
+    describe('error control', () => {
+        validateTypeErrors('torque', ['category', 'number']);
+        validateTypeErrors('torque', ['number', 'category']);
+        validateTypeErrors('torque', ['number', 'number', 'color']);
+        validateTypeErrors('torque', ['color', 'number']);
+        validateTypeErrors('torque', ['number', 'color']);
+    });
+    describe('type', () => {
+        validateStaticType('torque', ['number'], 'number');
+        validateStaticType('torque', ['number', 'number'], 'number');
+    });
+    describe('.eval()', () => {
+        it('should eval to 0 when the input is 1', () => {
+            expect(s.torque(1).eval()).toEqual(0);
         });
-        describe('constructor with invalid inputs', () => {
-            it('should throw with categorical inputs', () => {
-                expect(() => s.torque('cat')._compile()).toThrow();
-            });
-            it('should throw with a float duration', () => {
-                expect(() => s.torque(5, s.number(10))._compile()).toThrow();
-            });
-            it('should throw with a float fade', () => {
-                expect(() => s.torque(5, 10, s.number(10))._compile()).toThrow();
-            });
+        it('should eval close to 1 when the input is 0 and the fading is high', () => {
+            const t = s.torque(0, 10, s.fade(10));
+            t._setTimestamp(0);
+            expect(t.eval()).toEqual(1);
         });
-        describe('.eval()', () => {
-            it('should eval to 0 when the input is 1', () => {
-                expect(s.torque(1).eval()).toEqual(0);
-            });
-            it('should eval close to 1 when the input is 0 and the fading is high', () => {
-                const t = s.torque(0, 10, s.fade(10));
-                t._setTimestamp(0);
-                expect(t.eval()).toEqual(1);
-            });
-            it('should eval close to 0.75 when the input is 0 and we have wait a quarter of the animation', () => {
-                const t = s.torque(0, 1, s.fade(1));
-                t._setTimestamp(0.25);
-                expect(t.eval()).toEqual(0.75);
-            });
+        it('should eval close to 0.75 when the input is 0 and we have wait a quarter of the animation', () => {
+            const t = s.torque(0, 1, s.fade(1));
+            t._setTimestamp(0.25);
+            expect(t.eval()).toEqual(0.75);
         });
     });
 });

--- a/test/unit/core/viz/expressions/utils.js
+++ b/test/unit/core/viz/expressions/utils.js
@@ -1,4 +1,5 @@
 import * as s from '../../../../../src/core/viz/functions';
+import { isArgConstructorTimeTyped } from '../../../../../src/core/viz/expressions/utils';
 
 const metadata = {
     columns: [
@@ -14,13 +15,29 @@ const metadata = {
     ],
 };
 
+export function validateTypeErrors(expressionName, argTypes) {
+    describe(`invalid ${expressionName}(${argTypes.join(', ')})`, () => {
+        const simpleArgs = argTypes.map(getSimpleArg);
+        const propertyArgs = argTypes.map(getPropertyArg);
+        
+        validateConstructorTimeTypeError(expressionName, simpleArgs);
+
+        if (equalArgs(simpleArgs, propertyArgs)){
+            return;
+        }
+        if (argTypes.every(isArgConstructorTimeTyped)) {           
+            validateConstructorTimeTypeError(expressionName, propertyArgs);
+        }else{
+            validateCompileTimeTypeError(expressionName, propertyArgs);
+        }
+    });
+}
 export function validateDynamicTypeErrors(expressionName, argTypes) {
     describe(`invalid ${expressionName}(${argTypes.join(', ')})`, () => {
         validateConstructorTimeTypeError(expressionName, argTypes.map(getSimpleArg));
         validateCompileTimeTypeError(expressionName, argTypes.map(getPropertyArg));
     });
 }
-
 export function validateStaticTypeErrors(expressionName, argTypes) {
     describe(`invalid ${expressionName}(${argTypes.join(', ')})`, () => {
         const simpleArgs = argTypes.map(getSimpleArg);
@@ -44,6 +61,7 @@ function validateConstructorTimeTypeError(expressionName, args) {
         ).toThrowError(/[\s\S]*invalid.*parameter[\s\S]*/g);
     });
 }
+
 function validateCompileTimeTypeError(expressionName, args) {
     it(`${expressionName}(${args.map(arg => arg[1]).join(', ')}) should throw at compile time`, () => {
         expect(() => {

--- a/test/unit/core/viz/expressions/utils.js
+++ b/test/unit/core/viz/expressions/utils.js
@@ -58,7 +58,7 @@ function validateConstructorTimeTypeError(expressionName, args) {
     it(`${expressionName}(${args.map(arg => arg[1]).join(', ')}) should throw at constructor time`, () => {
         expect(() =>
             s[expressionName](...args.map(arg => arg[0]))
-        ).toThrowError(/[\s\S]*invalid.*parameter[\s\S]*/g);
+        ).toThrowError(new RegExp(`[\\s\\S]*${expressionName}[\\s\\S]*invalid.*parameter[\\s\\S]*`, 'g'));
     });
 }
 
@@ -67,7 +67,7 @@ function validateCompileTimeTypeError(expressionName, args) {
         expect(() => {
             const expression = s[expressionName](...args.map(arg => arg[0]));
             expression._compile(metadata);
-        }).toThrowError(/[\s\S]*invalid.*parameter[\s\S]*type[\s\S]*/g);
+        }).toThrowError(new RegExp(`[\\s\\S]*${expressionName}[\\s\\S]*invalid.*parameter[\\s\\S]*type[\\s\\S]*`, 'g'));
     });
 }
 


### PR DESCRIPTION
Fix https://github.com/CartoDB/carto-vl/issues/485

While fixing the original issue we found that `checkType` was miss-used in many places, generating incompatibilities with CARTO VL variables.

The root cause is that CARTO VL type checking on expressions at constructor time wasn't accepting variable aliases since they don't have types until later stages (after `_resolveAlias` is called). I thought about resolving aliases first and so that the strict type checking could work, but that will never work in the JS API since the order of execution cannot be controlled by us.

Therefore, I'm gonna make the type checking less strict in all expressions at constructor time. However, at compile time the type checking should stay strict.

I plan to:
- [x] Make less strict type checking at compile time in all expressions
- [x] Re-write torque type-checking (it was legacy code)
- [x] Re-write torque unit tests (legacy code)

To be done in another PR:
- Type check that parameters that must be feature independent are, in fact, feature independent.