### PR TITLE
Throw error when an expression has extra arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Throw error for duplicated properties and variables
+- Throw error extra arguments are passed to any expression.
 
 ### Changed
 - Improve polygon stroke rendering (+ joins)

--- a/src/renderer/viz/expressions/Animation.js
+++ b/src/renderer/viz/expressions/Animation.js
@@ -1,6 +1,6 @@
 import BaseExpression from './base';
 import { Fade } from './Fade';
-import { implicitCast, clamp, checkType, checkLooseType, checkFeatureIndependent } from './utils';
+import { implicitCast, clamp, checkType, checkLooseType, checkFeatureIndependent, checkMaxArguments } from './utils';
 import { number, linear, globalMin, globalMax } from '../expressions';
 import Property from './basic/property';
 import { castDate } from '../../../utils/util';
@@ -67,6 +67,8 @@ let waitingForOthers = new Set();
  */
 export class Animation extends BaseExpression {
     constructor (input, duration = 10, fade = new Fade()) {
+        checkMaxArguments(arguments, 3, 'animation');
+
         duration = implicitCast(duration);
         input = implicitCast(input);
         const originalInput = input;
@@ -81,7 +83,6 @@ export class Animation extends BaseExpression {
         checkLooseType('animation', 'fade', 2, 'fade', fade);
 
         const progress = number(0);
-
         super({ _input: input, progress, fade, duration });
         // TODO improve type check
         this.type = 'number';

--- a/src/renderer/viz/expressions/Fade.js
+++ b/src/renderer/viz/expressions/Fade.js
@@ -1,5 +1,5 @@
 import BaseExpression from './base';
-import { implicitCast, checkLooseType } from './utils';
+import { implicitCast, checkLooseType, checkMaxArguments } from './utils';
 
 /**
  * Create a FadeIn/FadeOut configuration. See `animation` for more details.
@@ -52,6 +52,8 @@ const DEFAULT_PARAM = undefined;
 
 export class Fade extends BaseExpression {
     constructor (param1 = DEFAULT_PARAM, param2 = DEFAULT_PARAM) {
+        checkMaxArguments(arguments, 2, 'fade');
+
         let fadeIn = param1 === DEFAULT_PARAM
             ? implicitCast(DEFAULT_FADE)
             : implicitCast(param1);

--- a/src/renderer/viz/expressions/Image.js
+++ b/src/renderer/viz/expressions/Image.js
@@ -26,7 +26,7 @@ import { checkString, checkMaxArguments } from './utils';
 
 export default class Image extends Base {
     constructor (url) {
-        checkMaxArguments(arguments, 2, 'image');
+        checkMaxArguments(arguments, 1, 'image');
         checkString('image', 'url', 0, url);
 
         super({});

--- a/src/renderer/viz/expressions/Image.js
+++ b/src/renderer/viz/expressions/Image.js
@@ -1,5 +1,5 @@
 import Base from './base';
-import { checkString } from './utils';
+import { checkString, checkMaxArguments } from './utils';
 
 /**
  * Image. Load an image and use it as a symbol.
@@ -26,7 +26,9 @@ import { checkString } from './utils';
 
 export default class Image extends Base {
     constructor (url) {
+        checkMaxArguments(arguments, 2, 'image');
         checkString('image', 'url', 0, url);
+
         super({});
         this.type = 'image';
         this.canvas = null;

--- a/src/renderer/viz/expressions/ImageList.js
+++ b/src/renderer/viz/expressions/ImageList.js
@@ -1,5 +1,5 @@
 import Base from './base';
-import { checkArray, checkLooseType } from './utils';
+import { checkArray, checkLooseType, checkMaxArguments } from './utils';
 
 /**
  * ImageList. Load an array of images and use them as a symbols.
@@ -10,7 +10,9 @@ import { checkArray, checkLooseType } from './utils';
  */
 export default class ImageList extends Base {
     constructor (imageArray) {
+        checkMaxArguments(arguments, 1, 'imageList');
         checkArray('imageArray', 'imageArray', 0, imageArray);
+
         imageArray.forEach((image, i) => checkLooseType('imageArray', `imageArray[${i}]`, 0, 'image', image));
 
         const children = {};

--- a/src/renderer/viz/expressions/SVG.js
+++ b/src/renderer/viz/expressions/SVG.js
@@ -1,7 +1,9 @@
 import Image from './Image';
+import { checkMaxArguments } from './utils';
 
 export default class SVG extends Image {
     constructor (svg) {
+        checkMaxArguments(arguments, 1, 'svg');
         super(`data:image/svg+xml,${encodeURIComponent(svg)}`);
     }
 }

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterAvg.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterAvg.js
@@ -1,4 +1,5 @@
 import ClusterAggregation from './ClusterAggregation';
+import { checkMaxArguments } from '../../utils';
 /**
  * Aggregate using the average. This operation disables the access to the property
  * except within other cluster aggregate functions.
@@ -26,6 +27,7 @@ import ClusterAggregation from './ClusterAggregation';
  */
 export default class ClusterAvg extends ClusterAggregation {
     constructor (property) {
+        checkMaxArguments(arguments, 1, 'clusterAvg');
         super({ property, expressionName: 'clusterAvg', aggName: 'avg', aggType: 'number' });
     }
 }

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterMax.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterMax.js
@@ -1,4 +1,5 @@
 import ClusterAggregation from './ClusterAggregation';
+import { checkMaxArguments } from '../../utils';
 
 /**
  * Aggregate using the maximum. This operation disables the access to the property
@@ -27,6 +28,7 @@ import ClusterAggregation from './ClusterAggregation';
  */
 export default class ClusterMax extends ClusterAggregation {
     constructor (property) {
+        checkMaxArguments(arguments, 1, 'clusterMax');
         super({ property, expressionName: 'clusterMax', aggName: 'max', aggType: 'number' });
     }
 }

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterMin.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterMin.js
@@ -1,5 +1,5 @@
 import ClusterAggregation from './ClusterAggregation';
-
+import { checkMaxArguments } from '../../utils';
 /**
  * Aggregate using the minimum. This operation disables the access to the property
  * except within other cluster aggregate functions.
@@ -27,6 +27,7 @@ import ClusterAggregation from './ClusterAggregation';
  */
 export default class ClusterMin extends ClusterAggregation {
     constructor (property) {
+        checkMaxArguments(arguments, 1, 'clusterMin');
         super({ property, expressionName: 'clusterMin', aggName: 'min', aggType: 'number' });
     }
 }

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterMode.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterMode.js
@@ -1,4 +1,5 @@
 import ClusterAggregation from './ClusterAggregation';
+import { checkMaxArguments } from '../../utils';
 /**
  * Aggregate using the mode. This operation disables the access to the property
  * except within other cluster aggregate functions.
@@ -26,6 +27,7 @@ import ClusterAggregation from './ClusterAggregation';
  */
 export default class ClusterMode extends ClusterAggregation {
     constructor (property) {
+        checkMaxArguments(arguments, 1, 'clusterMode');
         super({ property, expressionName: 'clusterMode', aggName: 'mode', aggType: 'category' });
     }
 }

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterSum.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterSum.js
@@ -1,5 +1,5 @@
 import ClusterAggregation from './ClusterAggregation';
-
+import { checkMaxArguments } from '../../utils';
 /**
  * Aggregate using the sum. This operation disables the access to the property
  * except within other cluster aggregate functions.
@@ -27,6 +27,7 @@ import ClusterAggregation from './ClusterAggregation';
  */
 export default class ClusterSum extends ClusterAggregation {
     constructor (property) {
+        checkMaxArguments(arguments, 1, 'clusterSum');
         super({ property, expressionName: 'clusterSum', aggName: 'sum', aggType: 'number' });
     }
 }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAvg.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAvg.js
@@ -29,7 +29,7 @@ import { checkMaxArguments } from '../../utils';
  */
 export default class GlobalAvg extends GlobalAggregation {
     constructor (property) {
-        checkMaxArguments(property, 1, 'avg');
+        checkMaxArguments(arguments, 1, 'globalAvg');
 
         super({ property, name: 'avg', type: 'number' });
     }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAvg.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAvg.js
@@ -1,4 +1,5 @@
 import GlobalAggregation from './GlobalAggregation';
+import { checkMaxArguments } from '../../utils';
 
 /**
  * Return the average of the feature property for the entire source data.
@@ -28,6 +29,8 @@ import GlobalAggregation from './GlobalAggregation';
  */
 export default class GlobalAvg extends GlobalAggregation {
     constructor (property) {
+        checkMaxArguments(property, 1, 'avg');
+
         super({ property, name: 'avg', type: 'number' });
     }
 }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalCount.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalCount.js
@@ -29,7 +29,7 @@ import { checkMaxArguments } from '../../utils';
  */
 export default class GlobalCount extends GlobalAggregation {
     constructor (property) {
-        checkMaxArguments(arguments, 1, 'count');
+        checkMaxArguments(arguments, 1, 'globalCount');
 
         super({ property, name: 'count', type: 'number' });
     }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalCount.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalCount.js
@@ -1,4 +1,5 @@
 import GlobalAggregation from './GlobalAggregation';
+import { checkMaxArguments } from '../../utils';
 
 /**
  * Return the feature count for the entire source data.
@@ -28,6 +29,8 @@ import GlobalAggregation from './GlobalAggregation';
  */
 export default class GlobalCount extends GlobalAggregation {
     constructor (property) {
+        checkMaxArguments(arguments, 1, 'count');
+
         super({ property, name: 'count', type: 'number' });
     }
 }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalMax.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalMax.js
@@ -1,5 +1,5 @@
 import GlobalAggregation from './GlobalAggregation';
-
+import { checkMaxArguments } from '../../utils';
 /**
  * Return the maximum of the feature property for the entire source data.
  *
@@ -28,6 +28,8 @@ import GlobalAggregation from './GlobalAggregation';
  */
 export default class GlobalMax extends GlobalAggregation {
     constructor (property) {
+        checkMaxArguments(arguments, 1, 'max');
+
         super({ property, name: 'max', type: 'number' });
     }
 }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalMax.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalMax.js
@@ -28,7 +28,7 @@ import { checkMaxArguments } from '../../utils';
  */
 export default class GlobalMax extends GlobalAggregation {
     constructor (property) {
-        checkMaxArguments(arguments, 1, 'max');
+        checkMaxArguments(arguments, 1, 'globalMax');
 
         super({ property, name: 'max', type: 'number' });
     }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalMin.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalMin.js
@@ -28,7 +28,7 @@ import { checkMaxArguments } from '../../utils';
  */
 export default class GlobalMin extends GlobalAggregation {
     constructor (property) {
-        checkMaxArguments(arguments, 1, 'min');
+        checkMaxArguments(arguments, 1, 'globalMin');
 
         super({ property, name: 'min', type: 'number' });
     }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalMin.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalMin.js
@@ -1,4 +1,5 @@
 import GlobalAggregation from './GlobalAggregation';
+import { checkMaxArguments } from '../../utils';
 /**
  * Return the minimum of the feature property for the entire source data.
  *
@@ -27,6 +28,8 @@ import GlobalAggregation from './GlobalAggregation';
  */
 export default class GlobalMin extends GlobalAggregation {
     constructor (property) {
+        checkMaxArguments(arguments, 1, 'min');
+
         super({ property, name: 'min', type: 'number' });
     }
 }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalPercentile.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalPercentile.js
@@ -29,7 +29,7 @@ import { checkMaxArguments } from '../../utils';
  */
 export default class GlobalPercentile extends BaseExpression {
     constructor (property, percentile) {
-        checkMaxArguments(arguments, 2, 'percentile');
+        checkMaxArguments(arguments, 2, 'globalPercentile');
 
         if (!Number.isFinite(percentile)) {
             throw new Error('Percentile must be a fixed literal number');

--- a/src/renderer/viz/expressions/aggregation/global/GlobalPercentile.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalPercentile.js
@@ -1,7 +1,7 @@
 import BaseExpression from '../../base';
 import * as schema from '../../../../schema';
 import { number } from '../../../expressions';
-
+import { checkMaxArguments } from '../../utils';
 /**
  * Return the Nth percentile of an numeric property for the entire source data.
  *
@@ -29,6 +29,8 @@ import { number } from '../../../expressions';
  */
 export default class GlobalPercentile extends BaseExpression {
     constructor (property, percentile) {
+        checkMaxArguments(arguments, 2, 'percentile');
+
         if (!Number.isFinite(percentile)) {
             throw new Error('Percentile must be a fixed literal number');
         }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalSum.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalSum.js
@@ -1,4 +1,5 @@
 import GlobalAggregation from './GlobalAggregation';
+import { checkMaxArguments } from '../../utils';
 
 /**
  * Return the sum of the feature property for the entire source data.
@@ -28,6 +29,8 @@ import GlobalAggregation from './GlobalAggregation';
  */
 export default class GlobalSum extends GlobalAggregation {
     constructor (property) {
+        checkMaxArguments(arguments, 1, 'sum');
+
         super({ property, name: 'sum' });
     }
 }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalSum.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalSum.js
@@ -29,7 +29,7 @@ import { checkMaxArguments } from '../../utils';
  */
 export default class GlobalSum extends GlobalAggregation {
     constructor (property) {
-        checkMaxArguments(arguments, 1, 'sum');
+        checkMaxArguments(arguments, 1, 'globalSum');
 
         super({ property, name: 'sum' });
     }

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportAvg.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportAvg.js
@@ -1,4 +1,5 @@
 import ViewportAggregation from './ViewportAggregation';
+import { checkMaxArguments } from '../../utils';
 
 /**
  * Return the average value of an expression for the features showed in the viewport (features outside the viewport and features that don't pass the filter will be excluded).
@@ -26,6 +27,8 @@ import ViewportAggregation from './ViewportAggregation';
  */
 export default class ViewportAvg extends ViewportAggregation {
     constructor (property) {
+        checkMaxArguments(arguments, 1, 'viewportAvg');
+
         super({ property });
         this._sum = 0;
         this._count = 0;

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportCount.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportCount.js
@@ -1,5 +1,6 @@
 import ViewportAggregation from './ViewportAggregation';
 import { number } from '../../../expressions';
+import { checkMaxArguments } from '../../utils';
 
 /**
  * Return the feature count of the features showed in the viewport (features outside the viewport and features that don't pass the filter will be excluded).
@@ -27,6 +28,8 @@ import { number } from '../../../expressions';
  */
 export default class ViewportCount extends ViewportAggregation {
     constructor () {
+        checkMaxArguments(arguments, 1, 'viewportCount');
+
         super({ property: number(0) });
         this._value = 0;
     }

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportHistogram.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportHistogram.js
@@ -1,5 +1,6 @@
 import BaseExpression from '../../base';
 import { implicitCast } from '../../utils';
+import { checkMaxArguments } from '../../utils';
 
 /**
  * Generates an histogram.
@@ -37,6 +38,8 @@ import { implicitCast } from '../../utils';
  */
 export default class ViewportHistogram extends BaseExpression {
     constructor (x, weight = 1, size = 1000) {
+        checkMaxArguments(arguments, 3, 'viewportHistogram');
+
         super({ x: implicitCast(x), weight: implicitCast(weight) });
 
         this.type = 'histogram';

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportMax.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportMax.js
@@ -1,5 +1,5 @@
 import ViewportAggregation from './ViewportAggregation';
-
+import { checkMaxArguments } from '../../utils';
 /**
  * Return the maximum value of an expression for the features showed in the viewport (features outside the viewport and features that don't pass the filter will be excluded).
  *
@@ -26,6 +26,7 @@ import ViewportAggregation from './ViewportAggregation';
  */
 export default class ViewportMax extends ViewportAggregation {
     constructor (property) {
+        checkMaxArguments(arguments, 1, 'viewportMax');
         super({ property });
         this._value = Number.NEGATIVE_INFINITY;
     }

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportMin.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportMin.js
@@ -1,4 +1,5 @@
 import ViewportAggregation from './ViewportAggregation';
+import { checkMaxArguments } from '../../utils';
 
 /**
  * Return the minimum value of an expression for the features showed in the viewport (features outside the viewport and features that don't pass the filter will be excluded).
@@ -26,6 +27,8 @@ import ViewportAggregation from './ViewportAggregation';
  */
 export default class ViewportMin extends ViewportAggregation {
     constructor (property) {
+        checkMaxArguments(arguments, 1, 'viewportMin');
+
         super({ property });
         this._value = Number.POSITIVE_INFINITY;
     }

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportPercentile.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportPercentile.js
@@ -1,7 +1,6 @@
 import ViewportAggregation from './ViewportAggregation';
 import { number } from '../../../expressions';
-import { implicitCast, clamp } from '../../utils';
-
+import { implicitCast, clamp, checkMaxArguments } from '../../utils';
 /**
  * Return the Nth percentile of an expression for the features showed in the viewport (features outside the viewport and features that don't pass the filter will be excluded).
  *
@@ -33,6 +32,8 @@ export default class ViewportPercentile extends ViewportAggregation {
      * @param {*} percentile
      */
     constructor (property, percentile) {
+        checkMaxArguments(arguments, 2, 'viewportPercentile');
+
         super({ property, _impostor: number(0) });
 
         this._isViewport = true;

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportSum.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportSum.js
@@ -1,4 +1,5 @@
 import ViewportAggregation from './ViewportAggregation';
+import { checkMaxArguments } from '../../utils';
 
 /**
  * Return the sum of an expression for the features showed in the viewport (features outside the viewport and features that don't pass the filter will be excluded).
@@ -26,6 +27,8 @@ import ViewportAggregation from './ViewportAggregation';
  */
 export default class ViewportSum extends ViewportAggregation {
     constructor (property) {
+        checkMaxArguments(arguments, 1, 'viewportSum');
+
         super({ property });
         this._value = 0;
     }

--- a/src/renderer/viz/expressions/basic/array.js
+++ b/src/renderer/viz/expressions/basic/array.js
@@ -1,5 +1,5 @@
 import BaseExpression from '../base';
-import { checkExpression, implicitCast, getOrdinalFromIndex } from '../utils';
+import { checkExpression, implicitCast, getOrdinalFromIndex, checkMaxArguments } from '../utils';
 
 /**
  * Wrapper around arrays. Explicit usage is unnecessary since CARTO VL will wrap implicitly all arrays using this function.
@@ -14,6 +14,8 @@ import { checkExpression, implicitCast, getOrdinalFromIndex } from '../utils';
  */
 export default class BaseArray extends BaseExpression {
     constructor (elems) {
+        checkMaxArguments(arguments, 1, 'array');
+
         elems = elems || [];
 
         if (!Array.isArray(elems)) {

--- a/src/renderer/viz/expressions/basic/category.js
+++ b/src/renderer/viz/expressions/basic/category.js
@@ -1,5 +1,5 @@
 import BaseExpression from '../base';
-import { checkString } from '../utils';
+import { checkString, checkMaxArguments } from '../utils';
 
 /**
  * Wrapper around category names. Explicit usage is unnecessary since CARTO VL will wrap implicitly all strings using this function.
@@ -14,7 +14,9 @@ import { checkString } from '../utils';
  */
 export default class BaseCategory extends BaseExpression {
     constructor (categoryName) {
+        checkMaxArguments(arguments, 1, 'category');
         checkString('category', 'categoryName', 0, categoryName);
+
         super({});
         this.expr = categoryName;
         this.type = 'category';

--- a/src/renderer/viz/expressions/basic/constant.js
+++ b/src/renderer/viz/expressions/basic/constant.js
@@ -1,5 +1,5 @@
 import BaseExpression from '../base';
-import { checkNumber } from '../utils';
+import { checkNumber, checkMaxArguments } from '../utils';
 
 /**
  * Wraps a constant number. Implies a GPU optimization vs {@link carto.expressions.number|number expression}.
@@ -25,7 +25,9 @@ import { checkNumber } from '../utils';
  */
 export default class Constant extends BaseExpression {
     constructor (x) {
+        checkMaxArguments(arguments, 1, 'constant');
         checkNumber('constant', 'x', 0, x);
+
         super({});
         this.expr = x;
         this.type = 'number';

--- a/src/renderer/viz/expressions/basic/number.js
+++ b/src/renderer/viz/expressions/basic/number.js
@@ -1,5 +1,5 @@
 import BaseExpression from '../base';
-import { checkNumber } from '../utils';
+import { checkNumber, checkMaxArguments } from '../utils';
 
 /**
  * Wraps a number. Explicit usage is unnecessary since CARTO VL will wrap implicitly all numbers using this function.
@@ -25,7 +25,9 @@ import { checkNumber } from '../utils';
  */
 export default class BaseNumber extends BaseExpression {
     constructor (x) {
+        checkMaxArguments(arguments, 1, 'number');
         checkNumber('number', 'x', 0, x);
+
         super({});
         this.expr = x;
         this.type = 'number';

--- a/src/renderer/viz/expressions/basic/property.js
+++ b/src/renderer/viz/expressions/basic/property.js
@@ -1,5 +1,5 @@
 import BaseExpression from '../base';
-import { checkString } from '../utils';
+import { checkString, checkMaxArguments } from '../utils';
 
 /**
  * Evaluates the value of a column for every row in the dataset.
@@ -32,7 +32,9 @@ import { checkString } from '../utils';
  */
 export default class Property extends BaseExpression {
     constructor (name) {
+        checkMaxArguments(arguments, 1, 'property');
         checkString('property', 'name', 0, name);
+
         if (name === '') {
             throw new Error('property(): invalid parameter, zero-length string');
         }

--- a/src/renderer/viz/expressions/basic/variable.js
+++ b/src/renderer/viz/expressions/basic/variable.js
@@ -29,7 +29,6 @@ import { checkString, checkMaxArguments } from '../utils';
  */
 export class Variable extends BaseExpression {
     constructor () {
-        checkMaxArguments(arguments, 0, variable);
         super({});
     }
 }
@@ -39,7 +38,9 @@ function isFunction (functionToCheck) {
 }
 
 export default function variable (name) {
+    checkMaxArguments(arguments, 1, 'variable');
     checkString('variable', 'name', 0, name);
+
     if (name === '') {
         throw new Error('variable(): invalid parameter, zero-length string');
     }

--- a/src/renderer/viz/expressions/basic/variable.js
+++ b/src/renderer/viz/expressions/basic/variable.js
@@ -1,5 +1,5 @@
 import BaseExpression from '../base';
-import { checkString } from '../utils';
+import { checkString, checkMaxArguments } from '../utils';
 
 /**
  * Alias to a named variable defined in the Viz.
@@ -29,12 +29,15 @@ import { checkString } from '../utils';
  */
 export class Variable extends BaseExpression {
     constructor () {
+        checkMaxArguments(arguments, 0, variable);
         super({});
     }
 }
+
 function isFunction (functionToCheck) {
     return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]';
 }
+
 export default function variable (name) {
     checkString('variable', 'name', 0, name);
     if (name === '') {

--- a/src/renderer/viz/expressions/belongs.js
+++ b/src/renderer/viz/expressions/belongs.js
@@ -1,4 +1,4 @@
-import { implicitCast, checkType, checkLooseType, checkExpression } from './utils';
+import { implicitCast, checkType, checkLooseType, checkExpression, checkMaxArguments } from './utils';
 import BaseExpression from './base';
 
 /**
@@ -68,6 +68,8 @@ function NIN_INLINE_MAKER (list) {
 function generateBelongsExpression (name, inlineMaker, jsEval) {
     return class BelongExpression extends BaseExpression {
         constructor (value, list) {
+            checkMaxArguments(arguments, 2, name);
+
             value = implicitCast(value);
             list = implicitCast(list);
 

--- a/src/renderer/viz/expressions/between.js
+++ b/src/renderer/viz/expressions/between.js
@@ -1,5 +1,5 @@
 import BaseExpression from './base';
-import { implicitCast, checkLooseType, checkType } from './utils';
+import { implicitCast, checkLooseType, checkType, checkMaxArguments } from './utils';
 
 /**
  * Check if a given value is contained within an inclusive range (including the limits).
@@ -29,6 +29,8 @@ import { implicitCast, checkLooseType, checkType } from './utils';
  */
 export default class Between extends BaseExpression {
     constructor (value, lowerLimit, upperLimit) {
+        checkMaxArguments(arguments, 3, 'between');
+
         value = implicitCast(value);
         lowerLimit = implicitCast(lowerLimit);
         upperLimit = implicitCast(upperLimit);

--- a/src/renderer/viz/expressions/binary.js
+++ b/src/renderer/viz/expressions/binary.js
@@ -1,5 +1,5 @@
 import { number } from '../expressions';
-import { implicitCast } from './utils';
+import { implicitCast, checkMaxArguments } from './utils';
 import BaseExpression from './base';
 
 // Each binary expression can have a set of the following signatures (OR'ed flags)
@@ -446,6 +446,8 @@ export const And = genBinaryOp('and',
 function genBinaryOp (name, allowedSignature, jsFn, glsl) {
     return class BinaryOperation extends BaseExpression {
         constructor (a, b) {
+            checkMaxArguments(arguments, 2, name);
+
             if (Number.isFinite(a) && Number.isFinite(b)) {
                 return number(jsFn(a, b));
             }

--- a/src/renderer/viz/expressions/blend.js
+++ b/src/renderer/viz/expressions/blend.js
@@ -1,4 +1,4 @@
-import { implicitCast, clamp, mix, checkLooseType, checkType, checkExpression } from './utils';
+import { implicitCast, clamp, mix, checkLooseType, checkType, checkExpression, checkMaxArguments } from './utils';
 import Transition from './transition';
 import BaseExpression from './base';
 
@@ -34,6 +34,7 @@ import BaseExpression from './base';
  */
 export default class Blend extends BaseExpression {
     constructor (a, b, mix, interpolator) {
+        checkMaxArguments(arguments, 4, 'blend');
         a = implicitCast(a);
         b = implicitCast(b);
         mix = implicitCast(mix);

--- a/src/renderer/viz/expressions/buckets.js
+++ b/src/renderer/viz/expressions/buckets.js
@@ -1,5 +1,5 @@
 import BaseExpression from './base';
-import { implicitCast, getOrdinalFromIndex } from './utils';
+import { implicitCast, getOrdinalFromIndex, checkMaxArguments } from './utils';
 
 /**
  * Given a property create "sub-groups" based on the given breakpoints.
@@ -66,6 +66,8 @@ import { implicitCast, getOrdinalFromIndex } from './utils';
  */
 export default class Buckets extends BaseExpression {
     constructor (input, list) {
+        checkMaxArguments(arguments, 2, 'buckets');
+
         input = implicitCast(input);
         list = implicitCast(list);
 

--- a/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
@@ -1,6 +1,6 @@
 import Classifier from './Classifier';
 import Property from '../basic/property';
-import { checkNumber, checkInstance, checkType, checkExpression } from '../utils';
+import { checkNumber, checkInstance, checkType, checkExpression, checkMaxArguments } from '../utils';
 
 /**
  * Classify `input` by using the equal intervals method with `n` buckets.
@@ -29,6 +29,7 @@ import { checkNumber, checkInstance, checkType, checkExpression } from '../utils
  */
 export default class GlobalEqIntervals extends Classifier {
     constructor (input, buckets) {
+        checkMaxArguments(arguments, 2, 'globalEqIntervals');
         checkInstance('globalEqIntervals', 'input', 0, Property, input && (input.property || input));
         checkNumber('globalEqIntervals', 'buckets', 1, buckets);
 

--- a/src/renderer/viz/expressions/classification/GlobalQuantiles.js
+++ b/src/renderer/viz/expressions/classification/GlobalQuantiles.js
@@ -1,6 +1,6 @@
 import Classifier from './Classifier';
 import Property from '../basic/property';
-import { checkInstance, checkType, checkExpression, checkNumber } from '../utils';
+import { checkInstance, checkType, checkExpression, checkNumber, checkMaxArguments } from '../utils';
 
 /**
  * Classify `input` by using the quantiles method with `n` buckets.
@@ -29,6 +29,7 @@ import { checkInstance, checkType, checkExpression, checkNumber } from '../utils
  */
 export default class GlobalQuantiles extends Classifier {
     constructor (input, buckets) {
+        checkMaxArguments(arguments, 2, 'globalQuantiles');
         checkInstance('globalQuantiles', 'input', 0, Property, input && (input.property || input));
         checkNumber('globalQuantiles', 'buckets', 1, buckets);
         super({ input }, buckets);

--- a/src/renderer/viz/expressions/classification/ViewportEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/ViewportEqIntervals.js
@@ -29,7 +29,7 @@ import { checkNumber, checkType, checkMaxArguments } from '../utils';
  */
 export default class ViewportEqIntervals extends Classifier {
     constructor (input, buckets) {
-        checkMaxArguments(arguments, 2, 'viewportEqualIntervals');
+        checkMaxArguments(arguments, 2, 'viewportEqIntervals');
         checkNumber('viewportEqIntervals', 'buckets', 1, buckets);
 
         const children = { input, _min: viewportMin(input), _max: viewportMax(input) };

--- a/src/renderer/viz/expressions/classification/ViewportEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/ViewportEqIntervals.js
@@ -1,6 +1,6 @@
 import Classifier from './Classifier';
 import { viewportMax, viewportMin } from '../../expressions';
-import { checkNumber, checkType } from '../utils';
+import { checkNumber, checkType, checkMaxArguments } from '../utils';
 
 /**
  * Classify `input` by using the equal intervals method with `n` buckets.
@@ -29,6 +29,7 @@ import { checkNumber, checkType } from '../utils';
  */
 export default class ViewportEqIntervals extends Classifier {
     constructor (input, buckets) {
+        checkMaxArguments(arguments, 2, 'viewportEqualIntervals');
         checkNumber('viewportEqIntervals', 'buckets', 1, buckets);
 
         const children = { input, _min: viewportMin(input), _max: viewportMax(input) };

--- a/src/renderer/viz/expressions/classification/ViewportQuantiles.js
+++ b/src/renderer/viz/expressions/classification/ViewportQuantiles.js
@@ -1,5 +1,5 @@
 import Classifier from './Classifier';
-import { checkNumber, checkType } from '../utils';
+import { checkNumber, checkType, checkMaxArguments } from '../utils';
 import { viewportHistogram } from '../../expressions';
 
 /**
@@ -29,6 +29,7 @@ import { viewportHistogram } from '../../expressions';
  */
 export default class ViewportQuantiles extends Classifier {
     constructor (input, buckets) {
+        checkMaxArguments(arguments, 2, 'viewportQuantiles');
         checkNumber('viewportQuantiles', 'buckets', 1, buckets);
 
         const children = { input, _histogram: viewportHistogram(input) };

--- a/src/renderer/viz/expressions/color/CIELab.js
+++ b/src/renderer/viz/expressions/color/CIELab.js
@@ -1,5 +1,5 @@
 import BaseExpression from '../base';
-import { implicitCast, checkLooseType, checkType, checkExpression } from '../utils';
+import { implicitCast, checkLooseType, checkType, checkExpression, checkMaxArguments } from '../utils';
 
 /**
  * Evaluates to a CIELab color.
@@ -27,6 +27,7 @@ import { implicitCast, checkLooseType, checkType, checkExpression } from '../uti
  */
 export default class CIELab extends BaseExpression {
     constructor (l, a, b) {
+        checkMaxArguments(arguments, 3, 'cielab');
         l = implicitCast(l);
         a = implicitCast(a);
         b = implicitCast(b);

--- a/src/renderer/viz/expressions/color/NamedColor.js
+++ b/src/renderer/viz/expressions/color/NamedColor.js
@@ -1,5 +1,5 @@
 import BaseExpression from '../base';
-import { checkString, getStringErrorPreface } from '../utils';
+import { checkString, checkMaxArguments, getStringErrorPreface } from '../utils';
 import { CSS_COLOR_NAMES } from './cssColorNames';
 
 /**
@@ -26,7 +26,9 @@ import { CSS_COLOR_NAMES } from './cssColorNames';
  */
 export default class NamedColor extends BaseExpression {
     constructor (colorName) {
+        checkMaxArguments(arguments, 1, 'namedColor');
         checkString('namedColor', 'colorName', 0, colorName);
+
         if (!CSS_COLOR_NAMES.includes(colorName.toLowerCase())) {
             throw new Error(getStringErrorPreface('namedColor', 'colorName', 0) + `\nInvalid color name:  "${colorName}"`);
         }
@@ -36,9 +38,11 @@ export default class NamedColor extends BaseExpression {
         this.color = _nameToRGBA(this.name);
         this.inlineMaker = () => `vec4(${(this.color.r / 255).toFixed(4)}, ${(this.color.g / 255).toFixed(4)}, ${(this.color.b / 255).toFixed(4)}, ${(1).toFixed(4)})`;
     }
+
     get value () {
         return this.eval();
     }
+
     eval () {
         return this.color;
     }

--- a/src/renderer/viz/expressions/color/hex.js
+++ b/src/renderer/viz/expressions/color/hex.js
@@ -1,5 +1,5 @@
 import BaseExpression from '../base';
-import { checkString, hexToRgb, getStringErrorPreface } from '../utils';
+import { checkString, hexToRgb, getStringErrorPreface, checkMaxArguments } from '../utils';
 
 /**
  * Create a color from its hexadecimal description.
@@ -25,7 +25,9 @@ import { checkString, hexToRgb, getStringErrorPreface } from '../utils';
  */
 export default class Hex extends BaseExpression {
     constructor (hexadecimalColor) {
+        checkMaxArguments(arguments, 1, 'hex');
         checkString('hex', 'hexadecimalColor', 0, hexadecimalColor);
+
         super({});
         this.type = 'color';
         try {

--- a/src/renderer/viz/expressions/color/hsl.js
+++ b/src/renderer/viz/expressions/color/hsl.js
@@ -1,5 +1,5 @@
 import BaseExpression from '../base';
-import { implicitCast, checkExpression, checkLooseType, checkType, clamp } from '../utils';
+import { implicitCast, checkExpression, checkLooseType, checkType, checkMaxArguments, clamp } from '../utils';
 
 /**
  * Evaluates to a hsl color.
@@ -57,6 +57,8 @@ export const HSLA = genHSL('hsla', true);
 function genHSL (name, alpha) {
     return class HSLA extends BaseExpression {
         constructor (h, s, l, a) {
+            checkMaxArguments(arguments, 4, 'hsla');
+
             [h, s, l, a] = [h, s, l, a].map(implicitCast);
 
             const children = { h, s, l };

--- a/src/renderer/viz/expressions/color/hsv.js
+++ b/src/renderer/viz/expressions/color/hsv.js
@@ -1,5 +1,5 @@
 import BaseExpression from '../base';
-import { implicitCast, checkExpression, checkLooseType, checkType, clamp } from '../utils';
+import { implicitCast, checkExpression, checkLooseType, checkType, checkMaxArguments, clamp } from '../utils';
 
 /**
  * Evaluates to a hsv color.
@@ -57,6 +57,8 @@ export const HSVA = genHSV('hsva', true);
 function genHSV (name, alpha) {
     return class extends BaseExpression {
         constructor (h, s, v, a) {
+            checkMaxArguments(arguments, 4, 'hsva');
+
             h = implicitCast(h);
             s = implicitCast(s);
             v = implicitCast(v);

--- a/src/renderer/viz/expressions/color/opacity.js
+++ b/src/renderer/viz/expressions/color/opacity.js
@@ -1,6 +1,6 @@
 import BaseExpression from '../base';
 import { number } from '../../expressions';
-import { checkLooseType, checkType } from '../utils';
+import { checkLooseType, checkType, checkMaxArguments } from '../utils';
 
 /**
  * Override the input color opacity.
@@ -32,6 +32,8 @@ export default class Opacity extends BaseExpression {
      * @param {*} alpha new opacity
      */
     constructor (color, alpha) {
+        checkMaxArguments(arguments, 2, 'opacity');
+
         if (Number.isFinite(alpha)) {
             alpha = number(alpha);
         }

--- a/src/renderer/viz/expressions/color/rgb.js
+++ b/src/renderer/viz/expressions/color/rgb.js
@@ -1,5 +1,5 @@
 import BaseExpression from '../base';
-import { implicitCast, checkLooseType, checkType } from '../utils';
+import { implicitCast, checkLooseType, checkType, checkMaxArguments } from '../utils';
 
 /**
  * Evaluates to a rgb color.
@@ -59,6 +59,8 @@ export const RGBA = genRGB('rgba', true);
 function genRGB (name, alpha) {
     return class RGBA extends BaseExpression {
         constructor (r, g, b, a) {
+            checkMaxArguments(arguments, 4, 'rgba');
+
             [r, g, b, a] = [r, g, b, a].map(implicitCast);
             checkLooseType(name, 'r', 0, 'number', r);
             checkLooseType(name, 'g', 1, 'number', g);

--- a/src/renderer/viz/expressions/interpolators.js
+++ b/src/renderer/viz/expressions/interpolators.js
@@ -1,11 +1,12 @@
-import { implicitCast } from './utils';
+import { implicitCast, checkMaxArguments } from './utils';
 import BaseExpression from './base';
 
 // TODO type checking
 
-export class ILinear extends genInterpolator(inner => inner, undefined, inner => inner) { }
+export class ILinear extends genInterpolator('iLinear', inner => inner, undefined, inner => inner) { }
 
 export class Cubic extends genInterpolator(
+    'cubic',
     inner => `cubicEaseInOut(${inner})`,
     `
     #ifndef CUBIC
@@ -24,6 +25,7 @@ export class Cubic extends genInterpolator(
 ) { }
 
 export class BounceEaseIn extends genInterpolator(
+    'bounceEaseIn',
     inner => `BounceEaseIn(${inner})`,
     `
     #ifndef BOUNCE_EASE_IN
@@ -58,9 +60,11 @@ export class BounceEaseIn extends genInterpolator(
 ) { }
 
 // Interpolators
-function genInterpolator (inlineMaker, preface, jsEval) {
+function genInterpolator (name, inlineMaker, preface, jsEval) {
     const fn = class Interpolator extends BaseExpression {
         constructor (m) {
+            checkMaxArguments(arguments, 1, name);
+
             m = implicitCast(m);
             super({ m });
         }

--- a/src/renderer/viz/expressions/linear.js
+++ b/src/renderer/viz/expressions/linear.js
@@ -1,5 +1,5 @@
 import BaseExpression from './base';
-import { checkExpression, checkLooseType, implicitCast, checkType } from './utils';
+import { checkExpression, checkLooseType, implicitCast, checkType, checkMaxArguments } from './utils';
 import { globalMin, globalMax } from '../expressions';
 
 /**
@@ -29,6 +29,8 @@ import { globalMin, globalMax } from '../expressions';
 */
 export default class Linear extends BaseExpression {
     constructor (input, min, max) {
+        checkMaxArguments(arguments, 3, 'linear');
+
         input = implicitCast(input);
 
         if (min === undefined && max === undefined) {

--- a/src/renderer/viz/expressions/now.js
+++ b/src/renderer/viz/expressions/now.js
@@ -1,5 +1,6 @@
 import BaseExpression from './base';
 import { number } from '../expressions';
+import { checkMaxArguments } from './utils';
 
 /**
  * Get the current timestamp. This is an advanced form of animation, `animation` expression is preferred.
@@ -24,6 +25,8 @@ import { number } from '../expressions';
  */
 export default class Now extends BaseExpression {
     constructor () {
+        checkMaxArguments(arguments, 0, 'now');
+
         super({ now: number(0) });
         this.type = 'number';
         super.inlineMaker = inline => inline.now;

--- a/src/renderer/viz/expressions/ordering.js
+++ b/src/renderer/viz/expressions/ordering.js
@@ -1,5 +1,5 @@
 import BaseExpression from './base';
-import { checkInstance } from './utils';
+import { checkInstance, checkMaxArguments } from './utils';
 
 /**
  * Order ascending by a provided expression. NOTE: only works with `width()`.
@@ -25,6 +25,8 @@ import { checkInstance } from './utils';
  */
 export class Asc extends BaseExpression {
     constructor (by) {
+        checkMaxArguments(arguments, 1, 'asc');
+
         super({});
         checkInstance('asc', 'by', 0, Width, by);
         this.type = 'orderer';
@@ -55,6 +57,8 @@ export class Asc extends BaseExpression {
  */
 export class Desc extends BaseExpression {
     constructor (by) {
+        checkMaxArguments(arguments, 1, 'desc');
+
         super({});
         checkInstance('desc', 'by', 0, Width, by);
         this.type = 'orderer';
@@ -84,6 +88,8 @@ export class Desc extends BaseExpression {
  */
 export class NoOrder extends BaseExpression {
     constructor () {
+        checkMaxArguments(arguments, 0, 'noOrder');
+
         super({});
         this.type = 'orderer';
     }
@@ -112,6 +118,8 @@ export class NoOrder extends BaseExpression {
  */
 export class Width extends BaseExpression {
     constructor () {
+        checkMaxArguments(arguments, 1, 'width');
+
         super({});
         this.type = 'propertyReference';
     }

--- a/src/renderer/viz/expressions/placement.js
+++ b/src/renderer/viz/expressions/placement.js
@@ -1,5 +1,5 @@
 import BaseExpression from './base';
-import { checkLooseType, checkType, implicitCast } from './utils';
+import { checkLooseType, checkType, implicitCast, checkMaxArguments } from './utils';
 
 /**
  * Placement. Define an image offset relative to its size. Where:
@@ -35,6 +35,8 @@ import { checkLooseType, checkType, implicitCast } from './utils';
 
 export default class Placement extends BaseExpression {
     constructor (x, y) {
+        checkMaxArguments(arguments, 2, 'placement');
+
         x = implicitCast(x);
         y = implicitCast(y);
         checkLooseType('placement', 'x', 0, 'number', x);

--- a/src/renderer/viz/expressions/ramp.js
+++ b/src/renderer/viz/expressions/ramp.js
@@ -1,5 +1,5 @@
 import BaseExpression from './base';
-import { implicitCast, checkLooseType, checkExpression, checkType, clamp, checkInstance } from './utils';
+import { implicitCast, checkLooseType, checkExpression, checkType, clamp, checkInstance, checkMaxArguments } from './utils';
 
 import { interpolateRGBAinCieLAB } from '../colorspaces';
 import NamedColor from './color/NamedColor';
@@ -84,6 +84,8 @@ const MAX_BYTE_VALUE = 255;
 */
 export default class Ramp extends BaseExpression {
     constructor (input, palette) {
+        checkMaxArguments(arguments, 2, 'ramp');
+
         input = implicitCast(input);
         palette = implicitCast(palette);
 

--- a/src/renderer/viz/expressions/time.js
+++ b/src/renderer/viz/expressions/time.js
@@ -34,12 +34,15 @@ export default class Time extends BaseExpression {
         this.date = util.castDate(date);
         this.inlineMaker = () => undefined;
     }
+
     get value () {
         return this.eval();
     }
+
     eval () {
         return this.date;
     }
+
     isAnimated () {
         return false;
     }

--- a/src/renderer/viz/expressions/time.js
+++ b/src/renderer/viz/expressions/time.js
@@ -1,5 +1,6 @@
 import BaseExpression from './base';
 import * as util from '../../../utils/util';
+import { checkMaxArguments } from './utils';
 
 /**
  * Time contant expression
@@ -25,6 +26,8 @@ import * as util from '../../../utils/util';
  */
 export default class Time extends BaseExpression {
     constructor (date) {
+        checkMaxArguments(arguments, 1, 'time');
+
         super({});
         // TODO improve type check
         this.type = 'time';

--- a/src/renderer/viz/expressions/top.js
+++ b/src/renderer/viz/expressions/top.js
@@ -1,5 +1,5 @@
 import BaseExpression from './base';
-import { checkType, checkLooseType, implicitCast, checkFeatureIndependent, checkInstance } from './utils';
+import { checkType, checkLooseType, implicitCast, checkFeatureIndependent, checkInstance, checkMaxArguments } from './utils';
 import Property from './basic/property';
 import { number } from '../expressions';
 
@@ -31,6 +31,8 @@ const MAX_TOP_BUCKETS = 16;
  */
 export default class Top extends BaseExpression {
     constructor (property, buckets) {
+        checkMaxArguments(arguments, 2, 'top');
+
         buckets = implicitCast(buckets);
         checkInstance('top', 'property', 0, Property, property);
         checkLooseType('top', 'buckets', 1, 'number', buckets);

--- a/src/renderer/viz/expressions/transition.js
+++ b/src/renderer/viz/expressions/transition.js
@@ -1,5 +1,5 @@
 import BaseExpression from './base';
-import { checkNumber, getStringErrorPreface } from './utils';
+import { checkNumber, checkMaxArguments, getStringErrorPreface } from './utils';
 
 /**
  * Transition returns a number from zero to one based on the elapsed number of milliseconds since the viz was instantiated.
@@ -16,6 +16,7 @@ import { checkNumber, getStringErrorPreface } from './utils';
 // TODO refactor to use uniformfloat class
 export default class Transition extends BaseExpression {
     constructor (duration) {
+        checkMaxArguments(arguments, 1, 'transition');
         checkNumber('transition', 'duration', 0, duration);
         if (duration < 0) {
             throw new Error(getStringErrorPreface('transition', 'duration', 0) + 'duration must be greater than or equal to 0');

--- a/src/renderer/viz/expressions/unary.js
+++ b/src/renderer/viz/expressions/unary.js
@@ -1,4 +1,4 @@
-import { implicitCast, checkLooseType, checkType } from './utils';
+import { implicitCast, checkLooseType, checkType, checkMaxArguments } from './utils';
 import BaseExpression from './base';
 
 /**
@@ -273,6 +273,8 @@ export const Ceil = genUnaryOp('ceil', x => Math.ceil(x), x => `ceil(${x})`);
 function genUnaryOp (name, jsFn, glsl) {
     return class UnaryOperation extends BaseExpression {
         constructor (a) {
+            checkMaxArguments(arguments, 1, name);
+
             a = implicitCast(a);
             checkLooseType(name, 'x', 0, 'number', a);
             super({ a });

--- a/src/renderer/viz/expressions/utils.js
+++ b/src/renderer/viz/expressions/utils.js
@@ -3,6 +3,13 @@ import BaseExpression from './base';
 
 export const DEFAULT = undefined;
 
+export function checkMaxArguments (constructorArguments, maxArguments, expressionName) {
+    if (constructorArguments.length > maxArguments) {
+        console.log('!!!', constructorArguments);
+        throw new Error(`Expression ${expressionName} accepts ${maxArguments} arguments, but ${constructorArguments.length} where passed. `);
+    }
+}
+
 // To support literals (string and numeric) out of the box we need to cast them implicitly on constructors
 export function implicitCast (value) {
     if (_isNumber(value)) {

--- a/src/renderer/viz/expressions/utils.js
+++ b/src/renderer/viz/expressions/utils.js
@@ -5,7 +5,7 @@ export const DEFAULT = undefined;
 
 export function checkMaxArguments (constructorArguments, maxArguments, expressionName) {
     if (constructorArguments.length > maxArguments) {
-        throw new Error(`Expression ${expressionName} accepts ${maxArguments} arguments, but ${constructorArguments.length} where passed.`);
+        throw new Error(`Expression ${expressionName} accepts ${maxArguments} arguments, but ${constructorArguments.length} were passed.`);
     }
 }
 

--- a/src/renderer/viz/expressions/utils.js
+++ b/src/renderer/viz/expressions/utils.js
@@ -5,8 +5,7 @@ export const DEFAULT = undefined;
 
 export function checkMaxArguments (constructorArguments, maxArguments, expressionName) {
     if (constructorArguments.length > maxArguments) {
-        console.log('!!!', constructorArguments);
-        throw new Error(`Expression ${expressionName} accepts ${maxArguments} arguments, but ${constructorArguments.length} where passed. `);
+        throw new Error(`Expression ${expressionName} accepts ${maxArguments} arguments, but ${constructorArguments.length} where passed.`);
     }
 }
 

--- a/src/renderer/viz/expressions/zoom.js
+++ b/src/renderer/viz/expressions/zoom.js
@@ -1,5 +1,6 @@
 import BaseExpression from './base';
 import { number } from '../expressions';
+import { checkMaxArguments } from './utils';
 
 /**
  * Get the current zoom level. Multiplying by zoom() makes features constant in real-world space respect their size at zoom level 0.
@@ -24,6 +25,8 @@ import { number } from '../expressions';
  */
 export default class Zoom extends BaseExpression {
     constructor () {
+        checkMaxArguments(arguments, 0, 'zoom');
+
         super({ zoom: number(0) });
         this.type = 'number';
         super.inlineMaker = inline => inline.zoom;

--- a/test/unit/renderer/viz/expressions/Animation.test.js
+++ b/test/unit/renderer/viz/expressions/Animation.test.js
@@ -1,5 +1,5 @@
 import * as s from '../../../../../src/renderer/viz/expressions';
-import { validateTypeErrors, validateStaticType, validateFeatureDependentErrors } from './utils';
+import { validateTypeErrors, validateStaticType, validateFeatureDependentErrors, validateMaxArgumentsError } from './utils';
 
 describe('src/renderer/viz/expressions/Animation', () => {
     describe('error control', () => {
@@ -8,6 +8,7 @@ describe('src/renderer/viz/expressions/Animation', () => {
         validateTypeErrors('animation', ['number', 10, 'color']);
         validateTypeErrors('animation', ['color', 10]);
         validateTypeErrors('animation', ['number', 'color']);
+        validateMaxArgumentsError('animation', ['number', 'number', 'number', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/Fade.test.js
+++ b/test/unit/renderer/viz/expressions/Fade.test.js
@@ -1,10 +1,11 @@
 import * as s from '../../../../../src/renderer/viz/expressions';
-import { validateTypeErrors, validateStaticType } from './utils';
+import { validateTypeErrors, validateStaticType, validateMaxArgumentsError } from './utils';
 
 describe('src/renderer/viz/expressions/Fade', () => {
     describe('error control', () => {
         validateTypeErrors('fade', ['color']);
         validateTypeErrors('fade', [undefined, 'color']);
+        validateMaxArgumentsError('fade', ['number', 'number', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/aggregation/clusterAggregation.test.js
+++ b/test/unit/renderer/viz/expressions/aggregation/clusterAggregation.test.js
@@ -1,5 +1,5 @@
 import * as s from '../../../../../../src/renderer/viz/expressions';
-import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors } from '../utils';
+import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors, validateMaxArgumentsError } from '../utils';
 
 describe('src/renderer/viz/expressions/clusterAggregation', () => {
     const fakeFeature = {
@@ -23,6 +23,11 @@ describe('src/renderer/viz/expressions/clusterAggregation', () => {
         validateStaticTypeErrors('clusterMax', [0]);
         validateDynamicTypeErrors('clusterMax', ['category']);
         validateDynamicTypeErrors('clusterMode', ['number']);
+        validateMaxArgumentsError('clusterMax', ['number', 'number']);
+        validateMaxArgumentsError('clusterMin', ['number', 'number']);
+        validateMaxArgumentsError('clusterSum', ['number', 'number']);
+        validateMaxArgumentsError('clusterAvg', ['number', 'number']);
+        validateMaxArgumentsError('clusterMode', ['number', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/aggregation/globalAggregation.test.js
+++ b/test/unit/renderer/viz/expressions/aggregation/globalAggregation.test.js
@@ -1,6 +1,16 @@
 import * as s from '../../../../../../src/renderer/viz/expressions';
+import { validateMaxArgumentsError } from '../utils';
 
 describe('src/renderer/viz/expressions/globalAggregation', () => {
+    describe('error control', () => {
+        validateMaxArgumentsError('globalMax', ['number', 'number']);
+        validateMaxArgumentsError('globalMin', ['number', 'number']);
+        validateMaxArgumentsError('globalSum', ['number', 'number']);
+        validateMaxArgumentsError('globalAvg', ['number', 'number']);
+        validateMaxArgumentsError('globalCount', ['number', 'number']);
+        validateMaxArgumentsError('globalPercentile', ['number', 'number', 'number']);
+    });
+
     const $price = s.property('price');
     describe('global filtering', () => {
         const fakeMetadata = {

--- a/test/unit/renderer/viz/expressions/aggregation/viewportAggregation.test.js
+++ b/test/unit/renderer/viz/expressions/aggregation/viewportAggregation.test.js
@@ -1,7 +1,18 @@
 import * as s from '../../../../../../src/renderer/viz/expressions';
 import Metadata from '../../../../../../src/renderer/Metadata';
+import { validateMaxArgumentsError } from '../utils';
 
 describe('src/renderer/viz/expressions/viewportAggregation', () => {
+    describe('error control', () => {
+        validateMaxArgumentsError('viewportMax', ['number', 'number']);
+        validateMaxArgumentsError('viewportMin', ['number', 'number']);
+        validateMaxArgumentsError('viewportSum', ['number', 'number']);
+        validateMaxArgumentsError('viewportAvg', ['number', 'number']);
+        validateMaxArgumentsError('viewportCount', ['number', 'number']);
+        validateMaxArgumentsError('viewportPercentile', ['number', 'number', 'number']);
+        validateMaxArgumentsError('viewportHistogram', ['number', 'number', 'number', 'number']);
+    });
+
     const $price = s.property('price');
     const $nulls = s.property('numeric_with_nulls');
     const $cat = s.property('cat');

--- a/test/unit/renderer/viz/expressions/basic/array.test.js
+++ b/test/unit/renderer/viz/expressions/basic/array.test.js
@@ -1,7 +1,9 @@
 import * as s from '../../../../../../src/renderer/viz/expressions';
+import { validateMaxArgumentsError } from '../utils';
 
 describe('src/renderer/viz/expressions/basic/array', () => {
     describe('error control', () => {
+        validateMaxArgumentsError('array', ['number', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/basic/category.test.js
+++ b/test/unit/renderer/viz/expressions/basic/category.test.js
@@ -1,5 +1,5 @@
 import * as s from '../../../../../../src/renderer/viz/expressions';
-import { validateStaticType, validateStaticTypeErrors } from '../utils';
+import { validateStaticType, validateStaticTypeErrors, validateMaxArgumentsError } from '../utils';
 import Metadata from '../../../../../../src/renderer/Metadata';
 
 describe('src/renderer/viz/expressions/basic/category', () => {
@@ -8,6 +8,7 @@ describe('src/renderer/viz/expressions/basic/category', () => {
         validateStaticTypeErrors('category', [undefined]);
         validateStaticTypeErrors('category', [123]);
         validateStaticTypeErrors('category', ['number']);
+        validateMaxArgumentsError('category', ['number', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/basic/constant.test.js
+++ b/test/unit/renderer/viz/expressions/basic/constant.test.js
@@ -1,10 +1,11 @@
 import * as s from '../../../../../../src/renderer/viz/expressions';
-import { validateStaticType, validateStaticTypeErrors } from '../utils';
+import { validateStaticType, validateStaticTypeErrors, validateMaxArgumentsError } from '../utils';
 
 describe('src/renderer/viz/expressions/basic/constant', () => {
     describe('error control', () => {
         validateStaticTypeErrors('number', [undefined]);
         validateStaticTypeErrors('number', ['123']);
+        validateMaxArgumentsError('number', ['number', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/basic/constant.test.js
+++ b/test/unit/renderer/viz/expressions/basic/constant.test.js
@@ -5,7 +5,6 @@ describe('src/renderer/viz/expressions/basic/constant', () => {
     describe('error control', () => {
         validateStaticTypeErrors('number', [undefined]);
         validateStaticTypeErrors('number', ['123']);
-        validateStaticTypeErrors('number', ['color', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/basic/number.test.js
+++ b/test/unit/renderer/viz/expressions/basic/number.test.js
@@ -5,7 +5,6 @@ describe('src/renderer/viz/expressions/basic/number', () => {
     describe('error control', () => {
         validateStaticTypeErrors('number', [undefined]);
         validateStaticTypeErrors('number', ['123']);
-        validateStaticTypeErrors('number', ['color', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/basic/number.test.js
+++ b/test/unit/renderer/viz/expressions/basic/number.test.js
@@ -1,10 +1,11 @@
 import * as s from '../../../../../../src/renderer/viz/expressions';
-import { validateStaticType, validateStaticTypeErrors } from '../utils';
+import { validateStaticType, validateStaticTypeErrors, validateMaxArgumentsError } from '../utils';
 
 describe('src/renderer/viz/expressions/basic/number', () => {
     describe('error control', () => {
         validateStaticTypeErrors('number', [undefined]);
         validateStaticTypeErrors('number', ['123']);
+        validateMaxArgumentsError('number', ['123', '123']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/basic/property.test.js
+++ b/test/unit/renderer/viz/expressions/basic/property.test.js
@@ -1,5 +1,5 @@
 import * as s from '../../../../../../src/renderer/viz/expressions';
-import { validateStaticTypeErrors } from '../utils';
+import { validateStaticTypeErrors, validateMaxArgumentsError } from '../utils';
 
 describe('src/renderer/viz/expressions/basic/property', () => {
     describe('error control', () => {
@@ -7,6 +7,7 @@ describe('src/renderer/viz/expressions/basic/property', () => {
         validateStaticTypeErrors('property', [undefined]);
         validateStaticTypeErrors('property', [123]);
         validateStaticTypeErrors('property', ['number']);
+        validateMaxArgumentsError('property', ['number', 'number']);
     });
 
     describe('.eval', () => {

--- a/test/unit/renderer/viz/expressions/basic/variable.test.js
+++ b/test/unit/renderer/viz/expressions/basic/variable.test.js
@@ -1,4 +1,4 @@
-import { validateStaticTypeErrors } from '../utils';
+import { validateStaticTypeErrors, validateMaxArgumentsError } from '../utils';
 
 describe('src/renderer/viz/expressions/basic/variable', () => {
     describe('error control', () => {
@@ -6,5 +6,6 @@ describe('src/renderer/viz/expressions/basic/variable', () => {
         validateStaticTypeErrors('variable', [undefined]);
         validateStaticTypeErrors('variable', [123]);
         validateStaticTypeErrors('variable', ['number']);
+        validateMaxArgumentsError('variable', ['number', 'number']);
     });
 });

--- a/test/unit/renderer/viz/expressions/belongs.test.js
+++ b/test/unit/renderer/viz/expressions/belongs.test.js
@@ -1,6 +1,6 @@
 import Metadata from '../../../../../src/renderer/Metadata';
 import * as s from '../../../../../src/renderer/viz/expressions';
-import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors } from './utils';
+import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors, validateMaxArgumentsError } from './utils';
 
 describe('src/renderer/viz/expressions/belongs', () => {
     const fakeMetadata = new Metadata({
@@ -26,6 +26,8 @@ describe('src/renderer/viz/expressions/belongs', () => {
         validateStaticTypeErrors('in', ['color']);
         validateDynamicTypeErrors('in', ['number', 'category-array']);
         validateDynamicTypeErrors('in', ['category', 'number-array']);
+        validateMaxArgumentsError('in', ['category', 'category-array', 'number']);
+        validateMaxArgumentsError('nin', ['category', 'category-array', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/between.test.js
+++ b/test/unit/renderer/viz/expressions/between.test.js
@@ -1,5 +1,5 @@
 import * as s from '../../../../../src/renderer/viz/expressions';
-import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors } from './utils';
+import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors, validateMaxArgumentsError } from './utils';
 
 describe('src/renderer/viz/expressions/between', () => {
     describe('error control', () => {
@@ -8,6 +8,7 @@ describe('src/renderer/viz/expressions/between', () => {
         validateDynamicTypeErrors('between', ['number', 'number', 'category']);
         validateStaticTypeErrors('between', ['number', 'number', 'color']);
         validateStaticTypeErrors('between', ['color', 'number', 'color']);
+        validateMaxArgumentsError('between', ['number', 'number', 'number', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/binary.test.js
+++ b/test/unit/renderer/viz/expressions/binary.test.js
@@ -1,5 +1,5 @@
 import * as s from '../../../../../src/renderer/viz/expressions';
-import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors, validateDynamicType } from './utils';
+import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors, validateDynamicType, validateMaxArgumentsError } from './utils';
 
 // Add custom toString function to improve test output.
 s.TRUE.toString = () => 's.TRUE';
@@ -10,8 +10,8 @@ describe('src/renderer/viz/expressions/binary', () => {
         describe('Signature NUMBERS_TO_NUMBER | NUMBER_AND_COLOR_TO_COLOR | COLORS_TO_COLOR', () => {
             validateDynamicTypeErrors('mul', ['number', 'category']);
             validateDynamicTypeErrors('mul', ['category', 'number']);
-
             validateDynamicTypeErrors('mul', ['category', 'category']);
+            validateMaxArgumentsError('mul', ['number', 'number', 'number']);
         });
 
         describe('Signature NUMBERS_TO_NUMBER | COLORS_TO_COLOR', () => {
@@ -22,6 +22,8 @@ describe('src/renderer/viz/expressions/binary', () => {
 
             validateDynamicTypeErrors('add', ['number', 'color']);
             validateDynamicTypeErrors('add', ['color', 'number']);
+
+            validateMaxArgumentsError('add', ['number', 'number', 'number']);
         });
 
         describe('Signature NUMBERS_TO_NUMBER', () => {
@@ -34,6 +36,8 @@ describe('src/renderer/viz/expressions/binary', () => {
             validateDynamicTypeErrors('mod', ['color', 'number']);
 
             validateStaticTypeErrors('mod', ['color', 'color']);
+
+            validateMaxArgumentsError('mod', ['number', 'number', 'number']);
         });
 
         describe('Signature NUMBERS_TO_NUMBER | CATEGORIES_TO_NUMBER', () => {
@@ -44,6 +48,8 @@ describe('src/renderer/viz/expressions/binary', () => {
             validateDynamicTypeErrors('equals', ['color', 'number']);
 
             validateStaticTypeErrors('equals', ['color', 'color']);
+
+            validateMaxArgumentsError('equals', ['number', 'number', 'number']);
         });
     });
 

--- a/test/unit/renderer/viz/expressions/blend.test.js
+++ b/test/unit/renderer/viz/expressions/blend.test.js
@@ -1,5 +1,5 @@
 import * as s from '../../../../../src/renderer/viz/expressions';
-import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors, validateDynamicType } from './utils';
+import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors, validateDynamicType, validateMaxArgumentsError } from './utils';
 
 describe('src/renderer/viz/expressions/blend', () => {
     describe('error control', () => {
@@ -11,6 +11,7 @@ describe('src/renderer/viz/expressions/blend', () => {
         validateDynamicTypeErrors('blend', ['category', 'number', 'number']);
         validateDynamicTypeErrors('blend', ['number', 'category', 'number']);
         validateDynamicTypeErrors('blend', ['number', 'number', 'category']);
+        validateMaxArgumentsError('blend', ['number', 'number', 'number', 'number', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/buckets.test.js
+++ b/test/unit/renderer/viz/expressions/buckets.test.js
@@ -1,4 +1,4 @@
-import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors } from './utils';
+import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors, validateMaxArgumentsError } from './utils';
 import * as s from '../../../../../src/renderer/viz/expressions';
 import Metadata from '../../../../../src/renderer/Metadata';
 
@@ -8,6 +8,7 @@ describe('src/renderer/viz/expressions/buckets', () => {
         validateDynamicTypeErrors('buckets', ['category', 'number-array']);
         validateStaticTypeErrors('buckets', ['color', 'number-array']);
         validateStaticTypeErrors('buckets', ['number', 'color-array']);
+        validateMaxArgumentsError('buckets', ['number', 'number-array', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/classifier.test.js
+++ b/test/unit/renderer/viz/expressions/classifier.test.js
@@ -2,7 +2,8 @@ import {
     validateDynamicTypeErrors,
     validateStaticType,
     validateStaticTypeErrors,
-    validateCompileTypeError
+    validateCompileTypeError,
+    validateMaxArgumentsError
 } from './utils';
 
 import {
@@ -22,24 +23,28 @@ describe('src/renderer/viz/expressions/classifier', () => {
         validateCompileTypeError('viewportQuantiles', ['category', 2]);
         validateCompileTypeError('viewportQuantiles', ['color', 2]);
         validateCompileTypeError('viewportQuantiles', ['number', 'color']);
+        validateMaxArgumentsError('viewportQuantiles', ['number', 'number-array', 'number']);
 
         validateCompileTypeError('viewportEqIntervals', []);
         validateCompileTypeError('viewportEqIntervals', ['number', 'category']);
         validateCompileTypeError('viewportEqIntervals', ['category', 2]);
         validateCompileTypeError('viewportEqIntervals', ['color', 2]);
         validateCompileTypeError('viewportEqIntervals', ['number', 'color']);
+        validateMaxArgumentsError('viewportEqIntervals', ['number', 'number-array', 'number']);
 
         validateStaticTypeErrors('globalQuantiles', []);
         validateStaticTypeErrors('globalQuantiles', ['number', 'category']);
         validateDynamicTypeErrors('globalQuantiles', ['category', 2]);
         validateStaticTypeErrors('globalQuantiles', ['color', 2]);
         validateStaticTypeErrors('globalQuantiles', ['number', 'color']);
+        validateMaxArgumentsError('globalQuantiles', ['number', 'number-array', 'number']);
 
         validateStaticTypeErrors('globalEqIntervals', []);
         validateStaticTypeErrors('globalEqIntervals', ['number', 'category']);
         validateDynamicTypeErrors('globalEqIntervals', ['category', 2]);
         validateStaticTypeErrors('globalEqIntervals', ['color', 2]);
         validateStaticTypeErrors('globalEqIntervals', ['number', 'color']);
+        validateMaxArgumentsError('globalEqIntervals', ['number', 'number-array', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/color/NamedColor.test.js
+++ b/test/unit/renderer/viz/expressions/color/NamedColor.test.js
@@ -1,4 +1,4 @@
-import { validateStaticType, validateStaticTypeErrors } from '../utils';
+import { validateStaticType, validateStaticTypeErrors, validateMaxArgumentsError } from '../utils';
 import { namedColor } from '../../../../../../src/renderer/viz/expressions';
 
 describe('src/core/viz/expressions/NamedColor', () => {
@@ -10,6 +10,7 @@ describe('src/core/viz/expressions/NamedColor', () => {
         validateStaticType('namedColor', ['blue'], 'color');
         validateStaticType('namedColor', ['AliceBlue'], 'color');
         validateStaticType('namedColor', ['BLACK'], 'color');
+        validateMaxArgumentsError('namedColor', ['blue', 'red']);
     });
 
     describe('.value', () => {

--- a/test/unit/renderer/viz/expressions/color/cielab.test.js
+++ b/test/unit/renderer/viz/expressions/color/cielab.test.js
@@ -1,4 +1,4 @@
-import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors } from '../utils';
+import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors, validateMaxArgumentsError } from '../utils';
 
 describe('src/renderer/viz/expressions/cielab', () => {
     describe('error control', () => {
@@ -10,6 +10,8 @@ describe('src/renderer/viz/expressions/cielab', () => {
 
         validateStaticTypeErrors('cielab', ['number', 'number', 'color']);
         validateStaticTypeErrors('cielab', ['color', 'number', 'number']);
+
+        validateMaxArgumentsError('cielab', ['number', 'number', 'number', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/color/hex.test.js
+++ b/test/unit/renderer/viz/expressions/color/hex.test.js
@@ -1,4 +1,4 @@
-import { validateStaticType, validateStaticTypeErrors } from '../utils';
+import { validateStaticType, validateStaticTypeErrors, validateMaxArgumentsError } from '../utils';
 import { hex } from '../../../../../../src/renderer/viz/expressions';
 
 describe('src/renderer/viz/expressions/hex', () => {
@@ -7,6 +7,7 @@ describe('src/renderer/viz/expressions/hex', () => {
         validateStaticTypeErrors('hex', ['number']);
         validateStaticTypeErrors('hex', ['category']);
         validateStaticTypeErrors('hex', ['#Z08080']);
+        validateMaxArgumentsError('hex', ['#Z08080', 'extraParam']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/color/hsl.test.js
+++ b/test/unit/renderer/viz/expressions/color/hsl.test.js
@@ -1,4 +1,4 @@
-import { validateStaticType, validateStaticTypeErrors } from '../utils';
+import { validateStaticType, validateStaticTypeErrors, validateMaxArgumentsError } from '../utils';
 import { hsl, hsla } from '../../../../../../src/renderer/viz/expressions';
 
 describe('src/renderer/viz/expressions/hsl', () => {
@@ -7,8 +7,8 @@ describe('src/renderer/viz/expressions/hsl', () => {
         validateStaticTypeErrors('hsl', ['number']);
         validateStaticTypeErrors('hsl', ['number', 'category']);
         validateStaticTypeErrors('hsl', ['number', 'number', 'color']);
-
-        validateStaticTypeErrors('hsla', ['number', 'number', 'number']);
+        validateMaxArgumentsError('hsl', ['number', 'number', 'number', 'number', 'number']);
+        validateMaxArgumentsError('hsla', ['number', 'number', 'number', 'number', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/color/hsv.test.js
+++ b/test/unit/renderer/viz/expressions/color/hsv.test.js
@@ -1,4 +1,4 @@
-import { validateStaticType, validateStaticTypeErrors } from '../utils';
+import { validateStaticType, validateStaticTypeErrors, validateMaxArgumentsError } from '../utils';
 import { hsv, hsva } from '../../../../../../src/renderer/viz/expressions';
 
 describe('src/renderer/viz/expressions/hsv', () => {
@@ -7,8 +7,9 @@ describe('src/renderer/viz/expressions/hsv', () => {
         validateStaticTypeErrors('hsv', ['number']);
         validateStaticTypeErrors('hsv', ['number', 'category']);
         validateStaticTypeErrors('hsv', ['number', 'number', 'color']);
-
         validateStaticTypeErrors('hsva', ['number', 'number', 'number']);
+        validateMaxArgumentsError('hsv', ['number', 'number', 'number', 'number', 'number']);
+        validateMaxArgumentsError('hsva', ['number', 'number', 'number', 'number', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/color/opacity.test.js
+++ b/test/unit/renderer/viz/expressions/color/opacity.test.js
@@ -1,4 +1,4 @@
-import { validateStaticType, validateStaticTypeErrors, validateDynamicTypeErrors } from '../utils';
+import { validateStaticType, validateStaticTypeErrors, validateDynamicTypeErrors, validateMaxArgumentsError } from '../utils';
 import { opacity, rgba, mul, variable, rgb } from '../../../../../../src/renderer/viz/expressions';
 
 describe('src/renderer/viz/expressions/opacity', () => {
@@ -7,6 +7,7 @@ describe('src/renderer/viz/expressions/opacity', () => {
         validateStaticTypeErrors('opacity', ['number']);
         validateDynamicTypeErrors('opacity', ['number', 'number']);
         validateDynamicTypeErrors('opacity', ['color', 'category']);
+        validateMaxArgumentsError('opacity', ['red', 'number', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/color/rgb.test.js
+++ b/test/unit/renderer/viz/expressions/color/rgb.test.js
@@ -1,4 +1,4 @@
-import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors } from '../utils';
+import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors, validateMaxArgumentsError } from '../utils';
 import { rgb, rgba } from '../../../../../../src/renderer/viz/expressions';
 
 describe('src/renderer/viz/expressions/rgb', () => {
@@ -10,6 +10,7 @@ describe('src/renderer/viz/expressions/rgb', () => {
         validateStaticTypeErrors('rgb', []);
         validateStaticTypeErrors('rgb', ['number', 'number']);
         validateDynamicTypeErrors('rgb', ['number', 'number', 'category']);
+        validateMaxArgumentsError('rgb', ['number', 'number', 'number', 'number', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/image.test.js
+++ b/test/unit/renderer/viz/expressions/image.test.js
@@ -1,4 +1,4 @@
-import { validateStaticType, validateStaticTypeErrors } from './utils';
+import { validateStaticType, validateStaticTypeErrors, validateMaxArgumentsError } from './utils';
 
 describe('src/renderer/viz/expressions/image', () => {
     describe('error control', () => {
@@ -8,6 +8,7 @@ describe('src/renderer/viz/expressions/image', () => {
         validateStaticTypeErrors('image', ['color']);
         validateStaticTypeErrors('image', ['category-property']);
         validateStaticTypeErrors('image', ['color-array']);
+        validateMaxArgumentsError('image', ['number', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/linear.test.js
+++ b/test/unit/renderer/viz/expressions/linear.test.js
@@ -1,5 +1,5 @@
 import * as s from '../../../../../src/renderer/viz/expressions';
-import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors } from './utils';
+import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors, validateMaxArgumentsError } from './utils';
 import GlobalMin from '../../../../../src/renderer/viz/expressions/aggregation/global/GlobalMin';
 import GlobalMax from '../../../../../src/renderer/viz/expressions/aggregation/global/GlobalMax';
 
@@ -11,6 +11,7 @@ describe('src/renderer/viz/expressions/linear', () => {
         validateStaticTypeErrors('linear', ['number', 'color', 'number']);
         validateDynamicTypeErrors('linear', ['category', 'number', 'number']);
         validateDynamicTypeErrors('linear', ['number', 'number', 'category']);
+        validateMaxArgumentsError('linear', ['number', 'number', 'number', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/ordering.test.js
+++ b/test/unit/renderer/viz/expressions/ordering.test.js
@@ -1,5 +1,5 @@
 import * as s from '../../../../../src/renderer/viz/expressions';
-import { validateStaticType, validateStaticTypeErrors } from './utils';
+import { validateStaticType, validateStaticTypeErrors, validateMaxArgumentsError } from './utils';
 
 describe('src/renderer/viz/expressions/ordering', () => {
     describe('error control', () => {
@@ -7,11 +7,15 @@ describe('src/renderer/viz/expressions/ordering', () => {
         validateStaticTypeErrors('asc', [undefined]);
         validateStaticTypeErrors('asc', [123]);
         validateStaticTypeErrors('asc', ['number']);
+        validateMaxArgumentsError('asc', ['number', 'number']);
 
         validateStaticTypeErrors('desc', []);
         validateStaticTypeErrors('desc', [undefined]);
         validateStaticTypeErrors('desc', [123]);
         validateStaticTypeErrors('desc', ['number']);
+        validateMaxArgumentsError('desc', ['number', 'number']);
+
+        validateMaxArgumentsError('noOrder', ['number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/ramp.test.js
+++ b/test/unit/renderer/viz/expressions/ramp.test.js
@@ -1,4 +1,4 @@
-import { validateStaticType, validateStaticTypeErrors, validateDynamicTypeErrors } from './utils';
+import { validateStaticType, validateStaticTypeErrors, validateDynamicTypeErrors, validateMaxArgumentsError } from './utils';
 import * as cartocolor from 'cartocolor';
 import { ramp, buckets, palettes, globalQuantiles, linear, namedColor, property, rgb, now, sin } from '../../../../../src/renderer/viz/expressions';
 import { hexToRgb } from '../../../../../src/renderer/viz/expressions/utils';
@@ -12,6 +12,7 @@ describe('src/renderer/viz/expressions/ramp', () => {
         validateStaticTypeErrors('ramp', ['number']);
         validateStaticTypeErrors('ramp', ['category']);
         validateDynamicTypeErrors('ramp', ['number', 'image-array']);
+        validateMaxArgumentsError('ramp', ['number', 'color-array', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/time.test.js
+++ b/test/unit/renderer/viz/expressions/time.test.js
@@ -1,6 +1,11 @@
 import Time from '../../../../../src/renderer/viz/expressions/time';
+import { validateMaxArgumentsError } from './utils';
 
 describe('src/renderer/viz/expressions/time', () => {
+    describe('error control', () => {
+        validateMaxArgumentsError('time', ['date', 'date']);
+    });
+
     const expectedDate = new Date('2016-05-30T13:45:00+05:00');
     it('should return a valid date when the parameter is a ISO_8601 string', () => {
         const time = new Time('2016-05-30T13:45:00+05:00');

--- a/test/unit/renderer/viz/expressions/top.test.js
+++ b/test/unit/renderer/viz/expressions/top.test.js
@@ -1,4 +1,4 @@
-import { validateTypeErrors, validateStaticType, validateFeatureDependentErrors } from './utils';
+import { validateTypeErrors, validateStaticType, validateFeatureDependentErrors, validateMaxArgumentsError } from './utils';
 import * as s from '../../../../../src/renderer/viz/expressions';
 
 describe('src/renderer/viz/expressions/top', () => {
@@ -6,7 +6,9 @@ describe('src/renderer/viz/expressions/top', () => {
         validateFeatureDependentErrors('top', ['category-property', 'dependent']);
         validateTypeErrors('top', ['number', 10]);
         validateTypeErrors('top', ['color', 10]);
+        validateMaxArgumentsError('top', ['category', 10, 'number']);
     });
+
     describe('type', () => {
         validateStaticType('top', ['category-property', 5], 'category');
     });

--- a/test/unit/renderer/viz/expressions/transition.test.js
+++ b/test/unit/renderer/viz/expressions/transition.test.js
@@ -1,5 +1,5 @@
 import * as s from '../../../../../src/renderer/viz/expressions';
-import { validateStaticType, validateStaticTypeErrors } from './utils';
+import { validateStaticType, validateStaticTypeErrors, validateMaxArgumentsError } from './utils';
 
 describe('src/renderer/viz/expressions/transition', () => {
     describe('error control', () => {
@@ -9,6 +9,7 @@ describe('src/renderer/viz/expressions/transition', () => {
         validateStaticTypeErrors('transition', ['number']);
         validateStaticTypeErrors('transition', ['color']);
         validateStaticTypeErrors('transition', ['category']);
+        validateMaxArgumentsError('transition', ['number', 'number']);
     });
 
     describe('type', () => {

--- a/test/unit/renderer/viz/expressions/unary.test.js
+++ b/test/unit/renderer/viz/expressions/unary.test.js
@@ -1,5 +1,5 @@
 import * as s from '../../../../../src/renderer/viz/expressions';
-import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors } from './utils';
+import { validateDynamicTypeErrors, validateStaticType, validateStaticTypeErrors, validateMaxArgumentsError } from './utils';
 
 // Add custom toString function to improve test output.
 s.TRUE.toString = () => 's.TRUE';
@@ -10,6 +10,19 @@ describe('src/renderer/viz/expressions/unary', () => {
         describe('Signature NUMBERS_TO_NUMBER', () => {
             validateDynamicTypeErrors('sin', ['category']);
             validateStaticTypeErrors('sin', ['color']);
+
+            validateMaxArgumentsError('sin', ['number', 'number']);
+            validateMaxArgumentsError('ceil', ['number', 'number']);
+            validateMaxArgumentsError('log', ['number', 'number']);
+            validateMaxArgumentsError('cos', ['number', 'number']);
+            validateMaxArgumentsError('sqrt', ['number', 'number']);
+            validateMaxArgumentsError('tan', ['number', 'number']);
+            validateMaxArgumentsError('sign', ['number', 'number']);
+            validateMaxArgumentsError('abs', ['number', 'number']);
+            validateMaxArgumentsError('isNaN', ['number', 'number']);
+            validateMaxArgumentsError('not', ['number', 'number']);
+            validateMaxArgumentsError('floor', ['number', 'number']);
+            validateMaxArgumentsError('isNaN', ['number', 'number']);
         });
     });
 

--- a/test/unit/renderer/viz/expressions/utils.js
+++ b/test/unit/renderer/viz/expressions/utils.js
@@ -84,6 +84,14 @@ export function validateCompileTypeError (expressionName, argTypes) {
     _validateCompileTimeTypeError(expressionName, simpleArgs);
 }
 
+export function validateMaxArgumentsError (expressionName, args) {
+    it(`${expressionName}(${args.map(arg => arg[1]).join(', ')}) should throw at compile time`, () => {
+        expect(() => {
+            s[expressionName](...args.map(arg => arg[0]));
+        }).toThrowError(new RegExp(`[\\s\\S]*${expressionName}[\\s\\S]*accepts.*arguments[\\s\\S]*passed[\\s\\S]*`, 'g'));
+    });
+}
+
 function equalArgs (argsA, argsB) {
     if (argsA.length !== argsB.length) {
         return false;

--- a/test/unit/renderer/viz/expressions/zoom.test.js
+++ b/test/unit/renderer/viz/expressions/zoom.test.js
@@ -1,7 +1,8 @@
-import { validateStaticType } from './utils';
+import { validateStaticType, validateMaxArgumentsError } from './utils';
 
 describe('src/renderer/viz/expressions/zoom', () => {
     describe('type', () => {
         validateStaticType('zoom', [], 'number');
+        validateMaxArgumentsError('zoom', ['number']);
     });
 });


### PR DESCRIPTION
Related with https://github.com/CartoDB/carto-vl/issues/675

# Description

This PR adds a check function that throws an error if the number of arguments passed to an expression exceeds the max number of arguments needed.

## TODO

* [x] Add check function for every expression
* [x] Test all the expressions