### PR TITLE
Remove deprecated exprs

### DIFF
--- a/debug/multi-anim.html
+++ b/debug/multi-anim.html
@@ -51,7 +51,7 @@
             strokeWidth: 0
             width: sqrt($speed*($accel_lateral*$accel_lateral)) + 1
             color: ramp(linear(abs($accel_lateral), 0, 1.2), temps)
-            filter: $lap == 24 and torque(linear($date), 20, fade(0, 100))
+            filter: $lap == 24 and animation(linear($date), 20, fade(0, 100))
         `);
         const layer = new carto.Layer('gpstrack', source, viz);
         layer.addTo(map, 'watername_ocean');
@@ -101,7 +101,7 @@ FROM geoms
             width: 4
             color: ramp(linear(abs($accel_lateral), 0, 1), temps)
             strokeWidth: 0
-            filter: $lap == 24 and torque(linear($date), 20, fade(0, 1))
+            filter: $lap == 24 and animation(linear($date), 20, fade(0, 1))
         `);
         const accelerationsLayer = new carto.Layer('accelerations', accelerationsSource, accelerations);
         accelerationsLayer.addTo(map, 'watername_ocean');

--- a/examples/styling/multiple-images.html
+++ b/examples/styling/multiple-images.html
@@ -19,10 +19,10 @@
   <aside class="toolbox">
     <div class="box">
       <header>
-        <h1>Multiple Sprites</h1>
+        <h1>Multiple Images</h1>
       </header>
       <section>
-        <p class="description open-sans">Show different sprites based on a category property</p>
+        <p class="description open-sans">Show different images based on a category property</p>
       </section>
       <footer class="js-footer"></footer>
     </div>

--- a/src/renderer/viz/expressions.js
+++ b/src/renderer/viz/expressions.js
@@ -285,8 +285,6 @@ export const constant = (...args) => new Constant(...args);
 
 export const image = (...args) => new Image(...args);
 export const imageList = (...args) => new ImageList(...args);
-export const sprite = (...args) => showDeprecationWarning(args, Image, 'sprite', 'image');
-export const sprites = (...args) => showDeprecationWarning(args, ImageList, 'sprites', 'imageList');
 
 export const svg = (...args) => new SVG(...args);
 

--- a/src/renderer/viz/expressions.js
+++ b/src/renderer/viz/expressions.js
@@ -340,7 +340,6 @@ export const top = (...args) => new Top(...args);
 
 export const fade = (...args) => new Fade(...args);
 export const animation = (...args) => new Animation(...args);
-export const torque = (...args) => showDeprecationWarning(args, Animation, 'torque', 'animation');
 
 export const log = (...args) => new Log(...args);
 export const sqrt = (...args) => new Sqrt(...args);


### PR DESCRIPTION
Fix for https://github.com/CartoDB/carto-vl/issues/696

TODO: replace removed expressions from the editor examples