### PR TITLE
518 change default cursor

### DIFF
--- a/src/api/interactivity.js
+++ b/src/api/interactivity.js
@@ -101,7 +101,6 @@ export default class Interactivity {
         }
         preCheckLayerList(layerList);
         this._init(layerList);
-        this._numListeners = {};
     }
 
     /**
@@ -139,9 +138,17 @@ export default class Interactivity {
         this._layerList = layerList;
         this._prevHoverFeatures = [];
         this._prevClickFeatures = [];
+        this._numListeners = {};
         return Promise.all(layerList.map(layer => layer._context)).then(() => {
             postCheckLayerList(layerList);
             this._subscribeToIntegratorEvents(layerList[0].getIntegrator());
+        }).then(this._setInteractiveCursor.bind(this));
+    }
+
+    _setInteractiveCursor() {
+        this.on('featureHover', event => {
+            // eslint-disable-next-line 
+            map.getCanvas().style.cursor = event.features.length ? 'pointer' : ''; // map is know at runtime
         });
     }
 

--- a/src/api/interactivity.js
+++ b/src/api/interactivity.js
@@ -76,7 +76,7 @@ export default class Interactivity {
     *
     * @param {carto.Layer|carto.Layer[]} layerList - {@link carto.Layer} or array of {@link carto.Layer}, events will be fired based on the features of these layers. The array cannot be empty, and all the layers must be attached to the same map.
     * @param {object} [options={}] - Object containing interactivity options
-    * @param {boolean} [options.defaultCursor=false] - A boolean flag indicating if the cursor should change when the mouse is over a feature.
+    * @param {boolean} [options.autoChangePointer=true] - A boolean flag indicating if the cursor should change when the mouse is over a feature.
     * 
     * @example
     * const interactivity = new carto.Interactivity(layer);
@@ -96,7 +96,7 @@ export default class Interactivity {
     * @memberof carto
     * @api
     */
