### PR TITLE
Another twist on the lines fix

### DIFF
--- a/src/renderer/decoder.js
+++ b/src/renderer/decoder.js
@@ -191,21 +191,7 @@ function addLine (lineString, vertices, normals) {
                     }
                 } else {
                     // Bevel join: adjust vertices and produce bevel triangle
-
-                    // Spike avoidance: joinNormal can produce points farther away than the geometry segments
-                    // This if fundamentally flawed: joinNormal dimensions are based on unit vectors, with no
-                    // relation to the segment geometry.
-                    // This could be performed properly in the vertex shader, if we pass segment information
-                    // (prev and/or next vertices) with each vertex.
-                    const MAGIC = 10;
-                    const joinLength = length(joinNormal);
-                    const segmentLength = MAGIC * Math.min(
-                        length(vector(prevPoint, currentPoint)),
-                        length(vector(currentPoint, nextPoint))
-                    );
-                    if (joinLength > segmentLength) {
-                        joinNormal = [joinNormal[0] * segmentLength / joinLength, joinNormal[1] * segmentLength / joinLength];
-                    }
+                    joinNormal = adjustJoinNormal(joinNormal, prevPoint, currentPoint, nextPoint);
 
                     if (turnLeft) {
                         nextLeft = joinNormal;
@@ -326,6 +312,28 @@ function normalize (v) {
 
 function length (v) {
     return Math.hypot(v[0], v[1]);
+}
+
+/**
+ * Adjust join normal to avoid spurious spkies
+ */
+function adjustJoinNormal (joinNormal, prevPoint, currentPoint, nextPoint) {
+    // Spike avoidance: joinNormal can produce points farther away than the geometry segments.
+    // FIXME
+    // This solution is fundamentally flawed: joinNormal dimensions are based on unit vectors,
+    // with no relation to the segment geometry.
+    // This could be performed properly in the vertex shader, if we pass segment information
+    // (prev and/or next vertices) with each vertex.
+    const MAGIC = 10;
+    const joinLength = length(joinNormal);
+    const segmentLength = MAGIC * Math.min(
+        length(vector(prevPoint, currentPoint)),
+        length(vector(currentPoint, nextPoint))
+    );
+    if (joinLength > segmentLength) {
+        joinNormal = [joinNormal[0] * segmentLength / joinLength, joinNormal[1] * segmentLength / joinLength];
+    }
+    return joinNormal;
 }
 
 export default { decodeGeom };

--- a/src/renderer/decoder.js
+++ b/src/renderer/decoder.js
@@ -174,7 +174,7 @@ function addLine (lineString, vertices, normals) {
                 // `turnLeft` indicates that the nextLine turns to the left
                 // `joinNormal` contains the direction and size for the `miter` vertex
                 //  `miter` indicates that the join must be `miter`, not `bevel`.
-                let {turnLeft, joinNormal, miter } = getJoinNormal(prevNormal, nextNormal);
+                let { turnLeft, joinNormal, miter } = getJoinNormal(prevNormal, nextNormal);
 
                 if (!joinNormal) {
                     // No join
@@ -189,7 +189,6 @@ function addLine (lineString, vertices, normals) {
                         nextLeft = currentLeft = neg(joinNormal);
                         nextRight = currentRight = joinNormal;
                     }
-
                 } else {
                     // Bevel join: adjust vertices and produce bevel triangle
 
@@ -200,12 +199,12 @@ function addLine (lineString, vertices, normals) {
                     // (prev and/or next vertices) with each vertex.
                     const MAGIC = 10;
                     const joinLength = length(joinNormal);
-                    const segmentLength = MAGIC*Math.min(
+                    const segmentLength = MAGIC * Math.min(
                         length(vector(prevPoint, currentPoint)),
                         length(vector(currentPoint, nextPoint))
                     );
                     if (joinLength > segmentLength) {
-                        joinNormal = [joinNormal[0]*segmentLength/joinLength, joinNormal[1]*segmentLength/joinLength];
+                        joinNormal = [joinNormal[0] * segmentLength / joinLength, joinNormal[1] * segmentLength / joinLength];
                     }
 
                     if (turnLeft) {
@@ -226,7 +225,7 @@ function addLine (lineString, vertices, normals) {
                         [joinNormal,
                             turnLeft ? neg(prevNormal) : nextNormal,
                             turnLeft ? neg(nextNormal) : prevNormal
-                            ]
+                        ]
                     );
                 }
             }
@@ -276,7 +275,7 @@ function addLine (lineString, vertices, normals) {
  */
 function getLineNormal (a, b) {
     const u = normalize(vector(a, b));
-    return [-u[1], u[0]]
+    return [-u[1], u[0]];
 }
 
 /**

--- a/src/renderer/decoder.js
+++ b/src/renderer/decoder.js
@@ -132,11 +132,6 @@ function decodeLine (geometry) {
     };
 }
 
-const NOJOIN = false;
-const MITERJOIN = false;
-const BEVELJOIN = false;
-
-
 /**
  * Create a triangulated lineString: zero-sized, vertex-shader expanded triangle list
  * with `miter` joins. For angle < 60 joins are automatically adjusted to `bevel`.
@@ -181,13 +176,11 @@ function addLine (lineString, vertices, normals) {
                 //  `miter` indicates that the join must be `miter`, not `bevel`.
                 let {turnLeft, joinNormal, miter } = getJoinNormal(prevNormal, nextNormal);
 
-                if (NOJOIN || !joinNormal) {
+                if (!joinNormal) {
+                    // No join
                     nextLeft = nextNormal;
                     nextRight = neg(nextNormal);
-                }
-                else {
-
-                if (MITERJOIN || (miter && !BEVELJOIN)) {
+                } else if (miter) {
                     // Miter join: adjust left/right vertices
                     if (turnLeft) {
                         nextLeft = currentLeft = joinNormal;
@@ -231,8 +224,6 @@ function addLine (lineString, vertices, normals) {
                             ]
                     );
                 }
-
-                }; // NOJOIN
             }
 
             // Segment from prevPoint to currentPoint triangles
@@ -301,7 +292,7 @@ function getJoinNormal (prevNormal, nextNormal) {
         turnLeft: sin > 0,
         miter: miterJoin,
         joinNormal: (factor !== 0) && [
-            (u[0] + v[0]) / factor, // TODO sin => join not always inner but R
+            (u[0] + v[0]) / factor,
             (u[1] + v[1]) / factor
         ]
     };

--- a/src/renderer/decoder.js
+++ b/src/renderer/decoder.js
@@ -173,7 +173,7 @@ function addLine (lineString, vertices, normals) {
                 //  If this is not defined means that the join must be `bevel`.
                 let {turnLeft, joinNormal, miter } = getJoinNormal(prevNormal, nextLNormal);
 
-                if (NOJOIN) {
+                if (NOJOIN || !joinNormal) {
                     nextPLNormal = nextLNormal;
                     nextPRNormal = nextRNormal;
                 }
@@ -288,7 +288,7 @@ function getJoinNormal (prevNormal, nextNormal) {
     return {
         turnLeft: sin > 0,
         miter: miterJoin,
-        joinNormal: [
+        joinNormal: (factor !== 0) && [
             (u[0] + v[0]) / factor, // TODO sin => join not always inner but R
             (u[1] + v[1]) / factor
         ]

--- a/src/renderer/decoder.js
+++ b/src/renderer/decoder.js
@@ -204,11 +204,11 @@ function addLine (lineString, vertices, normals) {
                         nextPLNormal = joinNormal;
                         nextPRNormal = nextRNormal
                         currentLNormal = joinNormal;
-                        currentRNormal = prevRNormal;
+                        currentRNormal = neg(prevNormal);
                     } else {
                         nextPRNormal = joinNormal;
                         nextPLNormal = nextLNormal;
-                        currentLNormal = prevLNormal;
+                        currentLNormal = prevNormal;
                         currentRNormal = joinNormal;
                     }
 

--- a/src/renderer/decoder.js
+++ b/src/renderer/decoder.js
@@ -191,12 +191,13 @@ function addLine (lineString, vertices, normals) {
 
                 } else {
                     // bevel
-                    const l = Math.hypot(joinNormal[0], joinNormal[1]);
-                    const prevL = Math.hypot(currentPoint[0]-prevPoint[0], currentPoint[1]-prevPoint[1]);
-                    const nextL = Math.hypot(nextPoint[0]-currentPoint[0], nextPoint[1]-currentPoint[1]);
-                    const ll = Math.min(prevL, nextL);
-                    if (l > ll) {
-                        joinNormal = [joinNormal[0]*ll/l, joinNormal[1]*ll/l];
+                    const joinLength = length(joinormal);
+                    const segmentLength = Math.min(
+                        length(vector(prevPoint, currentPoint)),
+                        length(vector(currentPoint, nextPoint))
+                    );
+                    if (joinLength > segmentLength) {
+                        joinNormal = [joinNormal[0]*segmentLength/joinLength, joinNormal[1]*segmentLength/joinLength];
                     }
 
                     if (turnLeft) {
@@ -313,8 +314,12 @@ function vector (p1, p2) {
  * Return the vector scaled to length 1
  */
 function normalize (v) {
-    const s = Math.sqrt(v[0] * v[0] + v[1] * v[1]);
+    const s = length(v);
     return [v[0] / s, v[1] / s];
+}
+
+function length (v) {
+    return Math.hypot(v[0], v[1]);
 }
 
 export default { decodeGeom };

--- a/src/renderer/decoder.js
+++ b/src/renderer/decoder.js
@@ -222,12 +222,11 @@ function addLine (lineString, vertices, normals) {
                     // Bevel triangle
                     addTriangle(
                         [currentPoint, currentPoint, currentPoint],
-                        [[0,0],
+                        [[0, 0],
                             turnLeft ? neg(prevNormal) : nextNormal,
                             turnLeft ? neg(nextNormal) : prevNormal
                         ]
                     );
-
                 }
             }
 

--- a/src/renderer/decoder.js
+++ b/src/renderer/decoder.js
@@ -191,7 +191,7 @@ function addLine (lineString, vertices, normals) {
 
                 } else {
                     // bevel
-                    const joinLength = length(joinormal);
+                    const joinLength = length(joinNormal);
                     const segmentLength = Math.min(
                         length(vector(prevPoint, currentPoint)),
                         length(vector(currentPoint, nextPoint))

--- a/src/renderer/decoder.js
+++ b/src/renderer/decoder.js
@@ -192,14 +192,19 @@ function addLine (lineString, vertices, normals) {
 
                 } else {
                     // Bevel join: adjust vertices and produce bevel triangle
+
+                    // Spike avoidance: joinNormal can produce points farther away than the geometry segments
+                    // This if fundamentally flawed: joinNormal dimensions are based on unit vectors, with no
+                    // relation to the segment geometry.
+                    // This could be performed properly in the vertex shader, if we pass segment information
+                    // (prev and/or next vertices) with each vertex.
+                    const MAGIC = 10;
                     const joinLength = length(joinNormal);
-                    const segmentLength = Math.min(
+                    const segmentLength = MAGIC*Math.min(
                         length(vector(prevPoint, currentPoint)),
                         length(vector(currentPoint, nextPoint))
                     );
-
                     if (joinLength > segmentLength) {
-                        // This is a coarse adjustment for problematic large join normals
                         joinNormal = [joinNormal[0]*segmentLength/joinLength, joinNormal[1]*segmentLength/joinLength];
                     }
 

--- a/src/renderer/decoder.js
+++ b/src/renderer/decoder.js
@@ -329,15 +329,14 @@ function length (v) {
 }
 
 /**
- * Adjust join normal to avoid spurious spkies
+ * Check if join normal can led to spikes
  */
 function checkJoinNormal (joinNormal, prevPoint, currentPoint, nextPoint) {
     // Spike avoidance: joinNormal can produce points farther away than the geometry segments.
     // FIXME
     // This solution is fundamentally flawed: joinNormal dimensions are based on unit vectors,
     // with no relation to the segment geometry.
-    // This could be performed properly in the vertex shader, if we pass segment information
-    // (prev and/or next vertices) with each vertex.
+    // Only in the vertex shader have the actual geometry and can avoid these artifacts.
     const MAGIC = 10;
     const joinLength = length(joinNormal);
     const segmentLength = MAGIC * Math.min(

--- a/src/renderer/decoder.js
+++ b/src/renderer/decoder.js
@@ -274,7 +274,7 @@ function getLineNormal (a, b) {
 /**
  * Compute the normal of the join from the lines' normals.
  * By definition this is the sum of the unitary vectors `u` (from B to A) and `v` (from B to C)
- * multiplied by a factor of `1/sin(theta)` to reach the intersecction of the wide lines.
+ * multiplied by a factor of `1/sin(theta)` to reach the intersection of the wide lines.
  * Theta is the angle between the vectors `v` and `u`. But instead of computing the angle,
  * the `sin(theta)` (with sign) is obtained directly from the vectorial product of `v` and `u`
  */
@@ -283,13 +283,12 @@ function getJoinNormal (prevNormal, nextNormal) {
     const v = [nextNormal[1], -nextNormal[0]];
     const sin = v[0] * u[1] - v[1] * u[0];
     const cos = v[0] * u[0] + v[1] * u[1];
-    // const sin = v[1] * u[0] - v[0] * u[1];
     const factor = Math.abs(sin);
     const miterJoin = !(factor < 0.866 && cos > 0.5); // 60 deg
     return {
         turnLeft: sin > 0,
         miter: miterJoin,
-        joinNormal: [ // TODO: factor === 0 case (long miter)
+        joinNormal: [
             (u[0] + v[0]) / factor, // TODO sin => join not always inner but R
             (u[1] + v[1]) / factor
         ]


### PR DESCRIPTION
This adjusts the condition for using miter (which wasn't used for angles close to 180), and eliminates a couple of triangles in the miter case (as was done before). It also supresses some overlapping in bevel joins, using a larger triangle. This latter triangle can introduce spikes again, and to alleviate that problem the length of the join normals is limited to the length of the connecting segments.

So, this should be almost as efficient as the original code (only an additional triangle for bevels), but it's not perfect and the problems when line width is larger than the lengths are still there.

There's also another problem: I've added a myriad of variables that make the code confusing. (We should give a try at refactoring)