### PR TITLE
Enhanced featureID to Z (depth) mapping

### DIFF
--- a/src/renderer/shaders/geometry/line/lineVertexShader.glsl
+++ b/src/renderer/shaders/geometry/line/lineVertexShader.glsl
@@ -27,7 +27,8 @@ void main(void) {
 
     // 64 is computed based on RTT_WIDTH and the depth buffer precision
     // 64 = 2^(BUFFER_BITS)/RTT_WIDTH = 2^16/1024 = 64
-    float z = mod(featureID.y, 1./64.)*63. + featureID.x / (64.);
+    float z = featureID.y * 63. / 64. + featureID.x / (64.);
+
     // Set z range (-1, 1)
     z = z * 2. - 1.;
 

--- a/src/renderer/shaders/geometry/polygon/polygonVertexShader.glsl
+++ b/src/renderer/shaders/geometry/polygon/polygonVertexShader.glsl
@@ -22,14 +22,16 @@ float decodeWidth(vec2 enc) {
 void main(void) {
     // 64 is computed based on RTT_WIDTH and the depth buffer precision
     // 64 = 2^(BUFFER_BITS)/RTT_WIDTH = 2^16/1024 = 64
-    float z = mod(featureID.y, 1./64.)*63. + featureID.x / (64.);
+    float z = featureID.y * 63. / 64. + featureID.x / (64.);
 
     vec4 c;
     if (normal == vec2(0.)){
         z = 2.*z - 1.;
         c = texture2D(colorTex, featureID);
     }else{
-        z = mod(z - 0.5, 1.);
+        z = mod(z + 1./64., 1.);
+        z = 2.*z - 1.;
+
         c = texture2D(strokeColorTex, featureID);
     }
     float filtering = texture2D(filterTex, featureID).a;

--- a/src/renderer/shaders/geometry/polygon/polygonVertexShader.glsl
+++ b/src/renderer/shaders/geometry/polygon/polygonVertexShader.glsl
@@ -22,18 +22,16 @@ float decodeWidth(vec2 enc) {
 void main(void) {
     // 64 is computed based on RTT_WIDTH and the depth buffer precision
     // 64 = 2^(BUFFER_BITS)/RTT_WIDTH = 2^16/1024 = 64
-    float z = featureID.y * 63. / 64. + featureID.x / (64.);
+    float z = featureID.y * 63. / 64. + featureID.x / 64.;
 
     vec4 c;
     if (normal == vec2(0.)){
-        z = 2.*z - 1.;
         c = texture2D(colorTex, featureID);
     }else{
         z = mod(z + (z > 0.5 ? -1./64. : 1./64.), 1.);
-        z = 2.*z - 1.;
-
         c = texture2D(strokeColorTex, featureID);
     }
+    z = 2.*z - 1.;
     float filtering = texture2D(filterTex, featureID).a;
     c.a *= filtering;
     float size = decodeWidth(texture2D(strokeWidthTex, featureID).rg);

--- a/src/renderer/shaders/geometry/polygon/polygonVertexShader.glsl
+++ b/src/renderer/shaders/geometry/polygon/polygonVertexShader.glsl
@@ -29,7 +29,7 @@ void main(void) {
         z = 2.*z - 1.;
         c = texture2D(colorTex, featureID);
     }else{
-        z = mod(z + 1./64., 1.);
+        z = mod(z + (z > 0.5 ? -1./64. : 1./64.), 1.);
         z = 2.*z - 1.;
 
         c = texture2D(strokeColorTex, featureID);


### PR DESCRIPTION
Our mapping from featureID to Z wasn't optimal to avoid collisions, since the y value of the featureID is already spread as much as possible in the -1, 1 range (so the Ys were colliding a lot).

The effect of this is barely noticeable because collisions were mostly avoided by the X, and collisions would produce visible effects only when colliding features overlap... but well, this is theoretically better.