### PR TITLE
Fix change animation duration

### DIFF
--- a/src/core/viz/expressions/torque.js
+++ b/src/core/viz/expressions/torque.js
@@ -1,6 +1,6 @@
 import BaseExpression from './base';
 import { implicitCast, DEFAULT, clamp, checkType, checkLooseType, checkFeatureIndependent } from './utils';
-import { number, linear, sub, add, globalMin, globalMax } from '../functions';
+import { number, linear, globalMin, globalMax } from '../functions';
 import Property from './basic/property';
 import Variable from './basic/variable';
 

--- a/src/core/viz/expressions/torque.js
+++ b/src/core/viz/expressions/torque.js
@@ -149,12 +149,11 @@ export class Torque extends BaseExpression {
     }
 
     _setTimestamp(timestamp) {
-        let deltaTime;
-        const speed = 1 / this.duration.eval();
-        
-        if (this._lastTime) {
-            deltaTime = timestamp - this._lastTime;
-        }
+        let deltaTime = 0;
+        const speed = 1 / this.duration.value;
+        const lastTime = this._lastTime || 0;
+    
+        deltaTime = timestamp - lastTime;
 
         this._lastTime = timestamp;
         this.progress.expr = (this.progress.expr + speed * deltaTime) % 1;
@@ -169,8 +168,8 @@ export class Torque extends BaseExpression {
             return 0;
         }
 
-        const progress = this.progress.eval();
-        const duration = this.duration.eval();
+        const progress = this.progress.value;
+        const duration = this.duration.value;
         const fadeIn = this.fade.fadeIn.eval(feature);
         const fadeOut = this.fade.fadeOut.eval(feature);
         
@@ -222,14 +221,18 @@ export class Torque extends BaseExpression {
         this.preface = `
             #ifndef TORQUE
             #define TORQUE
+            
             float torque(float _input, float progress, float duration, float fadeIn, float fadeOut){
                 float x = 0.;
+                
                 // Check for NaN
                 if (_input <= 0.0 || 0.0 <= _input){
-                    x = 1.- clamp(abs(_input-progress)*duration/(_input>progress? fadeIn: fadeOut), 0.,1.);
+                    x = 1. - clamp(abs(_input - progress) * duration / (_input > progress ? fadeIn: fadeOut), 0., 1.);
                 }
+
                 return x;
             }
+
             #endif
         `;
 

--- a/src/core/viz/expressions/torque.js
+++ b/src/core/viz/expressions/torque.js
@@ -140,11 +140,8 @@ export class Torque extends BaseExpression {
         
         super({ _input: input, progress, fade, duration });
         // TODO improve type check
-        this.duration = duration;
-        this.progress = progress; // 0 to 1
         this.type = 'number';
         this._originalInput = originalInput;
-        this._lastTime = 0;
     }
 
     isAnimated() {
@@ -152,9 +149,13 @@ export class Torque extends BaseExpression {
     }
 
     _setTimestamp(timestamp) {
-        const deltaTime = timestamp - this._lastTime;
+        let deltaTime;
         const speed = 1 / this.duration.eval();
         
+        if (this._lastTime) {
+            deltaTime = timestamp - this._lastTime;
+        }
+
         this._lastTime = timestamp;
         this.progress.expr = (this.progress.expr + speed * deltaTime) % 1;
 

--- a/src/core/viz/expressions/torque.js
+++ b/src/core/viz/expressions/torque.js
@@ -151,9 +151,10 @@ export class Torque extends BaseExpression {
     _setTimestamp(timestamp) {
         let deltaTime = 0;
         const speed = 1 / this.duration.value;
-        const lastTime = this._lastTime || 0;
     
-        deltaTime = timestamp - lastTime;
+        if (this._lastTime !== undefined) {
+            deltaTime = timestamp - this._lastTime;
+        }
 
         this._lastTime = timestamp;
         this.progress.expr = (this.progress.expr + speed * deltaTime) % 1;

--- a/src/core/viz/expressions/torque.js
+++ b/src/core/viz/expressions/torque.js
@@ -134,14 +134,9 @@ export class Torque extends BaseExpression {
         checkLooseType('torque', 'duration', 1, 'number', duration);
         checkFeatureIndependent('torque', 'duration', 1, duration);
         checkLooseType('torque', 'fade', 2, 'fade', fade);
-<<<<<<< HEAD
         
         const _cycle = _getCycleFunction(duration);
         
-=======
-
-        const _cycle = div(mod(now(), duration), duration);
->>>>>>> master
         super({ _input: input, _cycle, fade, duration });
         // TODO improve type check
         this.duration = duration;
@@ -151,13 +146,12 @@ export class Torque extends BaseExpression {
 
     eval(feature) {
         const input = this.input.eval(feature);
-<<<<<<< HEAD
-=======
+
         if (Number.isNaN(input)){
             return 0;
         }
+        
         const cycle = this._cycle.eval(feature);
->>>>>>> master
         const duration = this.duration.value;
         const cycle = this._cycle.eval(feature);
         const fadeIn = this.fade.fadeIn.eval(feature);

--- a/test/unit/core/viz/expressions/torque.test.js
+++ b/test/unit/core/viz/expressions/torque.test.js
@@ -24,6 +24,7 @@ describe('src/core/viz/expressions/torque', () => {
         });
         it('should eval close to 0.75 when the input is 0 and we have wait a quarter of the animation', () => {
             const t = s.torque(0, 1, s.fade(1));
+            t._setTimestamp(0);
             t._setTimestamp(0.25);
             expect(t.eval()).toEqual(0.75);
         });


### PR DESCRIPTION
This PR solves two problems:

* https://github.com/CartoDB/carto-vl/issues/531 When the duration of the torque animation changes, now it starts from the position when it has been changed, instead of "jumping" to another position. 

* Also, as @ramiroaznar noticed, the first time the map is instantiated, the animation starts at the initial position (as it is expected).

![torque](https://user-images.githubusercontent.com/3824953/41299306-71b5bbac-6e63-11e8-9000-6c0205831ef8.gif)
