### PR TITLE
Fix interactivity when layer is updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "cartocolor": "^4.0.0",
     "earcut": "^2.1.2",
     "jsep": "CartoDB/jsep#additional-char-ids-packaged",
+    "lodash.debounce": "^4.0.8",
     "lru-cache": "^4.1.1",
     "mitt": "^1.1.3",
     "pbf": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "cartocolor": "^4.0.0",
     "earcut": "^2.1.2",
     "jsep": "CartoDB/jsep#additional-char-ids-packaged",
-    "lodash.debounce": "^4.0.8",
     "lru-cache": "^4.1.1",
     "mitt": "^1.1.3",
     "pbf": "^3.1.0"

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -64,7 +64,6 @@ export default class Layer {
         this._checkViz(viz);
         this._oldDataframes = new Set();
         this._isInitialized = false;
-        this._isAnimated = false;
         this._init(id, source, viz);
     }
 
@@ -173,8 +172,6 @@ export default class Layer {
     async update (source, viz) {
         this._checkSource(source);
         this._checkViz(viz);
-
-        this._isAnimated = viz.isAnimated();
 
         source = source._clone();
         this._atomicChangeUID = this._atomicChangeUID + 1 || 1;
@@ -337,7 +334,7 @@ export default class Layer {
     }
 
     isAnimated () {
-        return this._isAnimated;
+        return this._viz && this._viz.isAnimated();
     }
 
     /**
@@ -472,8 +469,6 @@ export default class Layer {
         if (!this._source) {
             throw new Error('A source is required before changing the viz');
         }
-
-        this._isAnimated = viz.isAnimated();
 
         const source = this._source;
         const loadImagesPromise = viz.loadImages();

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -64,6 +64,7 @@ export default class Layer {
         this._checkViz(viz);
         this._oldDataframes = new Set();
         this._isInitialized = false;
+        this._isAnimated = false;
         this._init(id, source, viz);
     }
 
@@ -172,6 +173,9 @@ export default class Layer {
     async update (source, viz) {
         this._checkSource(source);
         this._checkViz(viz);
+
+        this._isAnimated = viz.isAnimated();
+
         source = source._clone();
         this._atomicChangeUID = this._atomicChangeUID + 1 || 1;
         const uid = this._atomicChangeUID;
@@ -332,6 +336,10 @@ export default class Layer {
             : [];
     }
 
+    isAnimated () {
+        return this._isAnimated;
+    }
+
     /**
      * Change layer visibility to visible
      *
@@ -464,6 +472,9 @@ export default class Layer {
         if (!this._source) {
             throw new Error('A source is required before changing the viz');
         }
+
+        this._isAnimated = viz.isAnimated();
+
         const source = this._source;
         const loadImagesPromise = viz.loadImages();
         const metadata = await source.requestMetadata(viz);

--- a/src/integrator/Map.js
+++ b/src/integrator/Map.js
@@ -62,7 +62,7 @@ export default class Map {
 
         this._layers.forEach((layer) => {
             const hasData = layer.hasDataframes();
-            const hasAnimation = layer.getViz() && layer.getViz().isAnimated();
+            const hasAnimation = layer.isAnimated();
 
             if (hasData || hasAnimation) {
                 layer.$paintCallback();

--- a/src/integrator/mapbox-gl.js
+++ b/src/integrator/mapbox-gl.js
@@ -80,8 +80,7 @@ class MGLIntegrator {
             this._paintedLayers++;
 
             // Last layer has been painted
-            const isAnimated = this._layers.some(layer =>
-                layer.getViz() && layer.getViz().isAnimated());
+            const isAnimated = this._layers.some(layer => layer.isAnimated());
             // Checking this.map.repaint is needed, because MGL repaint is a setter and it has the strange quite buggy side-effect of doing a "final" repaint after being disabled
             // if we disable it every frame, MGL will do a "final" repaint every frame, which will not disabled it in practice
             if (!isAnimated && this.map.repaint) {

--- a/src/interactivity/Interactivity.js
+++ b/src/interactivity/Interactivity.js
@@ -175,9 +175,7 @@ export default class Interactivity {
             // Debounce `updated` event calls
             // - Delay: 60 ms
             // - Maximum delay: 100 ms
-            layer.on('updated', _.debounce(() => {
-                this._onLayerUpdated(layer.isAnimated());
-            }, 60, { maxWait: 100 }));
+            layer.on('updated', _.debounce(this._onLayerUpdated.bind(this), 60, { maxWait: 100 }));
         });
     }
 
@@ -186,10 +184,8 @@ export default class Interactivity {
         integrator.on('click', this._onClick.bind(this));
     }
 
-    _onLayerUpdated (isAnimated) {
-        if (isAnimated) {
-            this._onMouseMove(this._mouseEvent, true);
-        }
+    _onLayerUpdated () {
+        this._onMouseMove(this._mouseEvent, true);
     }
 
     _onMouseMove (event, force) {

--- a/src/interactivity/Interactivity.js
+++ b/src/interactivity/Interactivity.js
@@ -188,11 +188,10 @@ export default class Interactivity {
     }
 
     _onMouseMove (event, force) {
-        if (event) {
-            this._mouseEvent = event;
-        }
+        // Store mouse event to be used in `onLayerUpdated`
+        this._mouseEvent = event;
 
-        if (!this._mouseEvent ||
+        if (!event ||
             (!this._numListeners['featureEnter'] &&
              !this._numListeners['featureHover'] &&
              !this._numListeners['featureLeave'])) {

--- a/src/interactivity/Interactivity.js
+++ b/src/interactivity/Interactivity.js
@@ -172,10 +172,11 @@ export default class Interactivity {
     }
 
     _subscribeToLayerEvents (layers) {
-        let animatedLayers = layers.filter(layer => layer && layer.isAnimated());
-        if (animatedLayers.length) {
-            animatedLayers[0].on('updated', this._onLayerUpdated.bind(this));
-        }
+        layers.forEach(layer => {
+            layer.on('updated', () => {
+                this._onLayerUpdated(layer.isAnimated());
+            });
+        });
     }
 
     _subscribeToIntegratorEvents (integrator) {
@@ -183,17 +184,21 @@ export default class Interactivity {
         integrator.on('click', this._onClick.bind(this));
     }
 
-    _onLayerUpdated () {
-        this._updateCalls++;
-        // Debounce calls to fire the events
-        if (this._updateCalls > BATCH_UPDATE_CALLS) {
-            this._updateCalls = 0;
-            this._onMouseMove(this._mouseEvent);
+    _onLayerUpdated (isAnimated) {
+        if (isAnimated) {
+            this._updateCalls++;
+            // Debounce calls to fire the events
+            if (this._updateCalls > BATCH_UPDATE_CALLS) {
+                this._updateCalls = 0;
+                this._onMouseMove(this._mouseEvent);
+            }
         }
     }
 
     _onMouseMove (event) {
-        this._mouseEvent = event;
+        if (event) {
+            this._mouseEvent = event;
+        }
 
         if (!this._mouseEvent ||
             (!this._numListeners['featureEnter'] &&

--- a/src/interactivity/Interactivity.js
+++ b/src/interactivity/Interactivity.js
@@ -183,7 +183,7 @@ export default class Interactivity {
         this._onMouseMove(this._mouseEvent, true);
     }
 
-    _onMouseMove (event, force) {
+    _onMouseMove (event, emulated) {
         // Store mouse event to be used in `onLayerUpdated`
         this._mouseEvent = event;
 
@@ -221,7 +221,7 @@ export default class Interactivity {
 
         // If the event comes from a real mouse move, trigger always (because coordinates and position have changed)
         // If the event comes from an animated event, trigger only when features have changed (because position is the same)
-        if (!force || (force && (featuresLeft.length || featuresEntered.length))) {
+        if (!emulated || (emulated && (featuresLeft.length || featuresEntered.length))) {
             // Launch hover event
             this._fireEvent('featureHover', featureEvent);
         }

--- a/src/interactivity/Interactivity.js
+++ b/src/interactivity/Interactivity.js
@@ -143,7 +143,6 @@ export default class Interactivity {
         this._prevHoverFeatures = [];
         this._prevClickFeatures = [];
         this._numListeners = {};
-        this._updateCalls = 0;
         return Promise.all(layerList.map(layer => layer._context)).then(() => {
             postCheckLayerList(layerList);
             this._subscribeToLayerEvents(layerList);

--- a/src/interactivity/Interactivity.js
+++ b/src/interactivity/Interactivity.js
@@ -2,7 +2,6 @@ import mitt from 'mitt';
 import Layer from '../Layer';
 import { WM_R, projectToWebMercator } from '../utils/util';
 import { wToR } from '../client/rsys';
-import * as _ from 'lodash';
 
 /**
  *
@@ -171,10 +170,7 @@ export default class Interactivity {
 
     _subscribeToLayerEvents (layers) {
         layers.forEach(layer => {
-            // Debounce `updated` event calls
-            // - Delay: 60 ms
-            // - Maximum delay: 100 ms
-            layer.on('updated', _.debounce(this._onLayerUpdated.bind(this), 60, { maxWait: 100 }));
+            layer.on('updated', this._onLayerUpdated.bind(this));
         });
     }
 

--- a/src/interactivity/Interactivity.js
+++ b/src/interactivity/Interactivity.js
@@ -176,7 +176,7 @@ export default class Interactivity {
             // - Delay: 60 ms
             // - Maximum delay: 100 ms
             layer.on('updated', _.debounce(() => {
-                this._onLayerUpdated(layer);
+                this._onLayerUpdated(layer.isAnimated());
             }, 60, { maxWait: 100 }));
         });
     }
@@ -186,13 +186,13 @@ export default class Interactivity {
         integrator.on('click', this._onClick.bind(this));
     }
 
-    _onLayerUpdated (layer) {
-        if (layer.isAnimated()) {
-            this._onMouseMove(this._mouseEvent);
+    _onLayerUpdated (isAnimated) {
+        if (isAnimated) {
+            this._onMouseMove(this._mouseEvent, true);
         }
     }
 
-    _onMouseMove (event) {
+    _onMouseMove (event, force) {
         if (event) {
             this._mouseEvent = event;
         }
@@ -227,10 +227,14 @@ export default class Interactivity {
             });
         }
 
-        this._prevHoverFeatures = featureEvent.features;
+        this._prevHoverFeatures = currentFeatures;
 
-        // Launch hover event
-        this._fireEvent('featureHover', featureEvent);
+        // If the event comes from a real mouse move, trigger always (because coordinates and position have changed)
+        // If the event comes from an animated event, trigger only when features have changed (because position is the same)
+        if (!force || (force && (featuresLeft.length || featuresEntered.length))) {
+            // Launch hover event
+            this._fireEvent('featureHover', featureEvent);
+        }
     }
 
     _onClick (event) {

--- a/test/integration/user/test/interactivity.test.js
+++ b/test/integration/user/test/interactivity.test.js
@@ -1,6 +1,5 @@
 import * as carto from '../../../../src';
 import * as util from '../../util';
-import * as _ from 'lodash';
 
 // More info: https://github.com/CartoDB/carto-vl/wiki/Interactivity-tests
 
@@ -200,10 +199,11 @@ describe('Interactivity', () => {
         });
     });
 
-    describe('when the user move the mouse on the map', () => {
+    describe('when the user moves the mouse on the map', () => {
         describe('and the mouse enters in a feature', () => {
             it('should fire a featureHover event with a features list containing the entered feature', done => {
                 interactivity.on('featureHover', event => {
+                    expect(event.features.length).toBe(1);
                     expect(event.features[0].id).toEqual(-0);
                     expect(event.features[0].layerId).toEqual('layer1');
                     done();
@@ -216,6 +216,7 @@ describe('Interactivity', () => {
 
             it('should fire a featureEnter event with a features list containing the entered feature', done => {
                 interactivity.on('featureEnter', event => {
+                    expect(event.features.length).toBe(1);
                     expect(event.features[0].id).toEqual(-0);
                     expect(event.features[0].layerId).toEqual('layer1');
                     done();
@@ -243,28 +244,16 @@ describe('Interactivity', () => {
         });
 
         describe('and the mouse leaves a feature', () => {
-            it('should fire a featureHover event with an empty features list', done => {
+            it('should fire a featureLeave event with a features list containing the previously entered feature', done => {
                 onLoaded(() => {
                     // Move mouse inside a feature 1
                     util.simulateMove({ lng: 5, lat: 5 });
-                    interactivity.on('featureHover', event => {
-                        expect(event.features.length).toEqual(0);
-                        done();
-                    });
-                    // Move mouse outside any feature (over a feature 1 hole)
-                    util.simulateMove({ lng: 15, lat: 15 });
-                });
-            });
-
-            it('should fire a featureLeave event with a features list containing the previously entered feature', done => {
-                onLoaded(() => {
                     interactivity.on('featureLeave', event => {
+                        expect(event.features.length).toBe(1);
                         expect(event.features[0].id).toEqual(-0);
                         expect(event.features[0].layerId).toEqual('layer1');
                         done();
                     });
-                    // Move mouse inside a feature 1
-                    util.simulateMove({ lng: 5, lat: 5 });
                     // Move mouse outside any feature
                     util.simulateMove({ lng: -5, lat: -5 });
                 });
@@ -280,14 +269,14 @@ describe('Interactivity', () => {
                         expect(featureLeaveSpy).not.toHaveBeenCalled();
                         done();
                     });
-                    // Move mouse outside any feature
-                    util.simulateMove({ lng: -10, lat: -10 });
+                    // Move mouse outside any feature (over a feature 1 hole)
+                    util.simulateMove({ lng: 15, lat: 15 });
                 });
             });
         });
     });
 
-    describe('when there is an animated layer', () => {
+    describe('when the layer changes', () => {
         describe('and appears a feature below the mouse', () => {
             it('should fire a featureHover event with the feature 1', done => {
                 onLoaded(() => {
@@ -298,17 +287,14 @@ describe('Interactivity', () => {
 
                     // Register event after move to be called by layer `updated`
                     interactivity.on('featureHover', event => {
-                        // Restore filter
-                        viz1.filter = 1;
-
                         expect(event.features.length).toBe(1);
                         expect(event.features[0].id).toEqual(-0);
                         expect(event.features[0].layerId).toEqual('layer1');
                         done();
                     });
 
-                    // Animate layer: show feature
-                    viz1.filter = carto.expressions.now();
+                    // Show feature
+                    viz1.filter = 1;
                 });
             });
         });

--- a/test/integration/user/test/interactivity.test.js
+++ b/test/integration/user/test/interactivity.test.js
@@ -197,89 +197,114 @@ describe('Interactivity', () => {
                 });
             });
         });
+    });
 
-        describe('when the user move the mouse on the map', () => {
-            describe('and the mouse enters in a feature', () => {
-                it('should fire a featureHover event with a features list containing the entered feature', done => {
-                    interactivity.on('featureHover', event => {
-                        expect(event.features[0].id).toEqual(-0);
-                        expect(event.features[0].layerId).toEqual('layer1');
-                        done();
-                    });
-                    onLoaded(() => {
-                        // Move mouse inside a feature 1
-                        util.simulateMove({ lng: 5, lat: 5 });
-                    });
+    describe('when the user move the mouse on the map', () => {
+        describe('and the mouse enters in a feature', () => {
+            it('should fire a featureHover event with a features list containing the entered feature', done => {
+                interactivity.on('featureHover', event => {
+                    expect(event.features[0].id).toEqual(-0);
+                    expect(event.features[0].layerId).toEqual('layer1');
+                    done();
                 });
-
-                it('should fire a featureEnter event with a features list containing the entered feature', done => {
-                    interactivity.on('featureEnter', event => {
-                        expect(event.features[0].id).toEqual(-0);
-                        expect(event.features[0].layerId).toEqual('layer1');
-                        done();
-                    });
-                    onLoaded(() => {
-                        // Move mouse inside a feature 1
-                        util.simulateMove({ lng: 5, lat: 5 });
-                    });
-                });
-
-                it('should not fire a featureEnter event when the mouse is moved inside the same feature', done => {
-                    const featureEnterSpy = jasmine.createSpy('featureEnterSpy');
-                    onLoaded(() => {
-                        interactivity.on('featureEnter', featureEnterSpy);
-                        // Move mouse inside a feature 1
-                        util.simulateMove({ lng: 5, lat: 5 });
-                        // Move mouse inside the same feature 1
-                        util.simulateMove({ lng: 5, lat: 15 });
-                        setTimeout(() => {
-                            expect(featureEnterSpy).toHaveBeenCalledTimes(1);
-                            done();
-                        }, 0);
-                    });
+                onLoaded(() => {
+                    // Move mouse inside a feature 1
+                    util.simulateMove({ lng: 5, lat: 5 });
                 });
             });
 
-            describe('and the mouse leaves a feature', () => {
-                it('should fire a featureHover event with an empty features list', done => {
-                    onLoaded(() => {
-                        // Move mouse inside a feature 1
-                        util.simulateMove({ lng: 5, lat: 5 });
-                        interactivity.on('featureHover', event => {
-                            expect(event.features.length).toEqual(0);
-                            done();
-                        });
-                        // Move mouse outside any feature (over a feature 1 hole)
-                        util.simulateMove({ lng: 15, lat: 15 });
-                    });
+            it('should fire a featureEnter event with a features list containing the entered feature', done => {
+                interactivity.on('featureEnter', event => {
+                    expect(event.features[0].id).toEqual(-0);
+                    expect(event.features[0].layerId).toEqual('layer1');
+                    done();
                 });
-
-                it('should fire a featureLeave event with a features list containing the previously entered feature', done => {
-                    onLoaded(() => {
-                        interactivity.on('featureLeave', event => {
-                            expect(event.features[0].id).toEqual(-0);
-                            expect(event.features[0].layerId).toEqual('layer1');
-                            done();
-                        });
-                        // Move mouse inside a feature 1
-                        util.simulateMove({ lng: 5, lat: 5 });
-                        // Move mouse outside any feature
-                        util.simulateMove({ lng: -5, lat: -5 });
-                    });
+                onLoaded(() => {
+                    // Move mouse inside a feature 1
+                    util.simulateMove({ lng: 5, lat: 5 });
                 });
+            });
 
-                it('should not fire a featureLeave event when the mouse is moved outside any feature', done => {
-                    layer2.on('loaded', () => {
-                        const featureLeaveSpy = jasmine.createSpy('featureLeaveSpy');
-                        // Move mouse outside any feature
-                        util.simulateMove({ lng: -5, lat: -5 });
-                        interactivity.on('featureLeave', featureLeaveSpy);
-                        interactivity.on('featureHover', () => {
-                            expect(featureLeaveSpy).not.toHaveBeenCalled();
-                            done();
-                        });
-                        // Move mouse outside any feature
-                        util.simulateMove({ lng: -10, lat: -10 });
+            it('should not fire a featureEnter event when the mouse is moved inside the same feature', done => {
+                const featureEnterSpy = jasmine.createSpy('featureEnterSpy');
+                onLoaded(() => {
+                    interactivity.on('featureEnter', featureEnterSpy);
+                    // Move mouse inside a feature 1
+                    util.simulateMove({ lng: 5, lat: 5 });
+                    // Move mouse inside the same feature 1
+                    util.simulateMove({ lng: 5, lat: 15 });
+                    setTimeout(() => {
+                        expect(featureEnterSpy).toHaveBeenCalledTimes(1);
+                        done();
+                    }, 0);
+                });
+            });
+        });
+
+        describe('and the mouse leaves a feature', () => {
+            it('should fire a featureHover event with an empty features list', done => {
+                onLoaded(() => {
+                    // Move mouse inside a feature 1
+                    util.simulateMove({ lng: 5, lat: 5 });
+                    interactivity.on('featureHover', event => {
+                        expect(event.features.length).toEqual(0);
+                        done();
+                    });
+                    // Move mouse outside any feature (over a feature 1 hole)
+                    util.simulateMove({ lng: 15, lat: 15 });
+                });
+            });
+
+            it('should fire a featureLeave event with a features list containing the previously entered feature', done => {
+                onLoaded(() => {
+                    interactivity.on('featureLeave', event => {
+                        expect(event.features[0].id).toEqual(-0);
+                        expect(event.features[0].layerId).toEqual('layer1');
+                        done();
+                    });
+                    // Move mouse inside a feature 1
+                    util.simulateMove({ lng: 5, lat: 5 });
+                    // Move mouse outside any feature
+                    util.simulateMove({ lng: -5, lat: -5 });
+                });
+            });
+
+            it('should not fire a featureLeave event when the mouse is moved outside any feature', done => {
+                layer2.on('loaded', () => {
+                    const featureLeaveSpy = jasmine.createSpy('featureLeaveSpy');
+                    // Move mouse outside any feature
+                    util.simulateMove({ lng: -5, lat: -5 });
+                    interactivity.on('featureLeave', featureLeaveSpy);
+                    interactivity.on('featureHover', () => {
+                        expect(featureLeaveSpy).not.toHaveBeenCalled();
+                        done();
+                    });
+                    // Move mouse outside any feature
+                    util.simulateMove({ lng: -10, lat: -10 });
+                });
+            });
+        });
+    });
+
+    describe('when there is an animated layer', () => {
+        describe('and appears a feature below the mouse', () => {
+            it('should fire a featureHover event with the feature 1', done => {
+                onLoaded(() => {
+                    // Setup initial mouse position
+                    util.simulateMove({ lng: 5, lat: 5 });
+
+                    // Animate layer
+                    viz1.width = carto.expressions.now();
+
+                    // Register event after move to be called by layer `updated`
+                    interactivity.on('featureHover', event => {
+                        // Restore static layer
+                        viz1.width = 0;
+
+                        expect(event.features.length).toBe(1);
+                        expect(event.features[0].id).toEqual(-0);
+                        expect(event.features[0].layerId).toEqual('layer1');
+                        done();
                     });
                 });
             });

--- a/test/integration/user/test/interactivity.test.js
+++ b/test/integration/user/test/interactivity.test.js
@@ -1,5 +1,6 @@
 import * as carto from '../../../../src';
 import * as util from '../../util';
+import * as _ from 'lodash';
 
 // More info: https://github.com/CartoDB/carto-vl/wiki/Interactivity-tests
 
@@ -290,22 +291,24 @@ describe('Interactivity', () => {
         describe('and appears a feature below the mouse', () => {
             it('should fire a featureHover event with the feature 1', done => {
                 onLoaded(() => {
+                    // Hide feature
+                    viz1.filter = 0;
                     // Setup initial mouse position
                     util.simulateMove({ lng: 5, lat: 5 });
 
-                    // Animate layer
-                    viz1.width = carto.expressions.now();
-
                     // Register event after move to be called by layer `updated`
                     interactivity.on('featureHover', event => {
-                        // Restore static layer
-                        viz1.width = 0;
+                        // Restore filter
+                        viz1.filter = 1;
 
                         expect(event.features.length).toBe(1);
                         expect(event.features[0].id).toEqual(-0);
                         expect(event.features[0].layerId).toEqual('layer1');
                         done();
                     });
+
+                    // Animate layer: show feature
+                    viz1.filter = carto.expressions.now();
                 });
             });
         });


### PR DESCRIPTION
Related to https://github.com/CartoDB/carto-vl/issues/853

Events `featureHover`, `featureEnter`, `featureLeave` are fired when the animated feature changes at the current mouse position.

![animated-featureevents](https://user-images.githubusercontent.com/2227572/44275149-4130e780-a244-11e8-8c83-5c91f2367292.gif)
