### PR TITLE
Resize static buffers

### DIFF
--- a/src/renderer/decoder/index.js
+++ b/src/renderer/decoder/index.js
@@ -4,14 +4,14 @@ import { decodePolygon } from './polygonDecoder';
 
 const geomLineBuffer = {
     index: 0,
-    vertices: new Float32Array(1024 * 1024 / 4),
-    normals: new Float32Array(1024 * 1024 / 4)
+    vertices: new Float32Array(1024 * 1024), // 4Mb
+    normals: new Float32Array(1024 * 1024) // 4Mb
 };
 
 const geomPolygonBuffer = {
     index: 0,
-    vertices: new Float32Array(1024 * 1024 / 4),
-    normals: new Float32Array(1024 * 1024 / 4)
+    vertices: new Float32Array(2 * 1024 * 1024), // 8Mb
+    normals: new Float32Array(2 * 1024 * 1024) // 8Mb
 };
 
 export function decodeGeom (geomType, geom) {

--- a/src/renderer/decoder/index.js
+++ b/src/renderer/decoder/index.js
@@ -2,14 +2,26 @@ import { decodePoint } from './pointDecoder';
 import { decodeLine } from './lineDecoder';
 import { decodePolygon } from './polygonDecoder';
 
+const geomLineBuffer = {
+    index: 0,
+    vertices: new Float32Array(8 * 1024 * 1024 / 32),
+    normals: new Float32Array(8 * 1024 * 1024 / 32)
+};
+
+const geomPolygonBuffer = {
+    index: 0,
+    vertices: new Float32Array(2000000),
+    normals: new Float32Array(2000000)
+};
+
 export function decodeGeom (geomType, geom) {
     switch (geomType) {
         case 'point':
             return decodePoint(geom);
         case 'line':
-            return decodeLine(geom);
+            return decodeLine(geom, geomLineBuffer);
         case 'polygon':
-            return decodePolygon(geom);
+            return decodePolygon(geom, geomPolygonBuffer);
         default:
             throw new Error(`Unimplemented geometry type: '${geomType}'`);
     }

--- a/src/renderer/decoder/index.js
+++ b/src/renderer/decoder/index.js
@@ -4,14 +4,14 @@ import { decodePolygon } from './polygonDecoder';
 
 const geomLineBuffer = {
     index: 0,
-    vertices: new Float32Array(8 * 1024 * 1024 / 32),
-    normals: new Float32Array(8 * 1024 * 1024 / 32)
+    vertices: new Float32Array(1024 * 1024 / 4),
+    normals: new Float32Array(1024 * 1024 / 4)
 };
 
 const geomPolygonBuffer = {
     index: 0,
-    vertices: new Float32Array(2000000),
-    normals: new Float32Array(2000000)
+    vertices: new Float32Array(1024 * 1024 / 4),
+    normals: new Float32Array(1024 * 1024 / 4)
 };
 
 export function decodeGeom (geomType, geom) {

--- a/src/renderer/decoder/lineDecoder.js
+++ b/src/renderer/decoder/lineDecoder.js
@@ -3,15 +3,23 @@ import { addLineString } from './common';
 // If the geometry type is 'line' it will generate the appropriate zero-sized, vertex-shader expanded triangle list with `miter` and `bevel` joins.
 // The geom will be an array of coordinates in this case
 
-const geomBuffer = {
-    index: 0,
-    vertices: new Float32Array(1000000),
-    normals: new Float32Array(1000000)
-};
+const MAX_VERTICES_PER_SEGMENT = 24;
 
-export function decodeLine (geometry) {
+export function decodeLine (geometry, geomBuffer) {
     let breakpoints = []; // Array of indices (to vertexArray) that separate each feature
     let featureIDToVertexIndex = new Map();
+
+    let numberFeatures = 0;
+    for (let i = 0; i < geometry.length; i++) {
+        numberFeatures += geometry[i].length;
+    }
+    let numberVertices = MAX_VERTICES_PER_SEGMENT * numberFeatures;
+    if (geomBuffer.vertices.length < numberVertices) {
+        // Resize the buffers
+        console.log('RESIZE', numberVertices);
+        geomBuffer.vertices = new Float32Array(numberVertices);
+        geomBuffer.normals = new Float32Array(numberVertices);
+    }
 
     geomBuffer.index = 0;
     for (let i = 0; i < geometry.length; i++) {

--- a/src/renderer/decoder/lineDecoder.js
+++ b/src/renderer/decoder/lineDecoder.js
@@ -3,24 +3,28 @@ import { addLineString } from './common';
 // If the geometry type is 'line' it will generate the appropriate zero-sized, vertex-shader expanded triangle list with `miter` and `bevel` joins.
 // The geom will be an array of coordinates in this case
 
-const MAX_VERTICES_PER_SEGMENT = 24;
+const MAX_VERTICES_PER_SEGMENT = 12;
 
 export function decodeLine (geometry, geomBuffer) {
     let breakpoints = []; // Array of indices (to vertexArray) that separate each feature
     let featureIDToVertexIndex = new Map();
+    let maxNumberVertices = 0;
+    let numberSegments = 0;
 
-    let numberFeatures = 0;
+    // Compute max number of vertices
     for (let i = 0; i < geometry.length; i++) {
-        numberFeatures += geometry[i].length;
+        numberSegments += geometry[i].length;
     }
-    let numberVertices = MAX_VERTICES_PER_SEGMENT * numberFeatures;
-    if (geomBuffer.vertices.length < numberVertices) {
+    maxNumberVertices = MAX_VERTICES_PER_SEGMENT * numberSegments;
+
+    // Allocate static memory if required
+    if (geomBuffer.vertices.length < maxNumberVertices) {
         // Resize the buffers
-        console.log('RESIZE', numberVertices);
-        geomBuffer.vertices = new Float32Array(numberVertices);
-        geomBuffer.normals = new Float32Array(numberVertices);
+        geomBuffer.vertices = new Float32Array(maxNumberVertices);
+        geomBuffer.normals = new Float32Array(maxNumberVertices);
     }
 
+    // Add vertices and normals
     geomBuffer.index = 0;
     for (let i = 0; i < geometry.length; i++) {
         const feature = geometry[i];

--- a/src/renderer/decoder/polygonDecoder.js
+++ b/src/renderer/decoder/polygonDecoder.js
@@ -7,19 +7,13 @@ import { addLineString } from './common';
 /*   let geom = [{
        flat: [
          0.,0., 1.,0., 1.,1., 0.,1., 0.,0, //A square
-         0.25,0.25, 0.75,0.25, 0.75,0.75, 0.25,0.75, 0.25,0.25//A small square
-       ]
+         0.25,0.25, 0.75,0.25, 0.75,0.75, 0.25,0.75, 0.25,0.25 //A small square
+       ],
        holes: [5]
      }]
 */
 
-const geomBuffer = {
-    index: 0,
-    vertices: new Float32Array(2000000),
-    normals: new Float32Array(2000000)
-};
-
-export function decodePolygon (geometry) {
+export function decodePolygon (geometry, geomBuffer) {
     let breakpoints = []; // Array of indices (to vertexArray) that separate each feature
     let featureIDToVertexIndex = new Map();
 

--- a/src/renderer/decoder/polygonDecoder.js
+++ b/src/renderer/decoder/polygonDecoder.js
@@ -23,10 +23,9 @@ export function decodePolygon (geometry, geomBuffer) {
     let numberTriangles = 0;
     let numberSegments = 0;
     let commonIndex = 0;
-    let polygonArray = [];
     let trianglesArray = [];
 
-    // Store polygons and triangles and compute max number of vertices
+    // Store triangles and compute max number of vertices
     for (let i = 0; i < geometry.length; i++) {
         const feature = geometry[i];
         for (let j = 0; j < feature.length; j++) {
@@ -36,7 +35,6 @@ export function decodePolygon (geometry, geomBuffer) {
             numberTriangles += triangles.length;
             numberSegments += polygon.flat.length;
 
-            polygonArray[commonIndex] = polygon;
             trianglesArray[commonIndex++] = triangles;
         }
     }
@@ -50,19 +48,23 @@ export function decodePolygon (geometry, geomBuffer) {
     }
 
     // Add vertices and normals
+    commonIndex = 0;
     geomBuffer.index = 0;
-    for (let i = 0; i < commonIndex; i++) {
-        const polygon = polygonArray[i];
-        const triangles = trianglesArray[i];
+    for (let i = 0; i < geometry.length; i++) {
+        const feature = geometry[i];
+        for (let j = 0; j < feature.length; j++) {
+            const polygon = feature[j];
+            const triangles = trianglesArray[commonIndex++];
 
-        for (let k = 0; k < triangles.length; k++) {
-            addVertex(polygon.flat, 2 * triangles[k], geomBuffer);
+            for (let k = 0; k < triangles.length; k++) {
+                addVertex(polygon.flat, 2 * triangles[k], geomBuffer);
+            }
+
+            addLineString(polygon.flat, geomBuffer, true, (index) => {
+                // Skip adding the line which connects two rings OR is clipped
+                return polygon.holes.includes((index - 2) / 2) || isClipped(polygon, index - 4, index - 2);
+            });
         }
-
-        addLineString(polygon.flat, geomBuffer, true, (index) => {
-            // Skip adding the line which connects two rings OR is clipped
-            return polygon.holes.includes((index - 2) / 2) || isClipped(polygon, index - 4, index - 2);
-        });
 
         featureIDToVertexIndex.set(breakpoints.length, breakpoints.length === 0
             ? { start: 0, end: geomBuffer.index }


### PR DESCRIPTION
In `decodeLine` and `decodePolygon` check the max buffer size to resize the static buffer if required.

Default values for line buffer are set to 4Mb, for polygon buffer to 8Mb