### PR TITLE
Fix zoom() resolution dependency problem

### DIFF
--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -253,7 +253,7 @@ export default class Renderer {
         const gl = this.gl;
         const aspect = this.getAspect();
         const drawMetadata = {
-            zoom: 1 / this._zoom, // Used by zoom expression
+            zoom: 1 / this._zoom / 1024 * gl.drawingBufferHeight / (window.devicePixelRatio || 1), // Used by zoom expression
         };
 
         if (!tiles.length) {
@@ -272,7 +272,7 @@ export default class Renderer {
 
         const styleDataframe = (tile, tileTexture, shader, vizExpr) => {
             const textureId = shader.textureIds.get(viz);
-            
+
             gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tileTexture, 0);
             gl.viewport(0, 0, RTT_WIDTH, tile.height);
             gl.clear(gl.COLOR_BUFFER_BIT);
@@ -296,7 +296,7 @@ export default class Renderer {
             gl.drawArrays(gl.TRIANGLES, 0, 3);
             gl.disableVertexAttribArray(shader.vertexAttribute);
         };
-        
+
         tiles.map(tile => styleDataframe(tile, tile.texColor, viz.colorShader, viz.color));
         tiles.map(tile => styleDataframe(tile, tile.texWidth, viz.widthShader, viz.width));
         tiles.map(tile => styleDataframe(tile, tile.texStrokeColor, viz.strokeColorShader, viz.strokeColor));

--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -253,7 +253,7 @@ export default class Renderer {
         const gl = this.gl;
         const aspect = this.getAspect();
         const drawMetadata = {
-            zoom: 1 / this._zoom / 1024 * gl.drawingBufferHeight / (window.devicePixelRatio || 1), // Used by zoom expression
+            zoom: gl.drawingBufferHeight / (this._zoom * 1024 * (window.devicePixelRatio || 1)), // Used by zoom expression
         };
 
         if (!tiles.length) {

--- a/test/acceptance/e2e/pop_density_points/scenario.js
+++ b/test/acceptance/e2e/pop_density_points/scenario.js
@@ -14,7 +14,7 @@ const source = new carto.source.Dataset('pop_density_points');
 const s = carto.expressions;
 const $dn = s.property('dn');
 const viz = new carto.Viz({
-    width: s.div(s.zoom(), 2),
+    width: s.div(s.zoom(), 2 / 1024 * 300),
     color: s.ramp(s.linear($dn, 1, 300), s.palettes.PRISM),
     strokeColor: s.rgba(0, 0, 0, 0.2),
     strokeWidth: 1,


### PR DESCRIPTION
As reported by @Jesus89 the `zoom()` expression doesn't work very well when the resolution varies. You can reproduce the problem by using `zoom()` in the `width:` and resize the browser, the problem is even more clear in mobile.

This changes the semantics of `zoom()` so that different resolutions generates the same output.

Basically `Renderer._zoom` is the percentage of Earth in the Y (latitude) axis that is covered by the map. However, what the user probably wants/needs is the scale: the ratio between a pixel and a real meter on the Earth.
