### PR TITLE
Replace use of instanceof to check expression type

### DIFF
--- a/src/client/windshaft-filtering.js
+++ b/src/client/windshaft-filtering.js
@@ -54,14 +54,14 @@ class AggregationFiltering {
     }
 
     _and(f) {
-        if (f instanceof And) {
+        if (f.isA(And)) {
             return this._and(f.a).concat(this._and(f.b)).filter(Boolean);
         }
         return [this._or(f)].filter(Boolean);
     }
 
     _or(f) {
-        if (f instanceof Or) {
+        if (f.isA(Or)) {
             let a = this._basicCondition(f.a);
             let b = this._basicCondition(f.b);
             if (a && b) {
@@ -75,7 +75,7 @@ class AggregationFiltering {
     }
 
     _removeBlend(f) {
-        if (f instanceof Blend && f.originalMix instanceof Transition) {
+        if (f.isA(Blend) && f.originalMix.isA(Transition)) {
             return f.b;
         }
         return f;
@@ -92,13 +92,13 @@ class AggregationFiltering {
 
     _value(f) {
         f = this._removeBlend(f);
-        if (f instanceof NumberExpression || f instanceof ConstantExpression || f instanceof CategoryExpression) {
+        if (f.isA(NumberExpression) || f.isA(ConstantExpression) || f.isA(CategoryExpression)) {
             return f.expr;
         }
     }
 
     _between(f) {
-        if (f instanceof Between) {
+        if (f.isA(Between)) {
             let p = this._aggregation(f.value);
             let lo = p && this._value(f.lowerLimit);
             let hi = p && lo && this._value(f.upperLimit);
@@ -113,7 +113,7 @@ class AggregationFiltering {
     }
 
     _in(f) {
-        if (f instanceof In) {
+        if (f.isA(In)) {
             let p = this._aggregation(f.value);
             let values = f.list.elems.map(c => this._value(c)).filter(v => v != null);
             if (p && values.length > 0 && values.length == f.list.elems.length) {
@@ -126,7 +126,7 @@ class AggregationFiltering {
     }
 
     _notIn(f) {
-        if (f instanceof Nin) {
+        if (f.isA(Nin)) {
             let p = this._aggregation(f.value);
             let values = f.list.elems.map(c => this._value(c)).filter(v => v != null);
             if (p && values.length > 0 && values.length == f.list.elems.length) {
@@ -164,7 +164,7 @@ class AggregationFiltering {
 
     _aggregation(f) {
         f = this._removeBlend(f);
-        if (f instanceof ClusterAvg || f instanceof ClusterMax || f instanceof ClusterMin || f instanceof ClusterMode || f instanceof ClusterSum) {
+        if (f.isA(ClusterAvg) || f.isA(ClusterMax) || f.isA(ClusterMin) || f.isA(ClusterMode) || f.isA(ClusterSum)) {
             let p = this._property(f.property);
             if (p) {
                 p.property = schema.column.aggColumn(p.property, f.aggName);
@@ -181,7 +181,7 @@ class AggregationFiltering {
 
     _property(f) {
         f = this._removeBlend(f);
-        if (f instanceof Property) {
+        if (f.isA(Property)) {
             return {
                 property: f.name,
                 filters: []
@@ -191,7 +191,7 @@ class AggregationFiltering {
 
     _cmpOp(f, opClass, opParam, inverseOpParam) {
         inverseOpParam = inverseOpParam || opParam;
-        if (f instanceof opClass) {
+        if (f.isA(opClass)) {
             let p = this._aggregation(f.a);
             let v = p && this._value(f.b);
             let op = opParam;
@@ -260,7 +260,7 @@ class PreaggregationFiltering {
     }
 
     _and(f) {
-        if (f instanceof And) {
+        if (f.isA(And)) {
             // we can ignore nonsupported (null) subexpressions that are combined with AND
             // and keep the supported ones as a partial filter
             const l = [this._filter(f.a), this._filter(f.b)].filter(Boolean).reduce((x, y) => x.concat(y), []);
@@ -278,7 +278,7 @@ class PreaggregationFiltering {
     }
 
     _or(f) {
-        if (f instanceof Or) {
+        if (f.isA(Or)) {
             // if any subexpression is not supported the OR combination isn't supported either
             let a = this._filter(f.a);
             let b = this._filter(f.b);
@@ -317,7 +317,7 @@ class PreaggregationFiltering {
     }
 
     _cmpOp(f, opClass, type) {
-        if (f instanceof opClass) {
+        if (f.isA(opClass)) {
             let a = this._property(f.a) || this._value(f.a);
             let b = this._property(f.b) || this._value(f.b);
             if (a && b) {
@@ -331,13 +331,13 @@ class PreaggregationFiltering {
     }
 
     _blend(f) {
-        if (f instanceof Blend && f.originalMix instanceof Transition) {
+        if (f.isA(Blend) && f.originalMix.isA(Transition)) {
             return this._filter(f.b);
         }
     }
 
     _property(f) {
-        if (f instanceof Property) {
+        if (f.isA(Property)) {
             return {
                 type: 'property',
                 property: f.name
@@ -346,7 +346,7 @@ class PreaggregationFiltering {
     }
 
     _value(f) {
-        if (f instanceof NumberExpression || f instanceof ConstantExpression || f instanceof CategoryExpression) {
+        if (f.isA(NumberExpression) || f.isA(ConstantExpression) || f.isA(CategoryExpression)) {
             return {
                 type: 'value',
                 value: f.expr
@@ -355,7 +355,7 @@ class PreaggregationFiltering {
     }
 
     _in(f) {
-        if (f instanceof In) {
+        if (f.isA(In)) {
             let p = this._property(f.value);
             let values = f.list.elems.map(cat => this._value(cat));
             if (p && values.length > 0 && values.length == f.list.elems.length) {
@@ -369,7 +369,7 @@ class PreaggregationFiltering {
     }
 
     _notIn(f) {
-        if (f instanceof Nin) {
+        if (f.isA(Nin)) {
             let p = this._property(f.value);
             let values = f.list.elems.map(cat => this._value(cat));
             if (p && values.length > 0 && values.length == f.list.elems.length) {
@@ -383,7 +383,7 @@ class PreaggregationFiltering {
     }
 
     _between(f) {
-        if (f instanceof Between) {
+        if (f.isA(Between)) {
             let p = this._property(f.value);
             let lo = this._value(f.lowerLimit);
             let hi = this._value(f.upperLimit);

--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -487,10 +487,10 @@ function getOrderingRenderBuckets(renderLayer) {
     let orderingMaxs = [1000];
     // We divide the ordering into 64 buckets of 2 pixels each, since the size limit is 127 pixels
     const NUM_BUCKETS = 64;
-    if (orderer instanceof Asc) {
+    if (orderer.isA(Asc)) {
         orderingMins = Array.from({ length: NUM_BUCKETS }, (_, i) => ((NUM_BUCKETS - 1) - i) * 2);
         orderingMaxs = Array.from({ length: NUM_BUCKETS }, (_, i) => i == 0 ? 1000 : ((NUM_BUCKETS - 1) - i + 1) * 2);
-    } else if (orderer instanceof Desc) {
+    } else if (orderer.isA(Desc)) {
         orderingMins = Array.from({ length: NUM_BUCKETS }, (_, i) => i * 2);
         orderingMaxs = Array.from({ length: NUM_BUCKETS }, (_, i) => i == (NUM_BUCKETS - 1) ? 1000 : (i + 1) * 2);
     }

--- a/src/renderer/viz/expressions/Animation.js
+++ b/src/renderer/viz/expressions/Animation.js
@@ -68,13 +68,11 @@ let waitingForOthers = new Set();
 export class Animation extends BaseExpression {
     constructor(input, duration = 10, fade = new Fade()) {
         duration = implicitCast(duration);
-        let originalInput = input;
+        input = implicitCast(input);
+        const originalInput = input;
 
-        if (input.valueOf() instanceof Property) {
+        if (input.isA(Property)) {
             input = linear(input, globalMin(input), globalMax(input));
-        } else {
-            input = implicitCast(input);
-            originalInput = input;
         }
 
         checkLooseType('animation', 'input', 0, 'number', input);

--- a/src/renderer/viz/expressions/Animation.js
+++ b/src/renderer/viz/expressions/Animation.js
@@ -70,7 +70,7 @@ export class Animation extends BaseExpression {
         duration = implicitCast(duration);
         let originalInput = input;
 
-        if (input.isA(Property)) {
+        if (input.valueOf() instanceof Property) {
             input = linear(input, globalMin(input), globalMax(input));
         } else {
             input = implicitCast(input);

--- a/src/renderer/viz/expressions/Animation.js
+++ b/src/renderer/viz/expressions/Animation.js
@@ -70,7 +70,7 @@ export class Animation extends BaseExpression {
         duration = implicitCast(duration);
         let originalInput = input;
 
-        if (input instanceof Property) {
+        if (input.isA(Property)) {
             input = linear(input, globalMin(input), globalMax(input));
         } else {
             input = implicitCast(input);

--- a/src/renderer/viz/expressions/base.js
+++ b/src/renderer/viz/expressions/base.js
@@ -207,4 +207,8 @@ export default class Base {
     eval(feature) {
         throw new Error('Unimplemented');
     }
+
+    isA(expressionClass) {
+        return this instanceof expressionClass;
+    }
 }

--- a/src/renderer/viz/expressions/blend.js
+++ b/src/renderer/viz/expressions/blend.js
@@ -26,7 +26,7 @@ import BaseExpression from './base';
  *                linear(zoom(), 2^10, 2^14)
  *          )
  * `);
- * 
+ *
  * @memberof carto.expressions
  * @name blend
  * @function
@@ -82,7 +82,7 @@ export default class Blend extends BaseExpression {
     }
     _preDraw(...args) {
         super._preDraw(...args);
-        if (this.originalMix instanceof Transition && !this.originalMix.isAnimated()) {
+        if (this.originalMix.isA(Transition) && !this.originalMix.isAnimated()) {
             this.parent.replaceChild(this, this.b);
             this.notify();
         }

--- a/src/renderer/viz/expressions/utils.js
+++ b/src/renderer/viz/expressions/utils.js
@@ -157,7 +157,7 @@ export function checkType(expressionName, parameterName, parameterIndex, expecte
 
 export function checkInstance(expressionName, parameterName, parameterIndex, expectedClass, parameter) {
     checkExpression(expressionName, parameterName, parameterIndex, parameter);
-    if (!(parameter instanceof expectedClass)) {
+    if (!(parameter.isA(expectedClass))) {
         throwInvalidInstance(expressionName, parameterName, parameterIndex, expectedClass, parameter.type);
     }
 }

--- a/src/renderer/viz/expressions/viewportFeatures.js
+++ b/src/renderer/viz/expressions/viewportFeatures.js
@@ -63,7 +63,7 @@ export default class ViewportFeatures extends BaseExpression {
     }
 
     _resetViewportAgg(metadata) {
-        if (!this._requiredProperties.every(p => (p.valueOf() instanceof Property))) {
+        if (!this._requiredProperties.every(p => (p.isA(Property)))) {
             throw new Error('viewportFeatures arguments can only be properties');
         }
         this._metadata = metadata;

--- a/test/unit/renderer/viz/expressions/basic/isa.test.js
+++ b/test/unit/renderer/viz/expressions/basic/isa.test.js
@@ -1,0 +1,38 @@
+import * as s from '../../../../../../src/renderer/viz/expressions';
+import Property from '../../../../../../src/renderer/viz/expressions/basic/property';
+import Number from '../../../../../../src/renderer/viz/expressions/basic/number';
+import { validateStaticTypeErrors } from '../utils';
+
+describe('Expressions', () => {
+    describe('error control', () => {
+        validateStaticTypeErrors('property', []);
+        validateStaticTypeErrors('property', [undefined]);
+        validateStaticTypeErrors('property', [123]);
+        validateStaticTypeErrors('property', ['number']);
+    });
+
+    describe('isA', () => {
+        it('should detect expression type directly', () => {
+            const propExpr = s.property('xyz');
+            const numbExpr = s.number(11);
+            expect(propExpr.isA(Property)).toEqual(true);
+            expect(propExpr.isA(Number)).toEqual(false);
+            expect(numbExpr.isA(Property)).toEqual(false);
+            expect(numbExpr.isA(Number)).toEqual(true);
+        });
+
+        it('should detect expression type through variables', () => {
+            const propExpr = s.property('xyz');
+            const numbExpr = s.number(11);
+            const propVar = s.variable('vprop');
+            const numbVar = s.variable('vnumb');
+            propVar._resolveAliases({ vprop: propExpr });
+            numbVar._resolveAliases({ vnumb: numbExpr });
+
+            expect(propVar.isA(Property)).toEqual(true);
+            expect(propVar.isA(Number)).toEqual(false);
+            expect(numbVar.isA(Property)).toEqual(false);
+            expect(numbVar.isA(Number)).toEqual(true);
+        });
+    });
+});

--- a/test/unit/renderer/viz/expressions/basic/isa.test.js
+++ b/test/unit/renderer/viz/expressions/basic/isa.test.js
@@ -1,38 +1,28 @@
 import * as s from '../../../../../../src/renderer/viz/expressions';
 import Property from '../../../../../../src/renderer/viz/expressions/basic/property';
 import Number from '../../../../../../src/renderer/viz/expressions/basic/number';
-import { validateStaticTypeErrors } from '../utils';
 
-describe('Expressions', () => {
-    describe('error control', () => {
-        validateStaticTypeErrors('property', []);
-        validateStaticTypeErrors('property', [undefined]);
-        validateStaticTypeErrors('property', [123]);
-        validateStaticTypeErrors('property', ['number']);
+describe('isA', () => {
+    it('should detect expression type directly', () => {
+        const propExpr = s.property('xyz');
+        const numbExpr = s.number(11);
+        expect(propExpr.isA(Property)).toEqual(true);
+        expect(propExpr.isA(Number)).toEqual(false);
+        expect(numbExpr.isA(Property)).toEqual(false);
+        expect(numbExpr.isA(Number)).toEqual(true);
     });
 
-    describe('isA', () => {
-        it('should detect expression type directly', () => {
-            const propExpr = s.property('xyz');
-            const numbExpr = s.number(11);
-            expect(propExpr.isA(Property)).toEqual(true);
-            expect(propExpr.isA(Number)).toEqual(false);
-            expect(numbExpr.isA(Property)).toEqual(false);
-            expect(numbExpr.isA(Number)).toEqual(true);
-        });
+    it('should detect expression type through variables', () => {
+        const propExpr = s.property('xyz');
+        const numbExpr = s.number(11);
+        const propVar = s.variable('vprop');
+        const numbVar = s.variable('vnumb');
+        propVar._resolveAliases({ vprop: propExpr });
+        numbVar._resolveAliases({ vnumb: numbExpr });
 
-        it('should detect expression type through variables', () => {
-            const propExpr = s.property('xyz');
-            const numbExpr = s.number(11);
-            const propVar = s.variable('vprop');
-            const numbVar = s.variable('vnumb');
-            propVar._resolveAliases({ vprop: propExpr });
-            numbVar._resolveAliases({ vnumb: numbExpr });
-
-            expect(propVar.isA(Property)).toEqual(true);
-            expect(propVar.isA(Number)).toEqual(false);
-            expect(numbVar.isA(Property)).toEqual(false);
-            expect(numbVar.isA(Number)).toEqual(true);
-        });
+        expect(propVar.isA(Property)).toEqual(true);
+        expect(propVar.isA(Number)).toEqual(false);
+        expect(numbVar.isA(Property)).toEqual(false);
+        expect(numbVar.isA(Number)).toEqual(true);
     });
 });


### PR DESCRIPTION
To support variables we need to use a function so that it is proxied to the underlying expression.
Fixes #657