### PR TITLE
updating feature enter example

### DIFF
--- a/docs/guides/07-introduction-to-interactivity.md
+++ b/docs/guides/07-introduction-to-interactivity.md
@@ -52,11 +52,11 @@ feature included in the `features` array.
 
 ```js
 interactivity.on('featureEnter', featureEvent => {
-    featureEvent.features[0].color.blendTo('rgba(255, 0, 0, 0.5)', 100);
+    featureEvent.features[0].color.blendTo('rgba(0, 255, 0, 0.8)', 100);
 });
 ```
 
-By the other side, when the `featureLeave` event is fired we tell our callback to `reset` the color of the feature
+When the `featureLeave` event is fired we tell our callback to `reset` the color of the feature
 
 ```js
 interactivity.on('featureLeave', featureEvent => {

--- a/examples/guides/interactivity/featureEnter.html
+++ b/examples/guides/interactivity/featureEnter.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
     <!-- Include CARTO VL JS -->
-    <script src="../../../../dist/carto-vl.js"></script>
+    <script src="https://libs.cartocdn.com/carto-vl/v0.5.3/carto-vl.min.js"></script>
     <!-- Include Mapbox GL JS -->
     <script src="https://libs.cartocdn.com/mapbox-gl/v0.45.0-carto1/mapbox-gl.js"></script>
     <!-- Include Mapbox GL CSS -->
@@ -43,7 +43,7 @@
 
         const interactivity = new carto.Interactivity(layer);
         interactivity.on('featureEnter', featureEvent => {
-            featureEvent.features[0].color.blendTo('rgba(255, 0, 0, 0.5)', 100);
+            featureEvent.features[0].color.blendTo('rgba(0, 255, 0, 0.8)', 100);
         });
 
         interactivity.on('featureLeave', featureEvent => {

--- a/examples/guides/interactivity/featureEnter.html
+++ b/examples/guides/interactivity/featureEnter.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
     <!-- Include CARTO VL JS -->
-    <script src="https://libs.cartocdn.com/carto-vl/v0.5.3/carto-vl.min.js"></script>
+    <script src="../../../../dist/carto-vl.js"></script>
     <!-- Include Mapbox GL JS -->
     <script src="https://libs.cartocdn.com/mapbox-gl/v0.45.0-carto1/mapbox-gl.js"></script>
     <!-- Include Mapbox GL CSS -->


### PR DESCRIPTION
The fix for this issue: https://github.com/CartoDB/carto-vl/issues/554

I updated the color for feature enter with a bright green so it has enough contrast to show the change from the default red.

I adjusted the guide text to reflect this change as well.