### PR TITLE
Optimize interactivity

### DIFF
--- a/src/api/interactivity.js
+++ b/src/api/interactivity.js
@@ -101,6 +101,7 @@ export default class Interactivity {
         }
         preCheckLayerList(layerList);
         this._init(layerList);
+        this._numListeners = {};
     }
 
     /**
@@ -114,6 +115,7 @@ export default class Interactivity {
      */
     on(eventName, callback) {
         checkEvent(eventName);
+        this._numListeners[eventName] = (this._numListeners[eventName] || 0) + 1;
         return this._emitter.on(eventName, callback);
     }
 
@@ -128,6 +130,7 @@ export default class Interactivity {
      */
     off(eventName, callback) {
         checkEvent(eventName);
+        this._numListeners[eventName] = this._numListeners[eventName] - 1;
         return this._emitter.off(eventName, callback);
     }
 
@@ -148,6 +151,10 @@ export default class Interactivity {
     }
 
     _onMouseMove(event) {
+        if (!this._numListeners['featureEnter'] && !this._numListeners['featureHover'] && !this._numListeners['featureLeave']) {
+            return;
+        }
+
         const featureEvent = this._createFeatureEvent(event);
         const currentFeatures = featureEvent.features;
 
@@ -178,6 +185,10 @@ export default class Interactivity {
     }
 
     _onClick(event) {
+        if (!this._numListeners['featureClick'] && !this._numListeners['featureClickOut']) {
+            return;
+        }
+
         const featureEvent = this._createFeatureEvent(event);
         const currentFeatures = featureEvent.features;
 

--- a/src/api/interactivity.js
+++ b/src/api/interactivity.js
@@ -32,7 +32,7 @@ import { wToR } from '../client/rsys';
  */
 
 /**
- * featureEnter events are fired when the user moves the cursor and the movement implies that a non-previously hovered feature is now under the cursor.
+ * featureEnter events are fired when the user moves the cursor and the movement implies that a non-previously hovered feature (as reported by featureHover or featureLeave) is now under the cursor.
  * The list of features that are now behind the cursor and that weren't before is provided.
  *
  * @event featureEnter
@@ -50,7 +50,7 @@ import { wToR } from '../client/rsys';
  */
 
 /**
- * featureLeave events are fired when the user moves the cursor and the movement implies that a previously hovered feature is no longer behind the cursor.
+ * featureLeave events are fired when the user moves the cursor and the movement implies that a previously hovered feature (as reported by featureHover or featureEnter) is no longer behind the cursor.
  * The list of features that are no longer behind the cursor and that were before is provided.
  *
  * @event featureLeave

--- a/src/core/dataframe.js
+++ b/src/core/dataframe.js
@@ -193,10 +193,8 @@ export default class Dataframe {
         // Linear search for all features
         // Tests triangles instead of polygons since we already have the triangulated form
         // Moreover, with an acceleration structure and triangle testing features can be subdivided easily
-        for (let i = 0; i < vertices.length; i += 6) {
-            if (i >= breakpoints[featureIndex]) {
-                featureIndex++;
-            }
+        let scale;
+        let computeScale = ()=>{
             const f = {};
             columnNames.forEach(name => {
                 f[name] = this.properties[name][featureIndex];
@@ -204,7 +202,14 @@ export default class Dataframe {
             // Line with is saturated at 336px
             const lineWidth = Math.min(vizWidth.eval(f), 336);
             // width is a diameter and scale is radius-like, we need to divide by 2
-            const scale = lineWidth / 2 * widthScale;
+            scale = lineWidth / 2 * widthScale;
+        };
+        computeScale();
+        for (let i = 0; i < vertices.length; i += 6) {
+            if (i >= breakpoints[featureIndex]) {
+                featureIndex++;
+                computeScale();
+            }
             const v1 = {
                 x: vertices[i + 0] + normals[i + 0] * scale,
                 y: vertices[i + 1] + normals[i + 1] * scale
@@ -243,10 +248,8 @@ export default class Dataframe {
         // Linear search for all features
         // Tests triangles instead of polygons since we already have the triangulated form
         // Moreover, with an acceleration structure and triangle testing features can be subdivided easily
-        for (let i = 0; i < vertices.length; i += 6) {
-            if (i >= breakpoints[featureIndex]) {
-                featureIndex++;
-            }
+        let scale;
+        let computeScale = ()=>{
             const f = {};
             columnNames.forEach(name => {
                 f[name] = this.properties[name][featureIndex];
@@ -254,7 +257,14 @@ export default class Dataframe {
             // Line with is saturated at 336px
             const lineWidth = Math.min(vizStrokeWidth.eval(f), 336);
             // width is a diameter and scale is radius-like, we need to divide by 2
-            const scale = lineWidth / 2 * widthScale;
+            scale = lineWidth / 2 * widthScale;
+        };
+        computeScale();
+        for (let i = 0; i < vertices.length; i += 6) {
+            if (i >= breakpoints[featureIndex]) {
+                featureIndex++;
+                computeScale();
+            }
             const v1 = {
                 x: vertices[i + 0] + normals[i + 0] * scale,
                 y: vertices[i + 1] + normals[i + 1] * scale

--- a/test/integration/user/api/interactivity.test.js
+++ b/test/integration/user/api/interactivity.test.js
@@ -225,15 +225,15 @@ describe('Interactivity', () => {
                 });
 
                 it('should not fire a featureEnter event when the mouse is moved inside the same feature', done => {
-                    const featureClickOutSpy = jasmine.createSpy('featureClickOutSpy');
+                    const featureEnterSpy = jasmine.createSpy('featureEnterSpy');
                     onLoaded(() => {
-                        // Move mouse inside a feature 1
-                        util.simulateMove({ lng: 5, lat: 5 });
-                        interactivity.on('featureEnter', featureClickOutSpy);
+                        interactivity.on('featureEnter', featureEnterSpy);
                         interactivity.on('featureHover', () => {
-                            expect(featureClickOutSpy).not.toHaveBeenCalled();
+                            expect(featureEnterSpy).toHaveBeenCalledTimes(1);
                             done();
                         });
+                        // Move mouse inside a feature 1
+                        util.simulateMove({ lng: 5, lat: 5 });
                         // Move mouse inside the same feature 1
                         util.simulateMove({ lng: 5, lat: 15 });
                     });
@@ -256,13 +256,13 @@ describe('Interactivity', () => {
 
                 it('should fire a featureLeave event with a features list containing the previously entered feature', done => {
                     onLoaded(() => {
-                        // Move mouse inside a feature 1
-                        util.simulateMove({ lng: 5, lat: 5 });
                         interactivity.on('featureLeave', event => {
                             expect(event.features[0].id).toEqual(-0);
                             expect(event.features[0].layerId).toEqual('layer1');
                             done();
                         });
+                        // Move mouse inside a feature 1
+                        util.simulateMove({ lng: 5, lat: 5 });
                         // Move mouse outside any feature
                         util.simulateMove({ lng: -5, lat: -5 });
                     });

--- a/test/integration/user/api/interactivity.test.js
+++ b/test/integration/user/api/interactivity.test.js
@@ -228,14 +228,14 @@ describe('Interactivity', () => {
                     const featureEnterSpy = jasmine.createSpy('featureEnterSpy');
                     onLoaded(() => {
                         interactivity.on('featureEnter', featureEnterSpy);
-                        interactivity.on('featureHover', () => {
-                            expect(featureEnterSpy).toHaveBeenCalledTimes(1);
-                            done();
-                        });
                         // Move mouse inside a feature 1
                         util.simulateMove({ lng: 5, lat: 5 });
                         // Move mouse inside the same feature 1
                         util.simulateMove({ lng: 5, lat: 15 });
+                        setTimeout(() => {
+                            expect(featureEnterSpy).toHaveBeenCalledTimes(1);
+                            done();
+                        }, 0);
                     });
                 });
             });

--- a/test/integration/user/karma.conf.js
+++ b/test/integration/user/karma.conf.js
@@ -14,7 +14,8 @@ module.exports = function (config) {
             'index.test.js': ['webpack', 'sourcemap'],
         },
         webpack: {
-            devtool: 'inline-source-map'
+            devtool: 'inline-source-map',
+            mode: 'development'
         },
         customLaunchers: {
             // Add no-sandbox flag due a bug. https://github.com/karma-runner/karma-chrome-launcher/issues/158


### PR DESCRIPTION
This PR optimizes interactivity in two ways:


## Don't do point in polygon computations if they are not needed.

Two tests are changed because they assumed that for example, a `featureEnter` event shouldn't be fired if the cursor is moved within the feature, even if the `.on` method was just called. The new semantics will fire the `featureEnter` if the user starts listening with cursor already on the feature.

## Compute style values (`.eval()`) per-feature and not per-triangle

## Results

For Ruben's map the performance increases from 1.7 fps to 23 fps: a 13.5x improvement