### PR TITLE
Optimize viewportFeatures

### DIFF
--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -230,7 +230,7 @@ export default class Renderer {
      */
     _featureFromDataFrame(dataframe, index) {
         if (!dataframe.cachedFeatures) {
-            dataframe.cachedFeatures = new Array(dataframe.numFeatures);
+            dataframe.cachedFeatures = [];
         }
 
         if (dataframe.cachedFeatures[index] !== undefined) {

--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -230,7 +230,7 @@ export default class Renderer {
      */
     _featureFromDataFrame(dataframe, index) {
         if (!dataframe.cachedFeatures) {
-            dataframe.cachedFeatures = [];
+            dataframe.cachedFeatures = new Array(dataframe.numFeatures);
         }
 
         if (dataframe.cachedFeatures[index] !== undefined) {
@@ -243,7 +243,7 @@ export default class Renderer {
             const name = propertyNames[i];
             feature[name] = dataframe.properties[name][index];
         }
-        dataframe.cachedFeatures.push(feature);
+        dataframe.cachedFeatures[index] = feature;
         return feature;
     }
 

--- a/src/renderer/viz/expressions/viewportFeatures.js
+++ b/src/renderer/viz/expressions/viewportFeatures.js
@@ -69,13 +69,13 @@ export default class ViewportFeatures extends BaseExpression {
                 throw new Error('viewportFeatures arguments can only be properties');
             }
             const columns = this._getMinimumNeededSchema().columns;
-            this.viewportFeature = this.genViewportFeatureClass(columns, metadata);
+            this._FeatureProxy = this.genViewportFeatureClass(columns, metadata);
         }
         this.expr = [];
     }
 
     accumViewportAgg(feature) {
-        this.expr.push(new this.viewportFeature(feature));
+        this.expr.push(new this._FeatureProxy(feature));
     }
 
     genViewportFeatureClass(properties, metadata) {

--- a/src/renderer/viz/expressions/viewportFeatures.js
+++ b/src/renderer/viz/expressions/viewportFeatures.js
@@ -44,6 +44,7 @@ export default class ViewportFeatures extends BaseExpression {
         this.type = 'featureList';
         this._isViewport = true;
         this._requiredProperties = properties;
+        this.viewportFeature = null;
     }
 
     _compile() {
@@ -63,30 +64,45 @@ export default class ViewportFeatures extends BaseExpression {
     }
 
     _resetViewportAgg(metadata) {
-        if (!this._requiredProperties.every(p => (p.isA(Property)))) {
-            throw new Error('viewportFeatures arguments can only be properties');
+        if (!this.viewportFeature) {
+            if (!this._requiredProperties.every(p => (p.isA(Property)))) {
+                throw new Error('viewportFeatures arguments can only be properties');
+            }
+            const columns = this._getMinimumNeededSchema().columns;
+            this.viewportFeature = this.genViewportFeatureClass(columns, metadata);
         }
-        this._metadata = metadata;
-        this._columns = this._getMinimumNeededSchema().columns;
         this.expr = [];
     }
 
     accumViewportAgg(feature) {
-        this.expr.push(_adaptFeature(feature, this._columns, this._metadata));
+        // this.expr.push(_adaptFeature(feature, this._columns, this._metadata));
+        this.expr.push(new this.viewportFeature(feature));
     }
-}
 
-function _adaptFeature(feature, propertyNames, metadata) {
-    const adaptedFeature = {};
-    for (let i = 0; i < propertyNames.length; i++) {
-        const name = propertyNames[i];
-        let value = feature[name];
-        if (metadata.properties[name].type === 'category') {
-            value = metadata.IDToCategory.get(value);
-        }
-        adaptedFeature[name] = value;
+    genViewportFeatureClass(properties, metadata) {
+        const categoryProperties = properties.filter(name => metadata.properties[name].type === 'category');
+        const nonCategoryProperties = properties.filter(name => metadata.properties[name].type !== 'category');
+        const cls = class ViewportFeature {
+            constructor(feature) {
+                this._feature = feature;
+            }
+        };
+        nonCategoryProperties.forEach(prop => {
+            Object.defineProperty(cls.prototype, prop, {
+                get: function() {
+                    return this._feature[prop];
+                }
+            });
+        });
+        categoryProperties.forEach(prop => {
+            Object.defineProperty(cls.prototype, prop, {
+                get: function() {
+                    return metadata.IDToCategory.get(this._feature[prop]);
+                }
+            });
+        });
+        return cls;
     }
-    return adaptedFeature;
 }
 
 function _childrenFromProperties(properties) {

--- a/src/renderer/viz/expressions/viewportFeatures.js
+++ b/src/renderer/viz/expressions/viewportFeatures.js
@@ -75,7 +75,6 @@ export default class ViewportFeatures extends BaseExpression {
     }
 
     accumViewportAgg(feature) {
-        // this.expr.push(_adaptFeature(feature, this._columns, this._metadata));
         this.expr.push(new this.viewportFeature(feature));
     }
 

--- a/src/sources/Mvt.js
+++ b/src/sources/Mvt.js
@@ -185,10 +185,12 @@ export default class MVT extends Base {
     }
 
     _decodeProperties(propertyNames, properties, feature, i) {
-        propertyNames.forEach(propertyName => {
+        const length = propertyNames.length;
+        for (let j = 0; j < length; j++) {
+            const propertyName = propertyNames[j];
             const propertyValue = feature.properties[propertyName];
             properties[propertyName][i] = this.decodeProperty(propertyName, propertyValue);
-        });
+        }
     }
 
     decodeProperty(propertyName, propertyValue) {

--- a/test/acceptance/e2e/non-compliant-mvt/scenario.js
+++ b/test/acceptance/e2e/non-compliant-mvt/scenario.js
@@ -11,11 +11,14 @@ const metadata = {
     properties: {}
 };
 
-let vizSpec = 'color: ramp(linear($attr_0, 0, 1000), temps)';
+let wadus = [];
+let vizSpec = 'color: ramp(linear($attr_0, 0, 1000), temps)\n';
 for (let i = 0; i < 600; i++) {
     metadata.properties['attr_' + i] = { type: 'number' };
     vizSpec += `@A${i}: $attr_${i}\n`;
+    wadus.push(`$attr_${i}`);
 }
+vizSpec += `\n@wadus: viewportFeatures(${wadus.join()})`;
 
 const source = new carto.source.MVT('./test.mvt', metadata);
 const viz = new carto.Viz(vizSpec);

--- a/test/integration/user/test/viewportFeatures.test.js
+++ b/test/integration/user/test/viewportFeatures.test.js
@@ -37,7 +37,7 @@ function checkFeatures(list, expectedList) {
     expect(list.length).toEqual(expectedList.length);
     for (let i=0; i<list.length; ++i) {
         const actual = {};
-        const expected = expectedList;
+        const expected = expectedList[i];
         Object.keys(expected).forEach(prop => actual[prop] = list[i][prop]);
         expect(actual).toEqual(expected);
     }

--- a/test/integration/user/test/viewportFeatures.test.js
+++ b/test/integration/user/test/viewportFeatures.test.js
@@ -32,6 +32,17 @@ const features = {
     features: [ feature1, feature2 ]
 };
 
+function checkFeatures(list, expectedList) {
+    // FIXME: this shouldn't require list to have the same order as expected
+    expect(list.length).toEqual(expectedList.length);
+    for (let i=0; i<list.length; ++i) {
+        const actual = {};
+        const expected = expectedList;
+        Object.keys(expected).forEach(prop => actual[prop] = list[i][prop]);
+        expect(actual).toEqual(expected);
+    }
+}
+
 describe('viewportFeatures', () => {
     let map, source1, viz1, layer1, source2, viz2, layer2;
 
@@ -63,7 +74,7 @@ describe('viewportFeatures', () => {
                 { value: 10, category: 'a'},
                 { value: 1000, category: 'b'}
             ];
-            expect(viz1.variables.list.eval()).toEqual(expected);
+            checkFeatures(viz1.variables.list.eval(), expected);
             done();
         });
     });
@@ -78,8 +89,8 @@ describe('viewportFeatures', () => {
                 { value: 10 },
                 { value: 1000 }
             ];
-            expect(viz2.variables.list2all.eval()).toEqual(expectedAll);
-            expect(viz2.variables.list2value.eval()).toEqual(expectedValue);
+            checkFeatures(viz2.variables.list2all.eval(), expectedAll);
+            checkFeatures(viz2.variables.list2value.eval(), expectedValue);
             done();
         });
     });
@@ -116,7 +127,7 @@ describe('viewportFeatures on a map with filters', () => {
             const expected = [
                 { value: 10, category: 'a'}
             ];
-            expect(viz1.variables.list.eval()).toEqual(expected);
+            checkFeatures(viz1.variables.list.eval(), expected);
             done();
         });
     });
@@ -129,8 +140,8 @@ describe('viewportFeatures on a map with filters', () => {
             const expectedValue = [
                 { value: 1000 }
             ];
-            expect(viz2.variables.list2all.eval()).toEqual(expectedAll);
-            expect(viz2.variables.list2value.eval()).toEqual(expectedValue);
+            checkFeatures(viz2.variables.list2all.eval(), expectedAll);
+            checkFeatures(viz2.variables.list2value.eval(), expectedValue);
             done();
         });
     });
@@ -167,7 +178,7 @@ describe('viewportFeatures on a zoomed-in map', () => {
             const expected = [
                 { value: 10, category: 'a'}
             ];
-            expect(viz1.variables.list.eval()).toEqual(expected);
+            checkFeatures(viz1.variables.list.eval(), expected);
             done();
         });
     });
@@ -180,8 +191,8 @@ describe('viewportFeatures on a zoomed-in map', () => {
             const expectedValue = [
                 { value: 10 }
             ];
-            expect(viz2.variables.list2all.eval()).toEqual(expectedAll);
-            expect(viz2.variables.list2value.eval()).toEqual(expectedValue);
+            checkFeatures(viz2.variables.list2all.eval(), expectedAll);
+            checkFeatures(viz2.variables.list2value.eval(), expectedValue);
             done();
         });
     });


### PR DESCRIPTION
This avoids creating new objects and copying the required properties for each feature.

I've also fixed a bug with the features cache of the renderer. The fix preallocates space for every feature in the dataframe. We should consider using a different approach for this cache.