### PR TITLE
Remove breaking Uglify plugin from minified build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/carto-vl",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "sideEffects": false,
   "description": "CARTO Vector library",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/carto-vl",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "sideEffects": false,
   "description": "CARTO Vector library",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "test:e2e:prepare": "yarn build:dev && node test/acceptance/e2e.prepare.js ",
     "test:benchmark": "node test/benchmark/benchmark.js",
     "serve": "yarn build:dev && yarn docs && http-server",
-    "preversion": "./scripts/preversion.sh",
     "postversion": "git push origin HEAD --follow-tags",
     "prepublishOnly": "./scripts/release.sh",
     "ghpublish": "git checkout gh-pages && git pull origin gh-pages && git merge master && yarn build && yarn docs && git commit -a -m \"Auto generated gh-pages\" && git push origin gh-pages && git checkout master",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "test:e2e:prepare": "yarn build:dev && node test/acceptance/e2e.prepare.js ",
     "test:benchmark": "node test/benchmark/benchmark.js",
     "serve": "yarn build:dev && yarn docs && http-server",
+    "preversion": "./scripts/preversion.sh",
     "postversion": "git push origin HEAD --follow-tags",
     "prepublishOnly": "./scripts/release.sh",
     "ghpublish": "git checkout gh-pages && git pull origin gh-pages && git merge master && yarn build && yarn docs && git commit -a -m \"Auto generated gh-pages\" && git push origin gh-pages && git checkout master",

--- a/webpack/webpack.min.config.js
+++ b/webpack/webpack.min.config.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const webpack = require('webpack');
 const banner = require('./banner');
-const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 
 module.exports = {
     entry: './src/index.js',
@@ -17,37 +16,6 @@ module.exports = {
         rules: [
             { test: /\.glsl$/, use: 'webpack-glsl-loader' },
             { test: /\.svg$/, use: 'svg-inline-loader' }
-        ]
-    },
-    optimization: {
-        minimizer: [
-            new UglifyJSPlugin({
-                uglifyOptions: {
-                    output: {
-                        comments: false
-                    },
-                    compress: {
-                        properties: true,
-                        keep_fargs: false,
-                        pure_getters: true,
-                        collapse_vars: true,
-                        warnings: false,
-                        sequences: true,
-                        dead_code: true,
-                        drop_debugger: true,
-                        comparisons: true,
-                        conditionals: true,
-                        evaluate: true,
-                        booleans: true,
-                        loops: true,
-                        unused: true,
-                        hoist_funs: true,
-                        if_return: true,
-                        join_vars: true,
-                        drop_console: true
-                    }
-                }
-            })
         ]
     },
     plugins: [


### PR DESCRIPTION
This a PR to fix the minified build (it crashes with every polygon map).

This change should be backported as proposed by @jgoizueta to release a `0.6.1` version that contains `0.6.0` and this change,  without the rest of the changes in `master`