### PR TITLE
Feature independent check

### DIFF
--- a/src/core/viz/expressions/aggregation/globalAggregation.js
+++ b/src/core/viz/expressions/aggregation/globalAggregation.js
@@ -153,7 +153,9 @@ function generateGlobalAggregattion(metadataPropertyName) {
             super({ _value: number(0) });
             this.property = implicitCast(property);
         }
-
+        _isFeatureDependent(){
+            return false;
+        }
         get value() {
             return this._value.expr;
         }
@@ -224,7 +226,9 @@ export class GlobalPercentile extends BaseExpression {
         this.property = property;
         this.percentile = percentile;
     }
-
+    _isFeatureDependent(){
+        return false;
+    }
     get value() {
         return this._value.expr;
     }

--- a/src/core/viz/expressions/aggregation/globalAggregation.js
+++ b/src/core/viz/expressions/aggregation/globalAggregation.js
@@ -153,7 +153,7 @@ function generateGlobalAggregattion(metadataPropertyName) {
             super({ _value: number(0) });
             this.property = implicitCast(property);
         }
-        _isFeatureDependent(){
+        isFeatureDependent(){
             return false;
         }
         get value() {
@@ -226,7 +226,7 @@ export class GlobalPercentile extends BaseExpression {
         this.property = property;
         this.percentile = percentile;
     }
-    _isFeatureDependent(){
+    isFeatureDependent(){
         return false;
     }
     get value() {

--- a/src/core/viz/expressions/aggregation/viewportAggregation.js
+++ b/src/core/viz/expressions/aggregation/viewportAggregation.js
@@ -170,7 +170,7 @@ function genViewportAgg(metadataPropertyName, zeroFn, accumFn, resolveFn) {
             });
             this._isViewport = true;
         }
-        _isFeatureDependent(){
+        isFeatureDependent(){
             return false;
         }
         get value() {
@@ -240,7 +240,7 @@ export class ViewportPercentile extends BaseExpression {
         });
         this._isViewport = true;
     }
-    _isFeatureDependent(){
+    isFeatureDependent(){
         return false;
     }
     get value() {

--- a/src/core/viz/expressions/aggregation/viewportAggregation.js
+++ b/src/core/viz/expressions/aggregation/viewportAggregation.js
@@ -170,7 +170,9 @@ function genViewportAgg(metadataPropertyName, zeroFn, accumFn, resolveFn) {
             });
             this._isViewport = true;
         }
-
+        _isFeatureDependent(){
+            return false;
+        }
         get value() {
             return resolveFn(this);
         }
@@ -238,7 +240,9 @@ export class ViewportPercentile extends BaseExpression {
         });
         this._isViewport = true;
     }
-
+    _isFeatureDependent(){
+        return false;
+    }
     get value() {
         return this.eval();
     }

--- a/src/core/viz/expressions/base.js
+++ b/src/core/viz/expressions/base.js
@@ -41,6 +41,10 @@ export default class Base {
         this._getChildren().map(child => child._setUID(idGenerator));
     }
 