-    constructor(layerList, options={}) {
+    constructor(layerList, options = { autoChangePointer: true }) {
         if (layerList instanceof Layer) {
             // Allow one layer as input
             layerList = [layerList];
@@ -145,7 +145,7 @@ export default class Interactivity {
             postCheckLayerList(layerList);
             this._subscribeToIntegratorEvents(layerList[0].getIntegrator());
         }).then(() => {
-            if (!options.defaultCursor) {
+            if (options.autoChangePointer) {
                 this._setInteractiveCursor();
             }
         });
@@ -154,7 +154,7 @@ export default class Interactivity {
     _setInteractiveCursor() {
         this.on('featureHover', event => {
             const map = this._layerList[0].getIntegrator().map; // All layers belong to the same map
-            map.getCanvas().style.cursor = event.features.length ? 'pointer' : '';
+            map.getCanvas().style.cursor = event.features.length ? 'pointer' : 'auto';
         });
     }
 

--- a/src/api/interactivity.js
+++ b/src/api/interactivity.js
@@ -65,7 +65,16 @@ const EVENTS = [
     'featureHover',
     'featureLeave',
 ];
+
+// https://github.com/CartoDB/carto-vl/pull/578#discussion_r196356856
+const _interactivityMap = new Map();
+
 export default class Interactivity {
+    
+    static get _interactivityMap() {
+        return _interactivityMap;
+    }
+
     /**
     *
     * Interactivity purpose is to allow the reception and management of user-generated events, like clicking, over layer features.
@@ -152,9 +161,17 @@ export default class Interactivity {
     }
 
     _setInteractiveCursor() {
+        const map = this._layerList[0].getIntegrator().map; // All layers belong to the same map
+        if (!map.__carto_interacivities) {
+            map.__carto_interacivities = new Set();
+        }
         this.on('featureHover', event => {
-            const map = this._layerList[0].getIntegrator().map; // All layers belong to the same map
-            map.getCanvas().style.cursor = event.features.length ? 'pointer' : 'auto';
+            if (event.features.length) {
+                map.__carto_interacivities.add(this);
+            } else {
+                map.__carto_interacivities.delete(this);
+            }
+            map.getCanvas().style.cursor = (map.__carto_interacivities.size > 0) ? 'pointer' : '';
         });
     }
 

--- a/src/api/interactivity.js
+++ b/src/api/interactivity.js
@@ -66,15 +66,7 @@ const EVENTS = [
     'featureLeave',
 ];
 
-// https://github.com/CartoDB/carto-vl/pull/578#discussion_r196356856
-const _interactivityMap = new Map();
-
 export default class Interactivity {
-    
-    static get _interactivityMap() {
-        return _interactivityMap;
-    }
-
     /**
     *
     * Interactivity purpose is to allow the reception and management of user-generated events, like clicking, over layer features.

--- a/test/integration/user/api/interactivity.test.js
+++ b/test/integration/user/api/interactivity.test.js
@@ -377,7 +377,7 @@ describe('Cursor', () => {
                 setTimeout(() => {
                     expect(map.getCanvas().style.cursor).toEqual('pointer');
                     done();
-                }, 100);
+                }, 0);
             });
         });
 
@@ -390,7 +390,7 @@ describe('Cursor', () => {
                 setTimeout(() => {
                     expect(map.getCanvas().style.cursor).toEqual('');
                     done();
-                }, 100);
+                }, 0);
             });
         });
     });

--- a/test/integration/user/api/interactivity.test.js
+++ b/test/integration/user/api/interactivity.test.js
@@ -350,7 +350,7 @@ describe('Interactivity', () => {
 });
 
 describe('Cursor', () => {
-    let map, source1, viz1, layer1, interactivity;
+    let map, source1, viz1, layer1;
 
     beforeEach(() => {
         const setup = util.createMap('map');
@@ -368,7 +368,7 @@ describe('Cursor', () => {
 
     describe('when the interactivity is instantiated by default', () => {
         it('should set the cursor to be pointer when user is over a feature', done => {
-            interactivity = new carto.Interactivity(layer1);
+            new carto.Interactivity(layer1);
             expect(map.getCanvas().style.cursor).toEqual('');
 
             layer1.on('loaded', () => {
@@ -382,7 +382,7 @@ describe('Cursor', () => {
         });
 
         it('should set the cursor to be empty when user is over a feature', done => {
-            interactivity = new carto.Interactivity(layer1, { autoChangePointer: false });
+            new carto.Interactivity(layer1, { autoChangePointer: false });
             expect(map.getCanvas().style.cursor).toEqual('');
             layer1.on('loaded', () => {
                 // Move mouse inside a feature 1

--- a/test/integration/user/api/interactivity.test.js
+++ b/test/integration/user/api/interactivity.test.js
@@ -348,3 +348,58 @@ describe('Interactivity', () => {
         document.body.removeChild(div);
     });
 });
+
+describe('Cursor', () => {
+    let map, source1, viz1, layer1, interactivity;
+
+    beforeEach(() => {
+        const setup = util.createMap('map');
+        map = setup.map;
+
+        source1 = new carto.source.GeoJSON(feature1);
+        viz1 = new carto.Viz(`
+            color: red
+            @wadus: 123
+        `);
+        layer1 = new carto.Layer('layer1', source1, viz1);
+
+        layer1.addTo(map);
+    });
+
+    describe('when the interactivity is instantiated by default', () => {
+        it('should set the cursor to pointer when user is over a feature', done => {
+            interactivity = new carto.Interactivity(layer1);
+            expect(map.getCanvas().style.cursor).toEqual('');
+            interactivity.on('featureHover', () => {
+                // This callback is executed before the one that acutally changes the cursor so we set a timeout to ensure the cursor was changed.
+                setTimeout(() => {
+                    expect(map.getCanvas().style.cursor).toEqual('pointer');
+                    done();
+                }, 10);
+
+            });
+
+            layer1.on('loaded', () => {
+                // Move mouse inside a feature 1
+                util.simulateMove({ lng: 5, lat: 5 });
+            });
+        });
+
+        it('should set the cursor to pointer when user is over a feature', done => {
+            interactivity = new carto.Interactivity(layer1, { autoChangePointer: false });
+            expect(map.getCanvas().style.cursor).toEqual('');
+            interactivity.on('featureHover', () => {
+                // This callback is executed before the one that acutally changes the cursor so we set a timeout to ensure the cursor was changed.
+                setTimeout(() => {
+                    expect(map.getCanvas().style.cursor).toEqual('');
+                    done();
+                }, 10);
+
+            });
+            layer1.on('loaded', () => {
+                // Move mouse inside a feature 1
+                util.simulateMove({ lng: 5, lat: 5 });
+            });
+        });
+    });
+});

--- a/test/integration/user/api/interactivity.test.js
+++ b/test/integration/user/api/interactivity.test.js
@@ -367,38 +367,30 @@ describe('Cursor', () => {
     });
 
     describe('when the interactivity is instantiated by default', () => {
-        it('should set the cursor to pointer when user is over a feature', done => {
+        it('should set the cursor to be pointer when user is over a feature', done => {
             interactivity = new carto.Interactivity(layer1);
             expect(map.getCanvas().style.cursor).toEqual('');
-            interactivity.on('featureHover', () => {
-                // This callback is executed before the one that acutally changes the cursor so we set a timeout to ensure the cursor was changed.
+
+            layer1.on('loaded', () => {
+                // Move mouse inside a feature 1
+                util.simulateMove({ lng: 5, lat: 5 });
                 setTimeout(() => {
                     expect(map.getCanvas().style.cursor).toEqual('pointer');
                     done();
-                }, 10);
-
-            });
-
-            layer1.on('loaded', () => {
-                // Move mouse inside a feature 1
-                util.simulateMove({ lng: 5, lat: 5 });
+                }, 100);
             });
         });
 
-        it('should set the cursor to pointer when user is over a feature', done => {
+        it('should set the cursor to be empty when user is over a feature', done => {
             interactivity = new carto.Interactivity(layer1, { autoChangePointer: false });
             expect(map.getCanvas().style.cursor).toEqual('');
-            interactivity.on('featureHover', () => {
-                // This callback is executed before the one that acutally changes the cursor so we set a timeout to ensure the cursor was changed.
-                setTimeout(() => {
-                    expect(map.getCanvas().style.cursor).toEqual('');
-                    done();
-                }, 10);
-
-            });
             layer1.on('loaded', () => {
                 // Move mouse inside a feature 1
                 util.simulateMove({ lng: 5, lat: 5 });
+                setTimeout(() => {
+                    expect(map.getCanvas().style.cursor).toEqual('');
+                    done();
+                }, 100);
             });
         });
     });


### PR DESCRIPTION
#518
---

This PR adds a new parameter to the Interactivity object that allows controlling de cursor when the user points to a feature.

By default the cursor will be [pointer](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor) and the user can override this by pasing an argument when creating the interactivity.

```js
// Cursor wont change on mouse hover
const interactivity = new carto.Interactivity(layer, {defaultCursor: true});

// Cursor will change on mouse hover
const interactivity = new carto.Interactivity(layer, {defaultCursor: false});

// Cursor will change on mouse hover (default)
const interactivity = new carto.Interactivity(layer);
```