### PR TITLE
Decode optimization

### DIFF
--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -1,6 +1,5 @@
 import shaders from './shaders';
 import { Asc, Desc } from './viz/expressions';
-import { getFloat32ArrayFromArray } from '../utils/util';
 
 const INITIAL_TIMESTAMP = Date.now();
 
@@ -70,12 +69,12 @@ export default class Renderer {
         // Use a "big" triangle instead of a square for performance and simplicity
         this.bigTriangleVBO = gl.createBuffer();
         gl.bindBuffer(gl.ARRAY_BUFFER, this.bigTriangleVBO);
-        const vertices = [
+        const vertices = new Float32Array([
             10.0, -10.0,
             0.0, 10.0,
             -10.0, -10.0
-        ];
-        gl.bufferData(gl.ARRAY_BUFFER, getFloat32ArrayFromArray(vertices), gl.STATIC_DRAW);
+        ]);
+        gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
 
         // Create a 1x1 RGBA texture set to [0,0,0,0]
         // Needed because sometimes we don't really use some textures within the shader, but they are declared anyway.

--- a/src/renderer/decoder/common.js
+++ b/src/renderer/decoder/common.js
@@ -4,7 +4,7 @@ import { getJoinNormal, getLineNormal, neg } from '../../utils/geometry';
  * Create a triangulated lineString: zero-sized, vertex-shader expanded triangle list
  * with `miter` joins. For angle < 60 joins are automatically adjusted to `bevel`.
  */
-export function addLine (lineString, vertices, normals, index, isPolygon, skipCallback) {
+export function addLineString (lineString, geomBuffer, isPolygon, skipCallback) {
     let prevPoint, currentPoint, nextPoint;
     let prevNormal, nextNormal;
     let drawLine;
@@ -21,34 +21,34 @@ export function addLine (lineString, vertices, normals, index, isPolygon, skipCa
 
             if (drawLine) {
                 // First triangle
-                vertices[index] = prevPoint[0];
-                normals[index++] = -prevNormal[0];
-                vertices[index] = prevPoint[1];
-                normals[index++] = -prevNormal[1];
-                vertices[index] = prevPoint[0];
-                normals[index++] = prevNormal[0];
-                vertices[index] = prevPoint[1];
-                normals[index++] = prevNormal[1];
-                vertices[index] = currentPoint[0];
-                normals[index++] = prevNormal[0];
-                vertices[index] = currentPoint[1];
-                normals[index++] = prevNormal[1];
+                geomBuffer.vertices[geomBuffer.index] = prevPoint[0];
+                geomBuffer.normals[geomBuffer.index++] = -prevNormal[0];
+                geomBuffer.vertices[geomBuffer.index] = prevPoint[1];
+                geomBuffer.normals[geomBuffer.index++] = -prevNormal[1];
+                geomBuffer.vertices[geomBuffer.index] = prevPoint[0];
+                geomBuffer.normals[geomBuffer.index++] = prevNormal[0];
+                geomBuffer.vertices[geomBuffer.index] = prevPoint[1];
+                geomBuffer.normals[geomBuffer.index++] = prevNormal[1];
+                geomBuffer.vertices[geomBuffer.index] = currentPoint[0];
+                geomBuffer.normals[geomBuffer.index++] = prevNormal[0];
+                geomBuffer.vertices[geomBuffer.index] = currentPoint[1];
+                geomBuffer.normals[geomBuffer.index++] = prevNormal[1];
 
                 // Second triangle
-                vertices[index] = prevPoint[0];
-                normals[index++] = -prevNormal[0];
-                vertices[index] = prevPoint[1];
-                normals[index++] = -prevNormal[1];
-                vertices[index] = currentPoint[0];
-                normals[index++] = prevNormal[0];
-                vertices[index] = currentPoint[1];
-                normals[index++] = prevNormal[1];
-                vertices[index] = currentPoint[0];
-                normals[index++] = -prevNormal[0];
-                vertices[index] = currentPoint[1];
-                normals[index++] = -prevNormal[1];
+                geomBuffer.vertices[geomBuffer.index] = prevPoint[0];
+                geomBuffer.normals[geomBuffer.index++] = -prevNormal[0];
+                geomBuffer.vertices[geomBuffer.index] = prevPoint[1];
+                geomBuffer.normals[geomBuffer.index++] = -prevNormal[1];
+                geomBuffer.vertices[geomBuffer.index] = currentPoint[0];
+                geomBuffer.normals[geomBuffer.index++] = prevNormal[0];
+                geomBuffer.vertices[geomBuffer.index] = currentPoint[1];
+                geomBuffer.normals[geomBuffer.index++] = prevNormal[1];
+                geomBuffer.vertices[geomBuffer.index] = currentPoint[0];
+                geomBuffer.normals[geomBuffer.index++] = -prevNormal[0];
+                geomBuffer.vertices[geomBuffer.index] = currentPoint[1];
+                geomBuffer.normals[geomBuffer.index++] = -prevNormal[1];
 
-                // vertices.push(
+                // geomBuffer.vertices.push(
                 //     prevPoint[0], prevPoint[1],
                 //     prevPoint[0], prevPoint[1],
                 //     currentPoint[0], currentPoint[1],
@@ -56,7 +56,7 @@ export function addLine (lineString, vertices, normals, index, isPolygon, skipCa
                 //     currentPoint[0], currentPoint[1],
                 //     currentPoint[0], currentPoint[1]
                 // );
-                // normals.push(
+                // geomBuffer.normals.push(
                 //     -prevNormal[0], -prevNormal[1],
                 //     prevNormal[0], prevNormal[1],
                 //     prevNormal[0], prevNormal[1],
@@ -86,25 +86,25 @@ export function addLine (lineString, vertices, normals, index, isPolygon, skipCa
                     let rightNormal = turnLeft ? nextNormal : neg(prevNormal);
 
                     // Third triangle
-                    vertices[index] = currentPoint[0];
-                    normals[index++] = 0;
-                    vertices[index] = currentPoint[1];
-                    normals[index++] = isPolygon ? 1e-37 : 0;
-                    vertices[index] = currentPoint[0];
-                    normals[index++] = leftNormal[0];
-                    vertices[index] = currentPoint[1];
-                    normals[index++] = leftNormal[1];
-                    vertices[index] = currentPoint[0];
-                    normals[index++] = rightNormal[0];
-                    vertices[index] = currentPoint[1];
-                    normals[index++] = rightNormal[1];
+                    geomBuffer.vertices[geomBuffer.index] = currentPoint[0];
+                    geomBuffer.normals[geomBuffer.index++] = 0;
+                    geomBuffer.vertices[geomBuffer.index] = currentPoint[1];
+                    geomBuffer.normals[geomBuffer.index++] = isPolygon ? 1e-37 : 0;
+                    geomBuffer.vertices[geomBuffer.index] = currentPoint[0];
+                    geomBuffer.normals[geomBuffer.index++] = leftNormal[0];
+                    geomBuffer.vertices[geomBuffer.index] = currentPoint[1];
+                    geomBuffer.normals[geomBuffer.index++] = leftNormal[1];
+                    geomBuffer.vertices[geomBuffer.index] = currentPoint[0];
+                    geomBuffer.normals[geomBuffer.index++] = rightNormal[0];
+                    geomBuffer.vertices[geomBuffer.index] = currentPoint[1];
+                    geomBuffer.normals[geomBuffer.index++] = rightNormal[1];
 
-                    // vertices.push(
+                    // geomBuffer.vertices.push(
                     //     currentPoint[0], currentPoint[1],
                     //     currentPoint[0], currentPoint[1],
                     //     currentPoint[0], currentPoint[1]
                     // );
-                    // normals.push(
+                    // geomBuffer.normals.push(
                     //     // Mark vertex to be stroke in PolygonShader with the
                     //     // non-zero value 1e-37, so it validates the expression
                     //     // `normal != vec2(0.)` without affecting the vertex position.
@@ -115,25 +115,25 @@ export function addLine (lineString, vertices, normals, index, isPolygon, skipCa
 
                     if (joinNormal) {
                         // Forth triangle
-                        vertices[index] = currentPoint[0];
-                        normals[index++] = joinNormal[0];
-                        vertices[index] = currentPoint[1];
-                        normals[index++] = joinNormal[1];
-                        vertices[index] = currentPoint[0];
-                        normals[index++] = rightNormal[0];
-                        vertices[index] = currentPoint[1];
-                        normals[index++] = rightNormal[1];
-                        vertices[index] = currentPoint[0];
-                        normals[index++] = leftNormal[0];
-                        vertices[index] = currentPoint[1];
-                        normals[index++] = leftNormal[1];
+                        geomBuffer.vertices[geomBuffer.index] = currentPoint[0];
+                        geomBuffer.normals[geomBuffer.index++] = joinNormal[0];
+                        geomBuffer.vertices[geomBuffer.index] = currentPoint[1];
+                        geomBuffer.normals[geomBuffer.index++] = joinNormal[1];
+                        geomBuffer.vertices[geomBuffer.index] = currentPoint[0];
+                        geomBuffer.normals[geomBuffer.index++] = rightNormal[0];
+                        geomBuffer.vertices[geomBuffer.index] = currentPoint[1];
+                        geomBuffer.normals[geomBuffer.index++] = rightNormal[1];
+                        geomBuffer.vertices[geomBuffer.index] = currentPoint[0];
+                        geomBuffer.normals[geomBuffer.index++] = leftNormal[0];
+                        geomBuffer.vertices[geomBuffer.index] = currentPoint[1];
+                        geomBuffer.normals[geomBuffer.index++] = leftNormal[1];
 
-                        // vertices.push(
+                        // geomBuffer.vertices.push(
                         //     currentPoint[0], currentPoint[1],
                         //     currentPoint[0], currentPoint[1],
                         //     currentPoint[0], currentPoint[1]
                         // );
-                        // normals.push(
+                        // geomBuffer.normals.push(
                         //     joinNormal[0], joinNormal[1],
                         //     rightNormal[0], rightNormal[1],
                         //     leftNormal[0], leftNormal[1]
@@ -149,6 +149,4 @@ export function addLine (lineString, vertices, normals, index, isPolygon, skipCa
             nextPoint = null;
         }
     }
-
-    return index;
 }

--- a/src/renderer/decoder/common.js
+++ b/src/renderer/decoder/common.js
@@ -47,23 +47,6 @@ export function addLineString (lineString, geomBuffer, isPolygon, skipCallback) 
                 geomBuffer.normals[geomBuffer.index++] = -prevNormal[0];
                 geomBuffer.vertices[geomBuffer.index] = currentPoint[1];
                 geomBuffer.normals[geomBuffer.index++] = -prevNormal[1];
-
-                // geomBuffer.vertices.push(
-                //     prevPoint[0], prevPoint[1],
-                //     prevPoint[0], prevPoint[1],
-                //     currentPoint[0], currentPoint[1],
-                //     prevPoint[0], prevPoint[1],
-                //     currentPoint[0], currentPoint[1],
-                //     currentPoint[0], currentPoint[1]
-                // );
-                // geomBuffer.normals.push(
-                //     -prevNormal[0], -prevNormal[1],
-                //     prevNormal[0], prevNormal[1],
-                //     prevNormal[0], prevNormal[1],
-                //     -prevNormal[0], -prevNormal[1],
-                //     prevNormal[0], prevNormal[1],
-                //     -prevNormal[0], -prevNormal[1]
-                // );
             }
 
             // If there is a next point, compute its properties
@@ -89,6 +72,9 @@ export function addLineString (lineString, geomBuffer, isPolygon, skipCallback) 
                     geomBuffer.vertices[geomBuffer.index] = currentPoint[0];
                     geomBuffer.normals[geomBuffer.index++] = 0;
                     geomBuffer.vertices[geomBuffer.index] = currentPoint[1];
+                    // Mark vertex to be stroke in PolygonShader with the
+                    // non-zero value 1e-37, so it validates the expression
+                    // `normal != vec2(0.)` without affecting the vertex position.
                     geomBuffer.normals[geomBuffer.index++] = isPolygon ? 1e-37 : 0;
                     geomBuffer.vertices[geomBuffer.index] = currentPoint[0];
                     geomBuffer.normals[geomBuffer.index++] = leftNormal[0];
@@ -98,20 +84,6 @@ export function addLineString (lineString, geomBuffer, isPolygon, skipCallback) 
                     geomBuffer.normals[geomBuffer.index++] = rightNormal[0];
                     geomBuffer.vertices[geomBuffer.index] = currentPoint[1];
                     geomBuffer.normals[geomBuffer.index++] = rightNormal[1];
-
-                    // geomBuffer.vertices.push(
-                    //     currentPoint[0], currentPoint[1],
-                    //     currentPoint[0], currentPoint[1],
-                    //     currentPoint[0], currentPoint[1]
-                    // );
-                    // geomBuffer.normals.push(
-                    //     // Mark vertex to be stroke in PolygonShader with the
-                    //     // non-zero value 1e-37, so it validates the expression
-                    //     // `normal != vec2(0.)` without affecting the vertex position.
-                    //     0, isPolygon ? 1e-37 : 0,
-                    //     leftNormal[0], leftNormal[1],
-                    //     rightNormal[0], rightNormal[1]
-                    // );
 
                     if (joinNormal) {
                         // Forth triangle
@@ -127,17 +99,6 @@ export function addLineString (lineString, geomBuffer, isPolygon, skipCallback) 
                         geomBuffer.normals[geomBuffer.index++] = leftNormal[0];
                         geomBuffer.vertices[geomBuffer.index] = currentPoint[1];
                         geomBuffer.normals[geomBuffer.index++] = leftNormal[1];
-
-                        // geomBuffer.vertices.push(
-                        //     currentPoint[0], currentPoint[1],
-                        //     currentPoint[0], currentPoint[1],
-                        //     currentPoint[0], currentPoint[1]
-                        // );
-                        // geomBuffer.normals.push(
-                        //     joinNormal[0], joinNormal[1],
-                        //     rightNormal[0], rightNormal[1],
-                        //     leftNormal[0], leftNormal[1]
-                        // );
                     }
                 }
             }

--- a/src/renderer/decoder/common.js
+++ b/src/renderer/decoder/common.js
@@ -4,74 +4,144 @@ import { getJoinNormal, getLineNormal, neg } from '../../utils/geometry';
  * Create a triangulated lineString: zero-sized, vertex-shader expanded triangle list
  * with `miter` joins. For angle < 60 joins are automatically adjusted to `bevel`.
  */
-export function addLine (lineString, vertices, normals, isPolygon, skipCallback) {
+export function addLine (lineString, vertices, normals, index, isPolygon, skipCallback) {
     let prevPoint, currentPoint, nextPoint;
     let prevNormal, nextNormal;
     let drawLine;
-    
+
     // We need at least two points
     if (lineString.length >= 4) {
         // Initialize the first two points
         prevPoint = [lineString[0], lineString[1]];
         currentPoint = [lineString[2], lineString[3]];
         prevNormal = getLineNormal(prevPoint, currentPoint);
-    
+
         for (let i = 4; i <= lineString.length; i += 2) {
             drawLine = !(skipCallback && skipCallback(i));
-    
+
             if (drawLine) {
                 // First triangle
-                addTriangle(
-                    [prevPoint, prevPoint, currentPoint],
-                    [neg(prevNormal), prevNormal, prevNormal]
-                );
-                
+                vertices[index] = prevPoint[0];
+                normals[index++] = -prevNormal[0];
+                vertices[index] = prevPoint[1];
+                normals[index++] = -prevNormal[1];
+                vertices[index] = prevPoint[0];
+                normals[index++] = prevNormal[0];
+                vertices[index] = prevPoint[1];
+                normals[index++] = prevNormal[1];
+                vertices[index] = currentPoint[0];
+                normals[index++] = prevNormal[0];
+                vertices[index] = currentPoint[1];
+                normals[index++] = prevNormal[1];
+
                 // Second triangle
-                addTriangle(
-                    [prevPoint, currentPoint, currentPoint],
-                    [neg(prevNormal), prevNormal, neg(prevNormal)]
-                );
+                vertices[index] = prevPoint[0];
+                normals[index++] = -prevNormal[0];
+                vertices[index] = prevPoint[1];
+                normals[index++] = -prevNormal[1];
+                vertices[index] = currentPoint[0];
+                normals[index++] = prevNormal[0];
+                vertices[index] = currentPoint[1];
+                normals[index++] = prevNormal[1];
+                vertices[index] = currentPoint[0];
+                normals[index++] = -prevNormal[0];
+                vertices[index] = currentPoint[1];
+                normals[index++] = -prevNormal[1];
+
+                // vertices.push(
+                //     prevPoint[0], prevPoint[1],
+                //     prevPoint[0], prevPoint[1],
+                //     currentPoint[0], currentPoint[1],
+                //     prevPoint[0], prevPoint[1],
+                //     currentPoint[0], currentPoint[1],
+                //     currentPoint[0], currentPoint[1]
+                // );
+                // normals.push(
+                //     -prevNormal[0], -prevNormal[1],
+                //     prevNormal[0], prevNormal[1],
+                //     prevNormal[0], prevNormal[1],
+                //     -prevNormal[0], -prevNormal[1],
+                //     prevNormal[0], prevNormal[1],
+                //     -prevNormal[0], -prevNormal[1]
+                // );
             }
-    
+
             // If there is a next point, compute its properties
             if (i <= lineString.length - 2) {
                 nextPoint = [lineString[i], lineString[i + 1]];
             } else if (isPolygon) {
                 nextPoint = [lineString[2], lineString[3]];
             }
-    
+
             if (nextPoint) {
                 nextNormal = getLineNormal(currentPoint, nextPoint);
-        
+
                 if (drawLine) {
                     // `turnLeft` indicates that the nextLine turns to the left
                     // `joinNormal` contains the direction and size for the `miter` vertex
                     //  If this is not defined means that the join must be `bevel`.
                     let {turnLeft, joinNormal} = getJoinNormal(prevNormal, nextNormal);
-                    
+
+                    let leftNormal = turnLeft ? prevNormal : neg(nextNormal);
+                    let rightNormal = turnLeft ? nextNormal : neg(prevNormal);
+
                     // Third triangle
-                    addTriangle(
-                        [currentPoint, currentPoint, currentPoint],
-                        // Mark vertex to be stroke in PolygonShader with the
-                        // non-zero value 1e-37, so it validates the expression
-                        // `normal != vec2(0.)` without affecting the vertex position.
-                        [[0, isPolygon ? 1e-37 : 0],
-                            turnLeft ? prevNormal : neg(nextNormal),
-                            turnLeft ? nextNormal : neg(prevNormal)]
-                    );
-                    
+                    vertices[index] = currentPoint[0];
+                    normals[index++] = 0;
+                    vertices[index] = currentPoint[1];
+                    normals[index++] = isPolygon ? 1e-37 : 0;
+                    vertices[index] = currentPoint[0];
+                    normals[index++] = leftNormal[0];
+                    vertices[index] = currentPoint[1];
+                    normals[index++] = leftNormal[1];
+                    vertices[index] = currentPoint[0];
+                    normals[index++] = rightNormal[0];
+                    vertices[index] = currentPoint[1];
+                    normals[index++] = rightNormal[1];
+
+                    // vertices.push(
+                    //     currentPoint[0], currentPoint[1],
+                    //     currentPoint[0], currentPoint[1],
+                    //     currentPoint[0], currentPoint[1]
+                    // );
+                    // normals.push(
+                    //     // Mark vertex to be stroke in PolygonShader with the
+                    //     // non-zero value 1e-37, so it validates the expression
+                    //     // `normal != vec2(0.)` without affecting the vertex position.
+                    //     0, isPolygon ? 1e-37 : 0,
+                    //     leftNormal[0], leftNormal[1],
+                    //     rightNormal[0], rightNormal[1]
+                    // );
+
                     if (joinNormal) {
                         // Forth triangle
-                        drawLine && addTriangle(
-                            [currentPoint, currentPoint, currentPoint],
-                            [joinNormal,
-                                turnLeft ? nextNormal : neg(prevNormal),
-                                turnLeft ? prevNormal : neg(nextNormal)]
-                        );
+                        vertices[index] = currentPoint[0];
+                        normals[index++] = joinNormal[0];
+                        vertices[index] = currentPoint[1];
+                        normals[index++] = joinNormal[1];
+                        vertices[index] = currentPoint[0];
+                        normals[index++] = rightNormal[0];
+                        vertices[index] = currentPoint[1];
+                        normals[index++] = rightNormal[1];
+                        vertices[index] = currentPoint[0];
+                        normals[index++] = leftNormal[0];
+                        vertices[index] = currentPoint[1];
+                        normals[index++] = leftNormal[1];
+
+                        // vertices.push(
+                        //     currentPoint[0], currentPoint[1],
+                        //     currentPoint[0], currentPoint[1],
+                        //     currentPoint[0], currentPoint[1]
+                        // );
+                        // normals.push(
+                        //     joinNormal[0], joinNormal[1],
+                        //     rightNormal[0], rightNormal[1],
+                        //     leftNormal[0], leftNormal[1]
+                        // );
                     }
                 }
             }
-    
+
             // Update the variables for the next iteration
             prevPoint = currentPoint;
             currentPoint = nextPoint;
@@ -79,17 +149,6 @@ export function addLine (lineString, vertices, normals, isPolygon, skipCallback)
             nextPoint = null;
         }
     }
-    
-    function addTriangle (p, n) {
-        vertices.push(
-            p[0][0], p[0][1],
-            p[1][0], p[1][1],
-            p[2][0], p[2][1]
-        );
-        normals.push(
-            n[0][0], n[0][1],
-            n[1][0], n[1][1],
-            n[2][0], n[2][1]
-        );
-    }
+
+    return index;
 }

--- a/src/renderer/decoder/common.js
+++ b/src/renderer/decoder/common.js
@@ -7,66 +7,71 @@ import { getJoinNormal, getLineNormal, neg } from '../../utils/geometry';
 export function addLine (lineString, vertices, normals, isPolygon, skipCallback) {
     let prevPoint, currentPoint, nextPoint;
     let prevNormal, nextNormal;
-    let skipLine = false;
-
+    let drawLine;
+    
     // We need at least two points
     if (lineString.length >= 4) {
         // Initialize the first two points
         prevPoint = [lineString[0], lineString[1]];
         currentPoint = [lineString[2], lineString[3]];
         prevNormal = getLineNormal(prevPoint, currentPoint);
-
+    
         for (let i = 4; i <= lineString.length; i += 2) {
-            skipLine = skipCallback && skipCallback(i);
-
-            // First triangle
-            addTriangle(
-                [prevPoint, prevPoint, currentPoint],
-                [neg(prevNormal), prevNormal, prevNormal]
-            );
-
-            // Second triangle
-            addTriangle(
-                [prevPoint, currentPoint, currentPoint],
-                [neg(prevNormal), prevNormal, neg(prevNormal)]
-            );
-
+            drawLine = !(skipCallback && skipCallback(i));
+    
+            if (drawLine) {
+                // First triangle
+                addTriangle(
+                    [prevPoint, prevPoint, currentPoint],
+                    [neg(prevNormal), prevNormal, prevNormal]
+                );
+                
+                // Second triangle
+                addTriangle(
+                    [prevPoint, currentPoint, currentPoint],
+                    [neg(prevNormal), prevNormal, neg(prevNormal)]
+                );
+            }
+    
             // If there is a next point, compute its properties
             if (i <= lineString.length - 2) {
                 nextPoint = [lineString[i], lineString[i + 1]];
             } else if (isPolygon) {
                 nextPoint = [lineString[2], lineString[3]];
             }
-
+    
             if (nextPoint) {
                 nextNormal = getLineNormal(currentPoint, nextPoint);
-                // `turnLeft` indicates that the nextLine turns to the left
-                // `joinNormal` contains the direction and size for the `miter` vertex
-                //  If this is not defined means that the join must be `bevel`.
-                let {turnLeft, joinNormal} = getJoinNormal(prevNormal, nextNormal);
-
-                // Third triangle
-                addTriangle(
-                    [currentPoint, currentPoint, currentPoint],
-                    // Mark vertex to be stroke in PolygonShader with the
-                    // non-zero value 1e-37, so it validates the expression
-                    // `normal != vec2(0.)` without affecting the vertex position.
-                    [[0, isPolygon ? 1e-37 : 0],
-                        turnLeft ? prevNormal : neg(nextNormal),
-                        turnLeft ? nextNormal : neg(prevNormal)]
-                );
-
-                if (joinNormal) {
-                    // Forth triangle
+        
+                if (drawLine) {
+                    // `turnLeft` indicates that the nextLine turns to the left
+                    // `joinNormal` contains the direction and size for the `miter` vertex
+                    //  If this is not defined means that the join must be `bevel`.
+                    let {turnLeft, joinNormal} = getJoinNormal(prevNormal, nextNormal);
+                    
+                    // Third triangle
                     addTriangle(
                         [currentPoint, currentPoint, currentPoint],
-                        [joinNormal,
-                            turnLeft ? nextNormal : neg(prevNormal),
-                            turnLeft ? prevNormal : neg(nextNormal)]
+                        // Mark vertex to be stroke in PolygonShader with the
+                        // non-zero value 1e-37, so it validates the expression
+                        // `normal != vec2(0.)` without affecting the vertex position.
+                        [[0, isPolygon ? 1e-37 : 0],
+                            turnLeft ? prevNormal : neg(nextNormal),
+                            turnLeft ? nextNormal : neg(prevNormal)]
                     );
+                    
+                    if (joinNormal) {
+                        // Forth triangle
+                        drawLine && addTriangle(
+                            [currentPoint, currentPoint, currentPoint],
+                            [joinNormal,
+                                turnLeft ? nextNormal : neg(prevNormal),
+                                turnLeft ? prevNormal : neg(nextNormal)]
+                        );
+                    }
                 }
             }
-
+    
             // Update the variables for the next iteration
             prevPoint = currentPoint;
             currentPoint = nextPoint;
@@ -74,19 +79,17 @@ export function addLine (lineString, vertices, normals, isPolygon, skipCallback)
             nextPoint = null;
         }
     }
-
+    
     function addTriangle (p, n) {
-        if (!skipLine) {
-            vertices.push(
-                p[0][0], p[0][1],
-                p[1][0], p[1][1],
-                p[2][0], p[2][1]
-            );
-            normals.push(
-                n[0][0], n[0][1],
-                n[1][0], n[1][1],
-                n[2][0], n[2][1]
-            );
-        }
+        vertices.push(
+            p[0][0], p[0][1],
+            p[1][0], p[1][1],
+            p[2][0], p[2][1]
+        );
+        normals.push(
+            n[0][0], n[0][1],
+            n[1][0], n[1][1],
+            n[2][0], n[2][1]
+        );
     }
 }

--- a/src/renderer/decoder/lineDecoder.js
+++ b/src/renderer/decoder/lineDecoder.js
@@ -1,33 +1,36 @@
-import { addLine } from './common';
+import { addLineString } from './common';
 import { getFloat32ArrayFromArray } from '../../utils/util';
 
 // If the geometry type is 'line' it will generate the appropriate zero-sized, vertex-shader expanded triangle list with `miter` and `bevel` joins.
 // The geom will be an array of coordinates in this case
 
-let vertices = new Array(1000000);
-let normals = new Array(1000000);
+const geomBuffer = {
+    index: 0,
+    vertices: new Array(1000000),
+    normals: new Array(1000000)
+};
 
 export function decodeLine (geometry) {
     let breakpoints = []; // Array of indices (to vertexArray) that separate each feature
     let featureIDToVertexIndex = new Map();
-    let vertexIndex = 0;
 
+    geomBuffer.index = 0;
     for (let i = 0; i < geometry.length; i++) {
         const feature = geometry[i];
         for (let j = 0; j < feature.length; j++) {
-            vertexIndex = addLine(feature[j], vertices, normals, vertexIndex);
+            addLineString(feature[j], geomBuffer);
         }
 
         featureIDToVertexIndex.set(breakpoints.length, breakpoints.length === 0
-            ? { start: 0, end: vertexIndex }
-            : { start: featureIDToVertexIndex.get(breakpoints.length - 1).end, end: vertexIndex });
+            ? { start: 0, end: geomBuffer.index }
+            : { start: featureIDToVertexIndex.get(breakpoints.length - 1).end, end: geomBuffer.index });
 
-        breakpoints.push(vertexIndex);
+        breakpoints.push(geomBuffer.index);
     }
 
     return {
-        vertices: getFloat32ArrayFromArray(vertices, vertexIndex),
-        normals: getFloat32ArrayFromArray(normals, vertexIndex),
+        vertices: getFloat32ArrayFromArray(geomBuffer.vertices, geomBuffer.index),
+        normals: getFloat32ArrayFromArray(geomBuffer.normals, geomBuffer.index),
         featureIDToVertexIndex,
         breakpoints
     };

--- a/src/renderer/decoder/lineDecoder.js
+++ b/src/renderer/decoder/lineDecoder.js
@@ -4,28 +4,30 @@ import { getFloat32ArrayFromArray } from '../../utils/util';
 // If the geometry type is 'line' it will generate the appropriate zero-sized, vertex-shader expanded triangle list with `miter` and `bevel` joins.
 // The geom will be an array of coordinates in this case
 
+let vertices = new Array(1000000);
+let normals = new Array(1000000);
+
 export function decodeLine (geometry) {
-    let vertices = [];
-    let normals = [];
     let breakpoints = []; // Array of indices (to vertexArray) that separate each feature
     let featureIDToVertexIndex = new Map();
+    let vertexIndex = 0;
 
     for (let i = 0; i < geometry.length; i++) {
         const feature = geometry[i];
         for (let j = 0; j < feature.length; j++) {
-            addLine(feature[j], vertices, normals);
+            vertexIndex = addLine(feature[j], vertices, normals, vertexIndex);
         }
 
         featureIDToVertexIndex.set(breakpoints.length, breakpoints.length === 0
-            ? { start: 0, end: vertices.length }
-            : { start: featureIDToVertexIndex.get(breakpoints.length - 1).end, end: vertices.length });
+            ? { start: 0, end: vertexIndex }
+            : { start: featureIDToVertexIndex.get(breakpoints.length - 1).end, end: vertexIndex });
 
-        breakpoints.push(vertices.length);
+        breakpoints.push(vertexIndex);
     }
 
     return {
-        vertices: getFloat32ArrayFromArray(vertices),
-        normals: getFloat32ArrayFromArray(normals),
+        vertices: getFloat32ArrayFromArray(vertices, vertexIndex),
+        normals: getFloat32ArrayFromArray(normals, vertexIndex),
         featureIDToVertexIndex,
         breakpoints
     };

--- a/src/renderer/decoder/lineDecoder.js
+++ b/src/renderer/decoder/lineDecoder.js
@@ -13,8 +13,7 @@ export function decodeLine (geometry) {
     for (let i = 0; i < geometry.length; i++) {
         const feature = geometry[i];
         for (let j = 0; j < feature.length; j++) {
-            const lineString = feature[j];
-            addLine(lineString, vertices, normals);
+            addLine(feature[j], vertices, normals);
         }
 
         featureIDToVertexIndex.set(breakpoints.length, breakpoints.length === 0

--- a/src/renderer/decoder/lineDecoder.js
+++ b/src/renderer/decoder/lineDecoder.js
@@ -1,13 +1,12 @@
 import { addLineString } from './common';
-import { getFloat32ArrayFromArray } from '../../utils/util';
 
 // If the geometry type is 'line' it will generate the appropriate zero-sized, vertex-shader expanded triangle list with `miter` and `bevel` joins.
 // The geom will be an array of coordinates in this case
 
 const geomBuffer = {
     index: 0,
-    vertices: new Array(1000000),
-    normals: new Array(1000000)
+    vertices: new Float32Array(1000000),
+    normals: new Float32Array(1000000)
 };
 
 export function decodeLine (geometry) {
@@ -29,8 +28,8 @@ export function decodeLine (geometry) {
     }
 
     return {
-        vertices: getFloat32ArrayFromArray(geomBuffer.vertices, geomBuffer.index),
-        normals: getFloat32ArrayFromArray(geomBuffer.normals, geomBuffer.index),
+        vertices: new Float32Array(geomBuffer.vertices.slice(0, geomBuffer.index)),
+        normals: new Float32Array(geomBuffer.normals.slice(0, geomBuffer.index)),
         featureIDToVertexIndex,
         breakpoints
     };

--- a/src/renderer/decoder/polygonDecoder.js
+++ b/src/renderer/decoder/polygonDecoder.js
@@ -23,8 +23,8 @@ const geomBuffer = {
 export function decodePolygon (geometry) {
     let breakpoints = []; // Array of indices (to vertexArray) that separate each feature
     let featureIDToVertexIndex = new Map();
-    geomBuffer.index = 0;
 
+    geomBuffer.index = 0;
     for (let i = 0; i < geometry.length; i++) {
         const feature = geometry[i];
         for (let j = 0; j < feature.length; j++) {
@@ -32,8 +32,6 @@ export function decodePolygon (geometry) {
             const triangles = earcut(polygon.flat, polygon.holes);
             for (let k = 0; k < triangles.length; k++) {
                 addVertex(polygon.flat, 2 * triangles[k], geomBuffer);
-                // vertices.push(polygon.flat[2 * index], polygon.flat[2 * index + 1]);
-                // normals.push(0, 0);
             }
 
             addLineString(polygon.flat, geomBuffer, true, (index) => {

--- a/src/renderer/decoder/polygonDecoder.js
+++ b/src/renderer/decoder/polygonDecoder.js
@@ -31,8 +31,7 @@ export function decodePolygon (geometry) {
                 normals.push(0, 0);
             }
 
-            const lineString = polygon.flat;
-            addLine(lineString, vertices, normals, true, (index) => {
+            addLine(polygon.flat, vertices, normals, true, (index) => {
                 // Skip adding the line which connects two rings OR is clipped
                 return polygon.holes.includes((index - 2) / 2) || isClipped(polygon, index - 4, index - 2);
             });

--- a/src/renderer/decoder/polygonDecoder.js
+++ b/src/renderer/decoder/polygonDecoder.js
@@ -1,5 +1,5 @@
 import * as earcut from 'earcut';
-import { addLine } from './common';
+import { addLineString } from './common';
 import { getFloat32ArrayFromArray } from '../../utils/util';
 
 // If the geometry type is 'polygon' it will triangulate the polygon list (geom)
@@ -14,13 +14,16 @@ import { getFloat32ArrayFromArray } from '../../utils/util';
      }]
 */
 
-let vertices = new Array(2000000);
-let normals = new Array(2000000);
+const geomBuffer = {
+    index: 0,
+    vertices: new Array(2000000),
+    normals: new Array(2000000)
+};
 
 export function decodePolygon (geometry) {
     let breakpoints = []; // Array of indices (to vertexArray) that separate each feature
     let featureIDToVertexIndex = new Map();
-    let vertexIndex = 0;
+    geomBuffer.index = 0;
 
     for (let i = 0; i < geometry.length; i++) {
         const feature = geometry[i];
@@ -28,34 +31,37 @@ export function decodePolygon (geometry) {
             const polygon = feature[j];
             const triangles = earcut(polygon.flat, polygon.holes);
             for (let k = 0; k < triangles.length; k++) {
-                const index = triangles[k];
-                vertices[vertexIndex] = polygon.flat[2 * index];
-                normals[vertexIndex++] = 0;
-                vertices[vertexIndex] = polygon.flat[2 * index + 1];
-                normals[vertexIndex++] = 0;
+                addVertex(polygon.flat, 2 * triangles[k], geomBuffer);
                 // vertices.push(polygon.flat[2 * index], polygon.flat[2 * index + 1]);
                 // normals.push(0, 0);
             }
 
-            vertexIndex = addLine(polygon.flat, vertices, normals, vertexIndex, true, (index) => {
+            addLineString(polygon.flat, geomBuffer, true, (index) => {
                 // Skip adding the line which connects two rings OR is clipped
                 return polygon.holes.includes((index - 2) / 2) || isClipped(polygon, index - 4, index - 2);
             });
         }
 
         featureIDToVertexIndex.set(breakpoints.length, breakpoints.length === 0
-            ? { start: 0, end: vertexIndex }
-            : { start: featureIDToVertexIndex.get(breakpoints.length - 1).end, end: vertexIndex });
+            ? { start: 0, end: geomBuffer.index }
+            : { start: featureIDToVertexIndex.get(breakpoints.length - 1).end, end: geomBuffer.index });
 
-        breakpoints.push(vertexIndex);
+        breakpoints.push(geomBuffer.index);
     }
 
     return {
-        vertices: getFloat32ArrayFromArray(vertices, vertexIndex),
-        normals: getFloat32ArrayFromArray(normals, vertexIndex),
+        vertices: getFloat32ArrayFromArray(geomBuffer.vertices, geomBuffer.index),
+        normals: getFloat32ArrayFromArray(geomBuffer.normals, geomBuffer.index),
         featureIDToVertexIndex,
         breakpoints
     };
+}
+
+function addVertex (array, index, geomBuffer) {
+    geomBuffer.vertices[geomBuffer.index] = array[index];
+    geomBuffer.normals[geomBuffer.index++] = 0;
+    geomBuffer.vertices[geomBuffer.index] = array[index + 1];
+    geomBuffer.normals[geomBuffer.index++] = 0;
 }
 
 function isClipped (polygon, i, j) {

--- a/src/renderer/decoder/polygonDecoder.js
+++ b/src/renderer/decoder/polygonDecoder.js
@@ -1,6 +1,5 @@
 import * as earcut from 'earcut';
 import { addLineString } from './common';
-import { getFloat32ArrayFromArray } from '../../utils/util';
 
 // If the geometry type is 'polygon' it will triangulate the polygon list (geom)
 // geom will be a list of polygons in which each polygon will have a flat array of vertices and a list of holes indices
@@ -16,8 +15,8 @@ import { getFloat32ArrayFromArray } from '../../utils/util';
 
 const geomBuffer = {
     index: 0,
-    vertices: new Array(2000000),
-    normals: new Array(2000000)
+    vertices: new Float32Array(2000000),
+    normals: new Float32Array(2000000)
 };
 
 export function decodePolygon (geometry) {
@@ -48,8 +47,8 @@ export function decodePolygon (geometry) {
     }
 
     return {
-        vertices: getFloat32ArrayFromArray(geomBuffer.vertices, geomBuffer.index),
-        normals: getFloat32ArrayFromArray(geomBuffer.normals, geomBuffer.index),
+        vertices: new Float32Array(geomBuffer.vertices.slice(0, geomBuffer.index)),
+        normals: new Float32Array(geomBuffer.normals.slice(0, geomBuffer.index)),
         featureIDToVertexIndex,
         breakpoints
     };

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -33,7 +33,7 @@ export function perpendicular ([x, y]) {
  * By definition it is the unitary vector from B to A, rotated +90 degrees counter-clockwise
  */
 export function getLineNormal (a, b) {
-    const u = normalize(vector(b, a));
+    const u = normalize(a[0] - b[0], a[1] - b[1]);
     return [-u[1], u[0]];
 }
 
@@ -68,18 +68,11 @@ export function neg (v) {
 }
 
 /**
- * Create a vector which goes from p1 to p2
- */
-function vector (p1, p2) {
-    return [p2[0] - p1[0], p2[1] - p1[1]];
-}
-
-/**
  * Return the vector scaled to length 1
  */
-function normalize (v) {
-    const s = Math.hypot(v[0], v[1]);
-    return [v[0] / s, v[1] / s];
+function normalize (v1, v2) {
+    const s = Math.hypot(v1, v2);
+    return [v1 / s, v2 / s];
 }
 
 // Returns true if p is inside the triangle or on a triangle's edge, false otherwise
@@ -140,7 +133,6 @@ export default {
     sub,
     dot,
     perpendicular,
-    normalize,
     getLineNormal,
     getJoinNormal,
     neg,

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -70,9 +70,9 @@ export function neg (v) {
 /**
  * Return the vector scaled to length 1
  */
-function normalize (v1, v2) {
-    const s = Math.hypot(v1, v2);
-    return [v1 / s, v2 / s];
+function normalize (x, y) {
+    const s = Math.hypot(x, y);
+    return [x / s, y / s];
 }
 
 // Returns true if p is inside the triangle or on a triangle's edge, false otherwise

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -32,15 +32,6 @@ export function isObject (value) {
     return value !== null && (type === 'object' || type === 'function');
 }
 
-export function getFloat32ArrayFromArray (array, length) {
-    length = length || array.length;
-    const float32Array = new Float32Array(length);
-    for (let i = 0; i < length; i++) {
-        float32Array[i] = array[i];
-    }
-    return float32Array;
-}
-
 /**
  * Transform the given parameter into a Date object.
  * When a number is given as a parameter is asummed to be a milliseconds epoch.

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -32,8 +32,8 @@ export function isObject (value) {
     return value !== null && (type === 'object' || type === 'function');
 }
 
-export function getFloat32ArrayFromArray (array) {
-    const length = array.length;
+export function getFloat32ArrayFromArray (array, length) {
+    length = length || array.length;
     const float32Array = new Float32Array(length);
     for (let i = 0; i < length; i++) {
         float32Array[i] = array[i];

--- a/test/benchmark/performance/decoder/line.spec.js
+++ b/test/benchmark/performance/decoder/line.spec.js
@@ -16,7 +16,5 @@ const geojson = new GeoJSON({
 const lineGeometry = geojson._decodeGeometry();
 
 falcon.benchmark('decodeLine', () => {
-    for (let i = 0; i < 10000; i++) {
-        decodeGeom('line', lineGeometry);
-    }
-}, {runs: 100});
+    decodeGeom('line', lineGeometry);
+}, {runs: 10000});

--- a/test/benchmark/performance/decoder/point.spec.js
+++ b/test/benchmark/performance/decoder/point.spec.js
@@ -11,7 +11,5 @@ const geojson = new GeoJSON({
 const pointGeometry = geojson._decodeGeometry();
 
 falcon.benchmark('decodePoint', () => {
-    for (let i = 0; i < 10000; i++) {
-        decodeGeom('point', pointGeometry);
-    }
-}, {runs: 100});
+    decodeGeom('point', pointGeometry);
+}, {runs: 10000});

--- a/test/benchmark/performance/decoder/polygon.spec.js
+++ b/test/benchmark/performance/decoder/polygon.spec.js
@@ -18,7 +18,5 @@ const geojson = new GeoJSON({
 const polygonGeometry = geojson._decodeGeometry();
 
 falcon.benchmark('decodePolygon', () => {
-    for (let i = 0; i < 10000; i++) {
-        decodeGeom('polygon', polygonGeometry);
-    }
-}, {runs: 100});
+    decodeGeom('polygon', polygonGeometry);
+}, {runs: 10000});


### PR DESCRIPTION
Related to https://github.com/CartoDB/carto-vl/issues/400, https://github.com/CartoDB/carto-vl/issues/771.

In the `polygon stroke` branch the polygon is properly rendered (bevel and miter joins) but with the current implementation, load time is twice slower compared with master (with the primitive support for strokes).

This PR introduces an optimization for line and polygon stroke decoding to improve load time to values even better than master but with the correct polygon stroke rendering.

## Results

### Polygon decoding

Improve decode time **1.7x faster**.

**Decode time**

| `master` | `polygon-stroke` | `polygon-stroke + decode-optimization` |
|:-:|:-:|:-:|
| 1x | 0.5x | 1.7x |

### Line decoding

Improve decode time **2.2x faster**.

**Decode time**

| `master` |`polygon-stroke + decode-optimization` |
|:-:|:-:|
| 1x | 2.2x |

## Optimization approach

The main approach is to do a better management of the memory regarding the geometry buffers. I noticed that `array.push(item)` allocates new memory for the entire buffer + 1 and then sets the value. This becomes slower when the array increases its size. So we need to allocate the memory first and then set the values to improve performance.

The approach of computing the exact number of vertices first, allocate memory and then set the values was discarded because obtaining the number of vertices adds more time than the time saved with only one memory allocation. Even using the maximum number of vertices plus a slice is not a good option too because it implies two memory allocations.

The final approach was to use a **resizable static buffers** of Float32Array instead of Array for both `vertices` and `normals` and then do a slice to get the final array. The buffers are resized to twice its capacity when there is an overflow with the current size. Sharing this memory allows reducing the time with the same results. The default memory for the static buffer is 4MB.

I get rid of `getFloat32ArrayFromArray` function in favor of `vertices.slice(0, index)` to get the final new buffers. Also tested functions like `new Float32Array(geomBuffer.vertices.subarray(0, index))` and `new Float32Array(new Float32Array(geomBuffer.vertices.buffer, 0, index))` but slice is the best option.

There are also other micro-optimizations like improve intermediate functions, optimize draw logic, using a common index, native `set` function instead of `for loop`, etc and adding the `addVertex` function, that improves performance by 10%.

## Performance tests

I have used local performance tests with local GeoJSON data, traces with `performance.now()` in the code to test the tiles and also the Chrome profiling tool to get the decode times and obtain the final results. 

```js
import { decodeGeom } from '../../../../src/renderer/decoder';
import GeoJSON from '../../../../src/sources/GeoJSON';

// let data = require('./sf_stclines.json');
let data = require('./mnmappluto.json');

const geojson = new GeoJSON(data);
const polygonGeometry = geojson._decodeGeometry();

falcon.benchmark('decodePolygon', () => {
    decodeGeom('polygon', polygonGeometry);
}, {runs: 1});
```