+    _isFeatureDependent(){
+        return this._getChildren().some(child => child._isFeatureDependent());
+    }
+
     _prefaceCode(glslCode) {
         if (!glslCode) {
             return '';

--- a/src/core/viz/expressions/base.js
+++ b/src/core/viz/expressions/base.js
@@ -41,8 +41,8 @@ export default class Base {
         this._getChildren().map(child => child._setUID(idGenerator));
     }
 
-    _isFeatureDependent(){
-        return this._getChildren().some(child => child._isFeatureDependent());
+    isFeatureDependent(){
+        return this._getChildren().some(child => child.isFeatureDependent());
     }
 
     _prefaceCode(glslCode) {

--- a/src/core/viz/expressions/basic/property.js
+++ b/src/core/viz/expressions/basic/property.js
@@ -39,6 +39,9 @@ export default class Property extends BaseExpression {
         super({});
         this.name = name;
     }
+    _isFeatureDependent(){
+        return true;
+    }
     get value() {
         return this.eval();
     }

--- a/src/core/viz/expressions/basic/property.js
+++ b/src/core/viz/expressions/basic/property.js
@@ -39,7 +39,7 @@ export default class Property extends BaseExpression {
         super({});
         this.name = name;
     }
-    _isFeatureDependent(){
+    isFeatureDependent(){
         return true;
     }
     get value() {

--- a/src/core/viz/expressions/basic/variable.js
+++ b/src/core/viz/expressions/basic/variable.js
@@ -36,6 +36,9 @@ export default class Variable extends BaseExpression {
         super({});
         this.name = name;
     }
+    _isFeatureDependent(){
+        return this.alias? this.alias._isFeatureDependent(): undefined;
+    }
     get value() {
         return this.eval();
     }

--- a/src/core/viz/expressions/basic/variable.js
+++ b/src/core/viz/expressions/basic/variable.js
@@ -36,8 +36,8 @@ export default class Variable extends BaseExpression {
         super({});
         this.name = name;
     }
-    _isFeatureDependent(){
-        return this.alias? this.alias._isFeatureDependent(): undefined;
+    isFeatureDependent(){
+        return this.alias? this.alias.isFeatureDependent(): undefined;
     }
     get value() {
         return this.eval();

--- a/src/core/viz/expressions/top.js
+++ b/src/core/viz/expressions/top.js
@@ -1,7 +1,9 @@
 import BaseExpression from './base';
+import { checkType, checkLooseType, implicitCast, checkFeatureIndependent, checkInstance } from './utils';
+import Property from './basic/property';
 
 /**
- * Get the top `n` properties.
+ * Get the top `n` properties, aggregating the rest into an "others" bucket category.
  *
  * @param {Category} property - Column of the table
  * @param {number} n - Number of top properties to be returned
@@ -25,9 +27,12 @@ import BaseExpression from './base';
  */
 export default class Top extends BaseExpression {
     constructor(property, buckets) {
-        // TODO 'cat'
+        buckets = implicitCast(buckets);
+        checkInstance('top', 'property', 0, Property, property);
+        checkLooseType('top', 'buckets', 1, 'number', buckets);
+        checkFeatureIndependent('top', 'buckets', 1, buckets);
         super({ property, buckets });
-        // TODO improve type check
+        this.type = 'category';
     }
     eval(feature) {
         const p = this.property.eval(feature);
@@ -42,11 +47,10 @@ export default class Top extends BaseExpression {
         return ret;
     }
     _compile(metadata) {
+        checkFeatureIndependent('top', 'buckets', 1, this.buckets);
         super._compile(metadata);
-        if (this.property.type != 'category') {
-            throw new Error(`top() first argument must be of type category, but it is of type '${this.property.type}'`);
-        }
-        this.type = 'category';
+        checkType('top', 'property', 0, 'category', this.property);
+        checkType('top', 'buckets', 1, 'number', this.buckets);
         this.othersBucket = true;
         this._meta = metadata;
         this._textureBuckets = null;

--- a/src/core/viz/expressions/torque.js
+++ b/src/core/viz/expressions/torque.js
@@ -1,5 +1,5 @@
 import BaseExpression from './base';
-import { implicitCast, DEFAULT, clamp, checkType, checkLooseType } from './utils';
+import { implicitCast, DEFAULT, clamp, checkType, checkLooseType, checkFeatureIndependent } from './utils';
 import { div, mod, now, linear, globalMin, globalMax } from '../functions';
 import Property from './basic/property';
 import Variable from './basic/variable';
@@ -131,8 +131,9 @@ export class Torque extends BaseExpression {
 
         checkLooseType('torque', 'input', 0, 'number', input);
         checkLooseType('torque', 'duration', 1, 'number', duration);
+        checkFeatureIndependent('torque', 'duration', 1, duration);
         checkLooseType('torque', 'fade', 2, 'fade', fade);
-
+        
         const _cycle = div(mod(now(), duration), duration);
         super({ _input: input, _cycle, fade, duration });
         // TODO improve type check

--- a/src/core/viz/expressions/torque.js
+++ b/src/core/viz/expressions/torque.js
@@ -190,6 +190,9 @@ export class Torque extends BaseExpression {
         super._compile(meta);
         checkType('torque', 'input', 0, 'number', this.input);
         checkType('torque', 'fade', 2, 'fade', this.fade);
+        checkFeatureIndependent('torque', 'duration', 1, this.duration);
+
+
         this.inlineMaker = (inline) =>
             `(1.- clamp(abs(${inline._input}-${inline._cycle})*(${inline.duration})/(${inline._input}>${inline._cycle}? ${inline.fade.in}: ${inline.fade.out}), 0.,1.) )`;
     }

--- a/src/core/viz/expressions/utils.js
+++ b/src/core/viz/expressions/utils.js
@@ -180,6 +180,13 @@ export function checkArray(expressionName, parameterName, parameterIndex, array)
     }
 }
 
+export function checkFeatureIndependent(expressionName, parameterName, parameterIndex, parameter) {
+    if (parameter._isFeatureDependent()) {
+        throw new Error(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+        parameter cannot be feature dependent`);
+    }
+}
+
 export function clamp(x, min, max) {
     return Math.min(Math.max(x, min), max);
 }

--- a/src/core/viz/expressions/utils.js
+++ b/src/core/viz/expressions/utils.js
@@ -181,7 +181,7 @@ export function checkArray(expressionName, parameterName, parameterIndex, array)
 }
 
 export function checkFeatureIndependent(expressionName, parameterName, parameterIndex, parameter) {
-    if (parameter._isFeatureDependent()) {
+    if (parameter.isFeatureDependent()) {
         throw new Error(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
         parameter cannot be feature dependent`);
     }

--- a/test/unit/core/viz/expressions/top.test.js
+++ b/test/unit/core/viz/expressions/top.test.js
@@ -1,0 +1,12 @@
+import { validateTypeErrors, validateStaticType, validateFeatureDependentErrors } from './utils';
+
+describe('src/core/viz/expressions/top', () => {
+    describe('error control', () => {
+        validateFeatureDependentErrors('top', ['category-property', 'dependent']);
+        validateTypeErrors('top', ['number', 10]);
+        validateTypeErrors('top', ['color', 10]);
+    });
+    describe('type', () => {
+        validateStaticType('top', ['category-property', 5], 'category');
+    });
+});

--- a/test/unit/core/viz/expressions/torque.test.js
+++ b/test/unit/core/viz/expressions/torque.test.js
@@ -1,17 +1,17 @@
 import * as s from '../../../../../src/core/viz/functions';
-import { validateTypeErrors, validateStaticType } from './utils';
+import { validateTypeErrors, validateStaticType, validateFeatureDependentErrors } from './utils';
 
 describe('src/core/viz/expressions/torque', () => {
     describe('error control', () => {
-        validateTypeErrors('torque', ['category', 'number']);
-        validateTypeErrors('torque', ['number', 'category']);
-        validateTypeErrors('torque', ['number', 'number', 'color']);
-        validateTypeErrors('torque', ['color', 'number']);
+        validateFeatureDependentErrors('torque', [0.5, 'number']);
+        validateTypeErrors('torque', ['category', 10]);
+        validateTypeErrors('torque', ['number', 10, 'color']);
+        validateTypeErrors('torque', ['color', 10]);
         validateTypeErrors('torque', ['number', 'color']);
     });
     describe('type', () => {
         validateStaticType('torque', ['number'], 'number');
-        validateStaticType('torque', ['number', 'number'], 'number');
+        validateStaticType('torque', ['number', 10], 'number');
     });
     describe('.eval()', () => {
         it('should eval to 0 when the input is 1', () => {

--- a/test/unit/core/viz/expressions/torque.test.js
+++ b/test/unit/core/viz/expressions/torque.test.js
@@ -3,7 +3,7 @@ import { validateTypeErrors, validateStaticType, validateFeatureDependentErrors 
 
 describe('src/core/viz/expressions/torque', () => {
     describe('error control', () => {
-        validateFeatureDependentErrors('torque', [0.5, 'number']);
+        validateFeatureDependentErrors('torque', [0.5, 'dependent']);
         validateTypeErrors('torque', ['category', 10]);
         validateTypeErrors('torque', ['number', 10, 'color']);
         validateTypeErrors('torque', ['color', 10]);

--- a/test/unit/core/viz/expressions/utils.js
+++ b/test/unit/core/viz/expressions/utils.js
@@ -15,28 +15,42 @@ const metadata = {
     ],
 };
 
+// Validate feature independence checks at constructor and compile times, mark the dependent argument with 'dependent' in argTypes
 export function validateFeatureDependentErrors(expressionName, argTypes) {
-    const args = argTypes.map(getPropertyArg);
-    it(`${expressionName}(${args.map(arg => arg[1]).join(', ')}) should throw at constructor time`, () => {
-        expect(() =>
-            s[expressionName](...args.map(arg => arg[0]))
-        ).toThrowError(new RegExp(`[\\s\\S]*${expressionName}[\\s\\S]*invalid.*parameter[\\s\\S]*dependent[\\s\\S]*`, 'g'));
-    });
+    {
+        const args = argTypes.map(type => type == 'dependent' ? 'number-property' : type).map(getPropertyArg);
+        it(`${expressionName}(${args.map(arg => arg[1]).join(', ')}) should throw at constructor time`, () => {
+            expect(() =>
+                s[expressionName](...args.map(arg => arg[0]))
+            ).toThrowError(new RegExp(`[\\s\\S]*${expressionName}[\\s\\S]*invalid.*parameter[\\s\\S]*dependent[\\s\\S]*`, 'g'));
+        });
+    }
+    {
+        const v = s.variable('var1');
+        const args = argTypes.map(type => type == 'dependent' ? [v, '{alias to numeric property}'] : getPropertyArg(type));
+        it(`${expressionName}(${args.map(arg => arg[1]).join(', ')}) should throw at compile time`, () => {
+            const expr = s[expressionName](...args.map(arg => arg[0]));
+            v.alias = s.property('wadus');
+            expect(() =>
+                expr._compile({ columns: [{ name: 'wadus', type: 'number' }] })
+            ).toThrowError(new RegExp(`[\\s\\S]*${expressionName}[\\s\\S]*invalid.*parameter[\\s\\S]*dependent[\\s\\S]*`, 'g'));
+        });
+    }
 }
 
 export function validateTypeErrors(expressionName, argTypes) {
     describe(`invalid ${expressionName}(${argTypes.join(', ')})`, () => {
         const simpleArgs = argTypes.map(getSimpleArg);
         const propertyArgs = argTypes.map(getPropertyArg);
-        
+
         validateConstructorTimeTypeError(expressionName, simpleArgs);
 
-        if (equalArgs(simpleArgs, propertyArgs)){
+        if (equalArgs(simpleArgs, propertyArgs)) {
             return;
         }
-        if (argTypes.every(isArgConstructorTimeTyped)) {           
+        if (argTypes.every(isArgConstructorTimeTyped)) {
             validateConstructorTimeTypeError(expressionName, propertyArgs);
-        }else{
+        } else {
             validateCompileTimeTypeError(expressionName, propertyArgs);
         }
     });

--- a/test/unit/core/viz/expressions/utils.js
+++ b/test/unit/core/viz/expressions/utils.js
@@ -19,7 +19,7 @@ const metadata = {
 export function validateFeatureDependentErrors(expressionName, argTypes) {
     {
         const args = argTypes.map(type => type == 'dependent' ? 'number-property' : type).map(getPropertyArg);
-        it(`${expressionName}(${args.map(arg => arg[1]).join(', ')}) should throw at constructor time`, () => {
+        it(`${expressionName}(${args.map(arg => arg[1]).join(', ')}) should throw at constructor time a feature dependent error`, () => {
             expect(() =>
                 s[expressionName](...args.map(arg => arg[0]))
             ).toThrowError(new RegExp(`[\\s\\S]*${expressionName}[\\s\\S]*invalid.*parameter[\\s\\S]*dependent[\\s\\S]*`, 'g'));
@@ -28,7 +28,7 @@ export function validateFeatureDependentErrors(expressionName, argTypes) {
     {
         const v = s.variable('var1');
         const args = argTypes.map(type => type == 'dependent' ? [v, '{alias to numeric property}'] : getPropertyArg(type));
-        it(`${expressionName}(${args.map(arg => arg[1]).join(', ')}) should throw at compile time`, () => {
+        it(`${expressionName}(${args.map(arg => arg[1]).join(', ')}) should throw at compile time a feature dependent error`, () => {
             const expr = s[expressionName](...args.map(arg => arg[0]));
             v.alias = s.property('wadus');
             expect(() =>

--- a/test/unit/core/viz/expressions/utils.js
+++ b/test/unit/core/viz/expressions/utils.js
@@ -15,6 +15,15 @@ const metadata = {
     ],
 };
 
+export function validateFeatureDependentErrors(expressionName, argTypes) {
+    const args = argTypes.map(getPropertyArg);
+    it(`${expressionName}(${args.map(arg => arg[1]).join(', ')}) should throw at constructor time`, () => {
+        expect(() =>
+            s[expressionName](...args.map(arg => arg[0]))
+        ).toThrowError(new RegExp(`[\\s\\S]*${expressionName}[\\s\\S]*invalid.*parameter[\\s\\S]*dependent[\\s\\S]*`, 'g'));
+    });
+}
+
 export function validateTypeErrors(expressionName, argTypes) {
     describe(`invalid ${expressionName}(${argTypes.join(', ')})`, () => {
         const simpleArgs = argTypes.map(getSimpleArg);


### PR DESCRIPTION
The parameters of some expressions don't support expressions that depend on feature properties. Like the duration of a `torque`.

This condition was uncontrolled.

This PR controls the condition and add unit tests to that control.

I fixed here https://github.com/CartoDB/carto-vl/issues/392 too since the problem was very related.