### PR TITLE
Add 'crossOrigin' attribute to sprite images

### DIFF
--- a/src/core/viz/expressions/sprite.js
+++ b/src/core/viz/expressions/sprite.js
@@ -40,6 +40,7 @@ export default class Sprite extends Base {
             };
             this.image.onerror = reject;
             this.image.src = this._url;
+            this.image.crossOrigin = 'anonymous';
         });
     }
 


### PR DESCRIPTION
This issue solves https://github.com/CartoDB/carto-vl/issues/557

![captura de pantalla 2018-06-15 a las 10 51 02](https://user-images.githubusercontent.com/3824953/41459485-07576bc4-708a-11e8-8e74-93368ed5373a.png)
