### PR TITLE
Avoid duplicated points between tiles

### DIFF
--- a/src/core/dataframe.js
+++ b/src/core/dataframe.js
@@ -9,11 +9,10 @@ export default class Dataframe {
         this.geom = geom;
         this.properties = properties;
         this.scale = scale;
-        this.size = size;
         this.type = type;
         this.decodedGeom = decoder.decodeGeom(this.type, this.geom);
-        this.numVertex = this.decodedGeom.vertices.length / 2;
-        this.numFeatures = this.decodedGeom.breakpoints.length || this.numVertex;
+        this.numVertex = type === 'point' ? size : this.decodedGeom.vertices.length / 2;
+        this.numFeatures = type === 'point' ? size : this.decodedGeom.breakpoints.length || this.numVertex;
         this.propertyTex = [];
         this.metadata = metadata;
         this.propertyID = {}; //Name => PID


### PR DESCRIPTION
Fixes #90
See also #91 

The tiler may repeat points between tiles, see https://github.com/CartoDB/Windshaft-cartodb/issues/889 and fixing that in the tiler may have a performance penalty.

So this avoids the problem by excluding points with tile coordinates out of `[-1, +1)` when decoding the MVT.
