### PR TITLE
Fix renderer initializing when adding layers

### DIFF
--- a/src/api/integrator/mapbox-gl.js
+++ b/src/api/integrator/mapbox-gl.js
@@ -81,15 +81,13 @@ class MGLIntegrator {
             layer.$paintCallback();
             this._paintedLayers++;
 
-            if (this._paintedLayers % this._layers.length == 0) {
-                // Last layer has been painted
-                const isAnimated = this._layers.some(layer =>
-                    layer.getViz() && layer.getViz().isAnimated());
-                // Checking this.map.repaint is needed, because MGL repaint is a setter and it has the strange quite buggy side-effect of doing a "final" repaint after being disabled
-                // if we disable it every frame, MGL will do a "final" repaint every frame, which will not disabled it in practice
-                if (!isAnimated && this.map.repaint) {
-                    this.map.repaint = false;
-                }
+            // Last layer has been painted
+            const isAnimated = this._layers.some(layer =>
+                layer.getViz() && layer.getViz().isAnimated());
+            // Checking this.map.repaint is needed, because MGL repaint is a setter and it has the strange quite buggy side-effect of doing a "final" repaint after being disabled
+            // if we disable it every frame, MGL will do a "final" repaint every frame, which will not disabled it in practice
+            if (!isAnimated && this.map.repaint) {
+                this.map.repaint = false;
             }
 
             invalidate();


### PR DESCRIPTION
This fixes https://github.com/CartoDB/carto-vl/issues/582

We were initializing the renderer every time we added a layer, because when calling `addLayer` method the variable `firstCallback` was always being set to `true`. 

Also, after talking with @davidmanzanares, we have seen that `(this._paintedLayers % this._layers.length == 0)` condition may be no longer needed.