### PR TITLE
[WIP] Replace spaces with underscore both in properties and SQL query

### DIFF
--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -4,6 +4,7 @@ import Metadata from '../renderer/Metadata';
 import schema from '../renderer/schema';
 import Time from '../renderer/viz/expressions/time';
 import * as windshaftFiltering from './windshaft-filtering';
+import { parseQuerySpaces } from '../renderer/viz/expressions/utils.js';
 
 const SAMPLE_ROWS = 1000;
 const MIN_FILTERING = 2000000;
@@ -274,7 +275,8 @@ export default class Windshaft {
 
     _buildQuery (select, filters) {
         const columns = select.join();
-        const relation = this._source._query ? `(${this._source._query}) as _cdb_query_wrapper` : this._source._tableName;
+        const query = this._source._query;
+        const relation = query ? `(${parseQuerySpaces(query)}) as _cdb_query_wrapper` : this._source._tableName;
         const condition = filters ? windshaftFiltering.getSQLWhere(filters) : '';
         return `SELECT ${columns} FROM ${relation} ${condition}`;
     }

--- a/src/renderer/viz/expressions/basic/property.js
+++ b/src/renderer/viz/expressions/basic/property.js
@@ -1,5 +1,5 @@
 import BaseExpression from '../base';
-import { checkString } from '../utils';
+import { checkString, parseSpaces } from '../utils';
 
 /**
  * Evaluates the value of a column for every row in the dataset.
@@ -33,11 +33,14 @@ import { checkString } from '../utils';
 export default class Property extends BaseExpression {
     constructor (name) {
         checkString('property', 'name', 0, name);
+        
         if (name === '') {
             throw new Error('property(): invalid parameter, zero-length string');
         }
+
         super({});
-        this.name = name;
+        this.originalName = name;
+        this.name = parseSpaces(name);
         super._setGenericGLSL((childInlines, getGLSLforProperty) => getGLSLforProperty(this.name));
     }
 
@@ -59,7 +62,7 @@ export default class Property extends BaseExpression {
     _bindMetadata (meta) {
         const metaColumn = meta.properties[this.name];
         if (!metaColumn) {
-            throw new Error(`Property '${this.name}' does not exist`);
+            throw new Error(`Property '${this.originalName}' does not exist`);
         }
         this.type = metaColumn.type;
 

--- a/src/renderer/viz/expressions/basic/property.js
+++ b/src/renderer/viz/expressions/basic/property.js
@@ -33,7 +33,7 @@ import { checkString, parseSpaces } from '../utils';
 export default class Property extends BaseExpression {
     constructor (name) {
         checkString('property', 'name', 0, name);
-        
+
         if (name === '') {
             throw new Error('property(): invalid parameter, zero-length string');
         }

--- a/src/renderer/viz/expressions/utils.js
+++ b/src/renderer/viz/expressions/utils.js
@@ -82,6 +82,7 @@ export function getOrdinalFromIndex (index) {
 export function getStringErrorPreface (expressionName, parameterName, parameterIndex) {
     return `${expressionName}(): invalid ${getOrdinalFromIndex(parameterIndex + 1)} parameter '${parameterName}'`;
 }
+
 export function throwInvalidType (expressionName, parameterName, parameterIndex, expectedType, actualType) {
     throw new Error(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
 expected type was '${expectedType}', actual type was '${actualType}'`);
@@ -196,6 +197,25 @@ export function clamp (x, min, max) {
 
 export function mix (x, y, a) {
     return x * (1 - a) + y * a;
+}
+
+export function parseQuerySpaces (query) {
+    const BETWEEN_QUOTES_REGEX = /"(.*?)"/g;
+    const ANY_SPACE_REGEX = /\s/g;
+    const UNDERSCORE = '_';
+
+    query.match(BETWEEN_QUOTES_REGEX).forEach((text) => {
+        query = query.replace(text, text.replace(ANY_SPACE_REGEX, UNDERSCORE));
+    });
+
+    return query;
+}
+
+export function parseSpaces (text) {
+    const ANY_SPACE_REGEX = /\s/g;
+    const UNDERSCORE = '_';
+
+    return text.replace(ANY_SPACE_REGEX, UNDERSCORE);
 }
 
 function _isNumber (value) {


### PR DESCRIPTION
Related with https://github.com/CartoDB/carto-vl/issues/522

## Description

This PR replaces the spaces found both in the SQL query and in every property name between double quotes with underscore (`_`). This should be transparent to the user.

## Example

From https://github.com/CartoDB/carto-vl/issues/522#issuecomment-412085107
```js
const source = new carto.source.SQL('SELECT *, 99 as "best price" FROM populated_places_simple', {
    apiKey: 'default_public',
    user: 'rochoa'
});

const viz = new carto.Viz(`width: prop('best price')`);
const layer = new carto.Layer('layer', source, viz);
```

## Discussion

In Builder, when a user tries to change a column name with spaces, they are also replaced with underscore. 

If we follow this approach, we should also take into account that property names and aliases with spaces can be declared between:
* single quotes
* double quotes
* backticks

As @Jesus89 mentions [here](https://github.com/CartoDB/carto-vl/issues/522#issuecomment-412455327) about *dimensions*, in this case they take the string already parsed.

I think we need to discuss further a solution.
* Instead of parsing the query and the properties, should we throw an error / warn the user if they contain spaces?
* @Jesus89 suggestion: > The request should be encoded with LZMA to allow valid characters `"`