### PR TITLE
Fix zoom/center bug in editor

### DIFF
--- a/examples/editor/index.js
+++ b/examples/editor/index.js
@@ -255,7 +255,6 @@ const superRefresh = (opts) => {
 
     opts = opts || {};
     showLoader();
-    saveConfig();
 
     const source = sourceType === sourceTypes.QUERY
         ? new carto.source.SQL(document.getElementById('source').value, sourceAuth, sourceUrl)
@@ -268,14 +267,16 @@ const superRefresh = (opts) => {
         setupMap(opts);
         layer = new carto.Layer('myCartoLayer', source, viz);
         layer.on('loaded', () => {
-            hideLoader();
+            saveConfig();
             document.getElementById('feedback').style.display = 'none';
+            hideLoader();
         });
         layer.addTo(map, 'watername_ocean');
     } else {
         layer.update(source, viz)
             .then(() => {
                 setupMap(opts);
+                saveConfig();
                 document.getElementById('feedback').style.display = 'none';
                 hideLoader();
             })


### PR DESCRIPTION
After loading an example in the editor the zoom and center are set to 0 so after F5 the original position is lost. This PR fixes the issue by saving the configuration after a layer load or update event.