### PR TITLE
Bugfix for blending to variables multiple times

### DIFF
--- a/debug/list.html
+++ b/debug/list.html
@@ -57,7 +57,7 @@
       @list: viewportFeatures(@number, $sttext)
       @anotheList: viewportFeatures($zip)
       width: 20 // + 0*@number
-      // filter: $zip > 50000
+      @c: $zip > 50000
     `);
     const layer = new carto.Layer('layer', source, viz);
     layer.addTo(map, 'background');

--- a/src/renderer/viz/expressions/basic/variable.js
+++ b/src/renderer/viz/expressions/basic/variable.js
@@ -56,8 +56,8 @@ export default function variable(name) {
             if (prop == 'parent') {
                 obj[prop] = value;
             } else if (prop == 'notify') {
-                return obj[prop];
-            } else if(alias && alias[prop]) {
+                obj[prop] = value;
+            } else if (alias && alias[prop]) {
                 alias[prop] = value;
             } else {
                 return false;
@@ -66,11 +66,15 @@ export default function variable(name) {
             return true;
         },
         get: (obj, prop) => {
-            if (prop == '_resolveAliases') {
+            if (prop == 'parent') {
+                return obj[prop];
+            } else if (prop == '_resolveAliases') {
                 return resolve;
             } else if (prop == '_getDependencies') {
                 return _getDependencies;
             } else if (prop == 'notify') {
+                return obj[prop];
+            } else if (prop == 'blendTo') {
                 return obj[prop];
             }
             if (alias && alias[prop]) {

--- a/test/integration/user/test/expressions.test.js
+++ b/test/integration/user/test/expressions.test.js
@@ -36,7 +36,7 @@ describe('BaseExpression', () => {
             it('should work well with variables', done => {
                 layer.on('loaded', () => {
                     viz.filter.blendTo(carto.expressions.var('var1'), 0);
-                    setTimeout(()=>{
+                    setTimeout(() => {
                         viz.filter.blendTo(carto.expressions.var('var1'));
                         done();
                     }, 0);
@@ -46,6 +46,7 @@ describe('BaseExpression', () => {
     });
 
     afterEach(() => {
+        map.remove();
         document.body.removeChild(div);
     });
 });

--- a/test/integration/user/test/expressions.test.js
+++ b/test/integration/user/test/expressions.test.js
@@ -32,6 +32,17 @@ describe('BaseExpression', () => {
                 done();
             });
         });
+        describe('.regression', () => {
+            it('should work well with variables', done => {
+                layer.on('loaded', () => {
+                    viz.filter.blendTo(carto.expressions.var('var1'), 0);
+                    setTimeout(()=>{
+                        viz.filter.blendTo(carto.expressions.var('var1'));
+                        done();
+                    }, 0);
+                });
+            });
+        });
     });
 
     afterEach(() => {

--- a/test/integration/user/test/interactivity.test.js
+++ b/test/integration/user/test/interactivity.test.js
@@ -345,15 +345,16 @@ describe('Interactivity', () => {
     }
 
     afterEach(() => {
+        map.remove();
         document.body.removeChild(div);
     });
 });
 
 describe('Cursor', () => {
-    let map, source1, viz1, layer1;
+    let map, source1, viz1, layer1, setup;
 
     beforeEach(() => {
-        const setup = util.createMap('map');
+        setup = util.createMap('map');
         map = setup.map;
 
         source1 = new carto.source.GeoJSON(feature1);
@@ -393,5 +394,10 @@ describe('Cursor', () => {
                 }, 0);
             });
         });
+    });
+
+    afterEach(()=>{
+        map.remove();
+        document.body.removeChild(setup.div);
     });
 });

--- a/test/integration/user/test/layer.test.js
+++ b/test/integration/user/test/layer.test.js
@@ -101,6 +101,7 @@ describe('Layer', () => {
     });
 
     afterEach(() => {
+        map.remove();
         document.body.removeChild(div);
     });
 });

--- a/test/integration/user/test/viewportFeatures.test.js
+++ b/test/integration/user/test/viewportFeatures.test.js
@@ -44,10 +44,10 @@ function checkFeatures(list, expectedList) {
 }
 
 describe('viewportFeatures', () => {
-    let map, source1, viz1, layer1, source2, viz2, layer2;
+    let map, source1, viz1, layer1, source2, viz2, layer2, setup;
 
     beforeEach(() => {
-        const setup = util.createMap('map');
+        setup = util.createMap('map');
         map = setup.map;
 
         source1 = new carto.source.GeoJSON(features);
@@ -94,13 +94,17 @@ describe('viewportFeatures', () => {
             done();
         });
     });
+
+    afterEach(() => {
+        document.body.removeChild(setup.div);
+    });
 });
 
 describe('viewportFeatures on a map with filters', () => {
-    let map, source1, viz1, layer1, source2, viz2, layer2;
+    let map, source1, viz1, layer1, source2, viz2, layer2, setup;
 
     beforeEach(() => {
-        const setup = util.createMap('map');
+        setup = util.createMap('map');
         map = setup.map;
 
         source1 = new carto.source.GeoJSON(features);
@@ -132,7 +136,7 @@ describe('viewportFeatures on a map with filters', () => {
         });
     });
 
-    it ('should get the fileered feature properties of another layer', done => {
+    it ('should get the filtered feature properties of another layer', done => {
         layer2.on('updated', () => {
             const expectedAll = [
                 { id: 2, value: 1000, category: 'b'}
@@ -145,14 +149,18 @@ describe('viewportFeatures on a map with filters', () => {
             done();
         });
     });
+
+    afterEach(() => {
+        document.body.removeChild(setup.div);
+    });
 });
 
 
 describe('viewportFeatures on a zoomed-in map', () => {
-    let map, source1, viz1, layer1, source2, viz2, layer2;
+    let map, source1, viz1, layer1, source2, viz2, layer2, setup;
 
     beforeEach(() => {
-        const setup = util.createMap('map');
+        setup = util.createMap('map');
         map = setup.map;
         map.setZoom(10);
 
@@ -196,13 +204,17 @@ describe('viewportFeatures on a zoomed-in map', () => {
             done();
         });
     });
+
+    afterEach(() => {
+        document.body.removeChild(setup.div);
+    });
 });
 
 describe('viewportFeatures with invalid parameters', () => {
-    let map, source, viz, layer;
+    let map, source, viz, layer, setup;
 
     beforeEach(() => {
-        const setup = util.createMap('map');
+        setup = util.createMap('map');
         map = setup.map;
 
         source = new carto.source.GeoJSON(features);
@@ -224,5 +236,10 @@ describe('viewportFeatures with invalid parameters', () => {
             }
         ).toThrowError(/arguments can only be properties/);
         done();
+    });
+
+    afterEach(() => {
+        map.remove();
+        document.body.removeChild(setup.div);
     });
 });


### PR DESCRIPTION
Steps to reproduce:
1. Open debug/list.html with these changes
2. Run viz.filter.blendTo(carto.expressions.var('c')) on the console after map loading
3. Run viz.filter.blendTo(carto.expressions.TRUE)
4. Run viz.filter.blendTo(carto.expressions.var('c')) again, it will crash without the changes on src/

- [x] Fix
- [x] Regression test

~Could be fixing https://github.com/CartoDB/carto-vl/issues/676~ No, this doesn't fix that issue.