### PR TITLE
Fix sprite flickering

### DIFF
--- a/src/core/viz/expressions/base.js
+++ b/src/core/viz/expressions/base.js
@@ -45,7 +45,7 @@ export default class Base {
         this._getChildren().map(child => child._setUID(idGenerator));
     }
 
-    isFeatureDependent(){
+    isFeatureDependent() {
         return this._getChildren().some(child => child.isFeatureDependent());
     }
 
@@ -178,6 +178,9 @@ export default class Base {
     }
 
     _blendFrom(final, duration = 500, interpolator = null) {
+        if (this.default && final.default) {
+            return;
+        }
         final = implicitCast(final);
         const parent = this.parent;
         const blender = blend(final, this, animate(duration), interpolator);


### PR DESCRIPTION
Fix https://github.com/CartoDB/carto-vl/issues/615

The problem is that the blending of two default colors is no longer considered a `default` anymore, therefore, until the blending ends, the color overrides the original sprite color.

The fix is based on avoiding blending between a default and another default, this should be a perf improvement too :smile: .