### PR TITLE
Admit epoch numbers as argumet of time()

### DIFF
--- a/src/core/viz/expressions/time.js
+++ b/src/core/viz/expressions/time.js
@@ -25,7 +25,13 @@ import BaseExpression from './base';
 export default class Time extends BaseExpression {
     constructor(date) {
         if (!(date instanceof Date)) {
-            date = new Date(date);
+            if (typeof(date) === 'number') {
+                const epoch = date;
+                date = new Date(0);
+                date.setUTCSeconds(epoch);
+            } else {
+                date = new Date(date);
+            }
         }
         super({});
         // TODO improve type check

--- a/test/unit/core/viz/expressions/time.test.js
+++ b/test/unit/core/viz/expressions/time.test.js
@@ -1,0 +1,20 @@
+import * as s from '../../../../../src/core/viz/functions';
+
+describe('src/core/viz/expressions/time', () => {
+    describe('time', () => {
+        const date = new Date('2016-05-30T13:45:00+05:00');
+        test('time', '2016-05-30T13:45:00+05:00', date);
+        test('time', 1464597900, date);
+        test('time', date, date);
+    });
+
+    function test(fn, param1, expected) {
+        it(`${fn}(${param1}) should return ${expected}`, () => {
+            let actual = s[fn](param1).eval();
+            expect(actual).toEqual(expected);
+            actual = s[fn](param1).value;
+            expect(actual).toEqual(expected);
+        });
+    }
+
+});


### PR DESCRIPTION
It can be useful to be able to treat epoch values (e.g. from a datasource column) as times, for example for filtering or formatting the result of `torque.getSimTime()`.

This will be important if we end up converting all time/date column values to an epoch in MVTs.