### PR TITLE
Remove support for SQL API

### DIFF
--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -171,7 +171,11 @@ export default class Windshaft {
         if (this._mvtClient) {
             this._mvtClient.free();
         }
-        this._mvtClient = new MVT(this._subdomains.map(s => urlTemplate.replace('{s}', s)));
+        let templateURL = this._subdomains.map(s => urlTemplate.replace('{s}', s));
+        if (this._subdomains.length === 0) {
+            templateURL = urlTemplate.replace('{s}', this._getSubdomain(0, 0));
+        }
+        this._mvtClient = new MVT(templateURL);
         this._mvtClient.bindLayer(this._addDataframe, this._dataLoadedCallback);
         this._mvtClient.decodeProperty = (propertyName, propertyValue) => {
             const basename = schema.column.getBase(propertyName);

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -287,12 +287,10 @@ export default class Windshaft {
     }
 
     _getConfig() {
-        // for local environments, which require direct access to Maps and SQL API ports, end the configured URL with "{local}"
         return {
             apiKey: this._source._apiKey,
             username: this._source._username,
-            mapsServerURL: this._source._serverURL.maps,
-            sqlServerURL: this._source._serverURL.sql
+            serverURL: this._source._serverURL
         };
     }
 
@@ -396,7 +394,7 @@ export default class Windshaft {
 }
 
 const endpoint = (conf, path = '') => {
-    let url = `${conf.mapsServerURL}/api/v1/map`;
+    let url = `${conf.serverURL}/api/v1/map`;
     if (path) {
         url += '/' + path;
     }

--- a/src/sources/BaseWindshaft.js
+++ b/src/sources/BaseWindshaft.js
@@ -46,10 +46,7 @@ export default class BaseWindshaft extends Base {
     _generateURL(auth, config) {
         let url = (config && config.serverURL) || DEFAULT_SERVER_URL_TEMPLATE;
         url = url.replace(/{user}/, auth.username);
-        validateServerURL(url.replace(/{local}/, ''));
-        return {
-            maps: url.replace(/{local}/, ':8181'),
-            sql:  url.replace(/{local}/, ':8080')
-        };
+        validateServerURL(url);
+        return url;
     }
 }

--- a/test/unit/source/base-windshaft.test.js
+++ b/test/unit/source/base-windshaft.test.js
@@ -25,8 +25,7 @@ describe('sources/base-windshaft', () => {
 
             expect(source._username).toEqual('test');
             expect(source._apiKey).toEqual('1234567890');
-            expect(source._serverURL.maps).toEqual('https://test.test.com');
-            expect(source._serverURL.sql).toEqual('https://test.test.com');
+            expect(source._serverURL).toEqual('https://test.test.com');
             expect(source._client).toBeDefined();
         });
 
@@ -36,8 +35,7 @@ describe('sources/base-windshaft', () => {
 
             expect(source._username).toEqual('test');
             expect(source._apiKey).toEqual('1234567890');
-            expect(source._serverURL.maps).toEqual('https://test.carto.com');
-            expect(source._serverURL.sql).toEqual('https://test.carto.com');
+            expect(source._serverURL).toEqual('https://test.carto.com');
             expect(source._client).toBeDefined();
         });
 

--- a/test/unit/source/dataset.test.js
+++ b/test/unit/source/dataset.test.js
@@ -16,8 +16,7 @@ describe('sources/dataset', () => {
             expect(source._tableName).toEqual('table0');
             expect(source._username).toEqual('test');
             expect(source._apiKey).toEqual('1234567890');
-            expect(source._serverURL.maps).toEqual('https://test.test.com');
-            expect(source._serverURL.sql).toEqual('https://test.test.com');
+            expect(source._serverURL).toEqual('https://test.test.com');
             expect(source._client).toBeDefined();
         });
 
@@ -26,8 +25,7 @@ describe('sources/dataset', () => {
             expect(source._tableName).toEqual('table0');
             expect(source._username).toEqual('test');
             expect(source._apiKey).toEqual('1234567890');
-            expect(source._serverURL.maps).toEqual('https://test.carto.com');
-            expect(source._serverURL.sql).toEqual('https://test.carto.com');
+            expect(source._serverURL).toEqual('https://test.carto.com');
             expect(source._client).toBeDefined();
         });
 

--- a/test/unit/source/sql.test.js
+++ b/test/unit/source/sql.test.js
@@ -16,8 +16,7 @@ describe('sources/sql', () => {
             expect(source._query).toEqual('SELECT * from table0');
             expect(source._username).toEqual('test');
             expect(source._apiKey).toEqual('1234567890');
-            expect(source._serverURL.maps).toEqual('https://test.test.com');
-            expect(source._serverURL.sql).toEqual('https://test.test.com');
+            expect(source._serverURL).toEqual('https://test.test.com');
             expect(source._client).toBeDefined();
         });
 
@@ -26,8 +25,7 @@ describe('sources/sql', () => {
             expect(source._query).toEqual('SELECT * from table0');
             expect(source._username).toEqual('test');
             expect(source._apiKey).toEqual('1234567890');
-            expect(source._serverURL.maps).toEqual('https://test.carto.com');
-            expect(source._serverURL.sql).toEqual('https://test.carto.com');
+            expect(source._serverURL).toEqual('https://test.carto.com');
             expect(source._client).toBeDefined();
         });
 


### PR DESCRIPTION
Only Maps API is used, so no need to keep SQL API urls or have {local} to support local environments

Fixes #613

Local usage is broken (cdn subdomains are required). I'll fix it in this PR
