### PR TITLE
prevent crash when url tile return 404 status

### DIFF
--- a/src/sources/Mvt.js
+++ b/src/sources/Mvt.js
@@ -74,7 +74,7 @@ export default class MVT extends Base {
     async responseToDataframeTransformer(response, x, y, z) {
         const MVT_EXTENT = 4096;
         const arrayBuffer = await response.arrayBuffer();
-        if (arrayBuffer.byteLength == 0 || response == 'null') {
+        if (arrayBuffer.byteLength == 0 || response == 'null' || response.status === 404) {
             return { empty: true };
         }
         const tile = new VectorTile(new Protobuf(arrayBuffer));


### PR DESCRIPTION
When you load a layer with a mvt source and you own .mbtiles It's very common not to have tiles generated for the entire world so some mvt urls can return a 404 status.

This PR prevent that Carto Vl crash  if receive a 404 status from mvt url