### PR TITLE
Simplify ramp constructor

### DIFF
--- a/src/core/viz/expressions/ramp.js
+++ b/src/core/viz/expressions/ramp.js
@@ -67,15 +67,13 @@ export default class Ramp extends BaseExpression {
         this.minKey = 0;
         this.maxKey = 1;
         this.palette = palette;
-        if (palette.type == 'number-array') {
-            this.type = 'number';
-        } else {
-            this.type = 'color';
-        }
         try {
             if (palette.type == 'number-array') {
+                this.type = 'number';
                 this.palette.floats = this.palette.eval();
-            } else if (palette.type == 'color-array') {
+            }
+            else if (palette.type == 'color-array') {
+                this.type = 'color';
                 this.palette.colors = this.palette.eval();
             }
         } catch (error) {
@@ -86,7 +84,7 @@ export default class Ramp extends BaseExpression {
     loadSprites() {
         return Promise.all([this.input.loadSprites(), this.palette.loadSprites()]);
     }
-    
+
     _setUID(idGenerator) {
         super._setUID(idGenerator);
         this.palette._setUID(idGenerator);
@@ -113,7 +111,7 @@ export default class Ramp extends BaseExpression {
         this._texCategories = null;
         this._GLtexCategories = null;
     }
-    
+
     _free(gl) {
         if (this.texture) {
             gl.deleteTexture(this.texture);


### PR DESCRIPTION
This simplifies the logic, notice also that when a array of sprites is passed as palette
we got the following wrong error:

Palettes must be formed by constant expressions, they cannot depend on feature properties