### PR TITLE
Fix ethnic example

### DIFF
--- a/src/core/viz/expressions/binary.js
+++ b/src/core/viz/expressions/binary.js
@@ -451,7 +451,7 @@ function genBinaryOp(name, allowedSignature, jsFn, glsl) {
             a = implicitCast(a);
             b = implicitCast(b);
 
-            const signature = getSignature(a, b);
+            const signature = getSignatureLoose(a, b);
             if (signature !== undefined) {
                 if (signature == UNSUPPORTED_SIGNATURE || !(signature & allowedSignature)) {
                     throw new Error(`${name}(): invalid parameter types\n'x' type was ${a.type}, 'y' type was ${b.type}`);
@@ -480,6 +480,30 @@ function genBinaryOp(name, allowedSignature, jsFn, glsl) {
             this.inlineMaker = inline => glsl(inline.a, inline.b);
         }
     };
+}
+
+function getSignatureLoose(a, b) {
+    if (!a.type || !b.type) {
+        if (!a.type && !b.type){
+            return undefined;
+        }
+        const knownType = a.type || b.type;
+        if (knownType == 'color'){
+            return NUMBER_AND_COLOR_TO_COLOR;
+        }
+    } else if (a.type == 'number' && b.type == 'number') {
+        return NUMBERS_TO_NUMBER;
+    } else if (a.type == 'number' && b.type == 'color') {
+        return NUMBER_AND_COLOR_TO_COLOR;
+    } else if (a.type == 'color' && b.type == 'number') {
+        return NUMBER_AND_COLOR_TO_COLOR;
+    } else if (a.type == 'color' && b.type == 'color') {
+        return COLORS_TO_COLOR;
+    } else if (a.type == 'category' && b.type == 'category') {
+        return CATEGORIES_TO_NUMBER;
+    } else {
+        return UNSUPPORTED_SIGNATURE;
+    }
 }
 
 function getSignature(a, b) {

--- a/test/unit/core/viz/expressions/color/opacity.test.js
+++ b/test/unit/core/viz/expressions/color/opacity.test.js
@@ -1,5 +1,5 @@
 import { validateStaticType, validateStaticTypeErrors, validateDynamicTypeErrors } from '../utils';
-import { opacity, rgba } from '../../../../../../src/core/viz/functions';
+import { opacity, rgba, mul, variable, rgb } from '../../../../../../src/core/viz/functions';
 
 describe('src/core/viz/expressions/opacity', () => {
     describe('error control', () => {
@@ -22,6 +22,14 @@ describe('src/core/viz/expressions/opacity', () => {
     describe('.eval', () => {
         it('should override the alpha channel', () => {
             expect(opacity(rgba(255, 255, 255, 0.5), 0.7).eval()).toEqual({ r: 255, g: 255, b: 255, a: 0.7 });
+        });
+    });
+
+    describe('regression', () => {
+        it('should work with binary operations and variables', () => {
+            expect(() =>
+                opacity(mul(variable('wadus'), rgb(0, 0, 0)), 0.5)
+            ).not.toThrow();
         });
     });
 });


### PR DESCRIPTION
The ethnic example map was broken due to a strict type checking. Opacity was requiring that the first argument was of type `color` at constructor time, which the binary operation could potentially state, was it was defaulting to `undefined`.

This fix improves binary ops constructors to return `color` once it's known that it must be of type `color`.