### PR TITLE
Add get legend method to ramp expression

### DIFF
--- a/examples/misc/legends.html
+++ b/examples/misc/legends.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <!-- Include CARTO VL JS -->
+  <script src="../../dist/carto-vl.js"></script>
+  <!-- Include Mapbox GL JS -->
+  <script src="https://libs.cartocdn.com/mapbox-gl/v0.45.0-carto1/mapbox-gl.js"></script>
+  <!-- Include Mapbox GL CSS -->
+  <link href="https://libs.cartocdn.com/mapbox-gl/v0.45.0-carto1/mapbox-gl.css" rel="stylesheet" />
+  <!-- Make the map visible -->
+  <link rel="stylesheet" type="text/css" href="../style.css">
+</head>
+
+<body>
+  <!-- Map goes here -->
+  <div id="map"></div>
+  <aside class="toolbox">
+    <div class="box">
+      <header>
+        <h1>Legend</h1>
+      </header>
+      <section>
+        <div id="controls">
+          <ul id="content"></ul>
+        </div>
+      </section>
+      <footer class="js-footer"></footer>
+    </div>
+  </aside>
+  <div id="loader">
+    <div class="CDB-LoaderIcon CDB-LoaderIcon--big">
+      <svg class="CDB-LoaderIcon-spinner" viewBox="0 0 50 50">
+        <circle class="CDB-LoaderIcon-path" cx="25" cy="25" r="20" fill="none"></circle>
+      </svg>
+    </div>
+  </div>
+
+  <script>
+    const map = new mapboxgl.Map({
+      container: 'map',
+      style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
+      center: [0, 30],
+      zoom: 1,
+      dragRotate: false,
+    });
+    map.touchZoomRotate.disableRotation();
+
+    // Autenticate the client
+    carto.setDefaultAuth({
+      user: 'cartovl',
+      apiKey: 'default_public'
+    });
+    // Create the source
+    const source = new carto.source.Dataset('ne_10m_populated_places_simple');
+    // Create an empty viz
+    const viz = new carto.Viz(`
+      color: ramp($adm0_a3, PRISM)
+    `);
+    // Create the layer
+    const layer = new carto.Layer('layer', source, viz);
+    layer.addTo(map, 'watername_ocean');
+    layer.on('loaded', () => {
+      hideLoader();
+      const colorLegend = layer.getViz().color.getLegend();
+      let colorLegendList = '';
+
+      colorLegend.forEach((category) => {
+        const colorHex = rgbToHex(category.value);
+        colorLegendList +=
+          `<li><span class="color-mark" style="background-color:${colorHex};"></span> <span>${category.name}</span></li>\n`;
+      });
+
+      document.getElementById('content').innerHTML = colorLegendList;
+    });
+
+    function hideLoader() {
+      document.getElementById('loader').style.opacity = '0';
+    }
+
+    function rgbToHex(color) {
+      return "#" + ((1 << 24) + (color.r << 16) + (color.g << 8) + color.b).toString(16).slice(1);
+    }
+
+  </script>
+</body>
+
+</html>

--- a/src/renderer/viz/expressions/Image.js
+++ b/src/renderer/viz/expressions/Image.js
@@ -32,7 +32,7 @@ export default class Image extends Base {
         super({});
         this.type = 'image';
         this.canvas = null;
-        this._url = url;
+        this.url = url;
         this._promise = new Promise((resolve, reject) => {
             this.image = new window.Image();
             this.image.onload = () => {
@@ -42,7 +42,7 @@ export default class Image extends Base {
             };
             this.image.onerror = reject;
             this.image.crossOrigin = 'anonymous';
-            this.image.src = this._url;
+            this.image.src = this.url;
         });
     }
 

--- a/src/renderer/viz/expressions/base.js
+++ b/src/renderer/viz/expressions/base.js
@@ -100,8 +100,9 @@ export default class Base {
     }
 
     getCategories () {
-        if (this.input) {
-            return this.input.getCategories();
+        const children = this._getChildren();
+        if (children) {
+            return children[0].getCategories();
         }
     }
 

--- a/src/renderer/viz/expressions/base.js
+++ b/src/renderer/viz/expressions/base.js
@@ -99,6 +99,12 @@ export default class Base {
         return this instanceof expressionClass;
     }
 
+    getCategories () {
+        if (this.input) {
+            return this.input.getCategories();
+        }
+    }
+
     notify () {
         this.parent.notify();
     }

--- a/src/renderer/viz/expressions/basic/property.js
+++ b/src/renderer/viz/expressions/basic/property.js
@@ -63,10 +63,12 @@ export default class Property extends BaseExpression {
         if (!metaColumn) {
             throw new Error(`Property '${this.name}' does not exist`);
         }
+
         this.type = metaColumn.type;
 
         if (this.type === 'category') {
             this.numCategories = metaColumn.categories.length;
+            this.categories = metaColumn.categories;
         }
     }
 

--- a/src/renderer/viz/expressions/basic/property.js
+++ b/src/renderer/viz/expressions/basic/property.js
@@ -58,6 +58,12 @@ export default class Property extends BaseExpression {
         return feature[this.name];
     }
 
+    getCategories () {
+        return this.type === 'category'
+            ? this.categories
+            : [];
+    }
+
     _bindMetadata (meta) {
         const metaColumn = meta.properties[this.name];
         if (!metaColumn) {

--- a/src/renderer/viz/expressions/ramp.js
+++ b/src/renderer/viz/expressions/ramp.js
@@ -121,7 +121,7 @@ export default class Ramp extends BaseExpression {
     eval (feature) {
         this.palette = this._calcPaletteValues(this.palette);
 
-        const texturePixels = this._computeTextureIfNeeded(); 
+        const texturePixels = this._computeTextureIfNeeded();
         const input = this.input.eval(feature);
         const numValues = texturePixels.length - 1;
         const m = (input - this.minKey) / (this.maxKey - this.minKey);

--- a/src/renderer/viz/expressions/ramp.js
+++ b/src/renderer/viz/expressions/ramp.js
@@ -133,7 +133,26 @@ export default class Ramp extends BaseExpression {
         return color;
     }
 
-    getValue (index) {
+    getLegend () {
+        if (this.input.type === inputTypes.CATEGORY) {
+            return this.input.categories.map(this._getLegendCategoryValue);
+        }
+    }
+
+    _getLegendCategoryValue (category, index) {
+        return {
+            name: this._getCategoryName(category),
+            value: this._getRampValueByIndex(index)
+        };
+    }
+
+    _getRampValueByIndex (index) {
+        if (this.palette.type === paletteTypes.IMAGE) {
+            return this.palette[`image${index}`]
+                ? this.palette[`image${index}`].url
+                : null;
+        }
+
         this.palette = this._calcPaletteValues(this.palette);
 
         const texturePixels = this._computeTextureIfNeeded();
@@ -148,14 +167,9 @@ export default class Ramp extends BaseExpression {
         return color;
     }
 
-    getLegend () {
-        if (this.input.type === inputTypes.CATEGORY) {
-            const legend = this.input.categories.map((category, index) => {
-                return { name: category.name, color: this.getValue(index) };
-            });
-
-            return legend;
-        }
+    _getCategoryName (category) {
+        const DEFAULT_OTHERS_NAME = 'Others';
+        return category.name ? category.name : DEFAULT_OTHERS_NAME;
     }
 
     _getPaletteValues () {

--- a/src/renderer/viz/expressions/ramp.js
+++ b/src/renderer/viz/expressions/ramp.js
@@ -133,6 +133,78 @@ export default class Ramp extends BaseExpression {
         return color;
     }
 
+    /**
+     * Get the value associated with each category
+     *
+     * @returns {Array} Array of { name, value } objects
+     *
+     * @example <caption>Get the color associated with each category</caption>
+     * const s = carto.expressions;
+     * const viz = new carto.Viz({
+     *   color: s.ramp(s.prop('vehicles'), s.palettes.PRISM)
+     * });
+     *
+     * layer.on('loaded', () => {
+     *   const legend = layer.getViz().color.getLegend();
+     *   // legend = [
+     *   //   { name: 'Bicycle', value: { r: 95, g: 70, b: 144, a: 1 } },
+     *   //   { name: 'Car', value: { r: 29, g: 105, b: 150, a: 1 } }
+     *   //   { name: 'Bus', value: { r: 56, g: 166, b: 165, a: 1 } }
+     *   //   { name: 'Others', value: { r: 15, g: 133, b: 84, a: 1 } }
+     *   // ]
+     * });
+     *
+     * @example <caption>Get the color associated with each category (String)</caption>
+     * const s = carto.expressions;
+     * const viz = new carto.Viz(`
+     *   color: ramp($vehicles, PRISM)
+     * ´);
+     *
+     * layer.on('loaded', () => {
+     *   const legend = layer.getViz().color.getLegend();
+     *   // legend = [
+     *   //   { name: 'Bicycle', value: { r: 95, g: 70, b: 144, a: 1 } },
+     *   //   { name: 'Car', value: { r: 29, g: 105, b: 150, a: 1 } }
+     *   //   { name: 'Bus', value: { r: 56, g: 166, b: 165, a: 1 } }
+     *   //   { name: 'Others', value: { r: 15, g: 133, b: 84, a: 1 } }
+     *   // ]
+     * });
+     *
+     * @example <caption>Get the image url associated with each category</caption>
+     * const s = carto.expressions;
+     * const viz = new carto.Viz({
+     *   symbol: s.ramp(s.prop('vehicles'), s.imageList([s.BICYCLE, s.CAR, s.BUS]))
+     * });
+     *
+     * layer.on('loaded', () => {
+     *   const legend = layer.getViz().symbol.getLegend();
+     *   // legend = [
+     *   //   { name: 'Bicycle', value: bicycleImageUrl },
+     *   //   { name: 'Car', value: carImageUrl }
+     *   //   { name: 'Bus', value: busImageUrl }
+     *   // ]
+     * });
+     *
+     * @example <caption>Get the image url associated with each category (String)</caption>
+     * const s = carto.expressions;
+     * const viz = new carto.Viz(`
+     *   symbol: ramp('$vehicles'), imageList([BICYCLE, CAR, BUS]))
+     * `);
+     *
+     * layer.on('loaded', () => {
+     *   const legend = layer.getViz().symbol.getLegend();
+     *   // legend = [
+     *   //   { name: 'Bicycle', value: bicycleImageUrl },
+     *   //   { name: 'Car', value: carImageUrl }
+     *   //   { name: 'Bus', value: busImageUrl }
+     *   // ]
+     * });
+     *
+     * @memberof carto.expressions.Ramp
+     * @name getLegend
+     * @instance
+     * @api
+     */
     getLegend () {
         if (this.input.isA(Linear)) {
             return this._computeTextureIfNeeded();

--- a/src/renderer/viz/expressions/ramp.js
+++ b/src/renderer/viz/expressions/ramp.js
@@ -134,8 +134,12 @@ export default class Ramp extends BaseExpression {
     }
 
     getLegend () {
+        if (this.input.isA(Linear)) {
+            return this._computeTextureIfNeeded();
+        }
+
         if (this.input.type === inputTypes.CATEGORY) {
-            return this.input.categories.map(this._getLegendCategoryValue);
+            return this.input.getCategories().map(this._getLegendCategoryValue.bind(this));
         }
     }
 
@@ -170,15 +174,6 @@ export default class Ramp extends BaseExpression {
     _getCategoryName (category) {
         const DEFAULT_OTHERS_NAME = 'Others';
         return category.name ? category.name : DEFAULT_OTHERS_NAME;
-    }
-
-    _getPaletteValues () {
-        switch (this.palette.type) {
-            case paletteTypes.PALETTE:
-                return _getSubPalettes(this.palette, this.input.numCategories);
-            default:
-                return this.palette.colors;
-        }
     }
 
     _getValue (texturePixels, numValues, m) {

--- a/src/renderer/viz/expressions/ramp.js
+++ b/src/renderer/viz/expressions/ramp.js
@@ -121,9 +121,8 @@ export default class Ramp extends BaseExpression {
     eval (feature) {
         this.palette = this._calcPaletteValues(this.palette);
 
-        const texturePixels = this._computeTextureIfNeeded();
+        const texturePixels = this._computeTextureIfNeeded(); 
         const input = this.input.eval(feature);
-
         const numValues = texturePixels.length - 1;
         const m = (input - this.minKey) / (this.maxKey - this.minKey);
 
@@ -132,6 +131,40 @@ export default class Ramp extends BaseExpression {
             : this._getColorValue(texturePixels, m);
 
         return color;
+    }
+
+    getValue (index) {
+        this.palette = this._calcPaletteValues(this.palette);
+
+        const texturePixels = this._computeTextureIfNeeded();
+        const input = index;
+        const numValues = texturePixels.length - 1;
+        const m = (input - this.minKey) / (this.maxKey - this.minKey);
+
+        const color = this.type === rampTypes.NUMBER
+            ? this._getValue(texturePixels, numValues, m)
+            : this._getColorValue(texturePixels, m);
+
+        return color;
+    }
+
+    getLegend () {
+        if (this.input.type === inputTypes.CATEGORY) {
+            const legend = this.input.categories.map((category, index) => {
+                return { name: category.name, color: this.getValue(index) };
+            });
+
+            return legend;
+        }
+    }
+
+    _getPaletteValues () {
+        switch (this.palette.type) {
+            case paletteTypes.PALETTE:
+                return _getSubPalettes(this.palette, this.input.numCategories);
+            default:
+                return this.palette.colors;
+        }
     }
 
     _getValue (texturePixels, numValues, m) {
@@ -170,6 +203,7 @@ export default class Ramp extends BaseExpression {
             checkInstance('ramp', 'palette', 1, ImageList, this.palette);
         }
 
+        this._properties = metadata.properties;
         this._texCategories = null;
         this._GLtexCategories = null;
     }

--- a/test/unit/renderer/viz/expressions/ramp.test.js
+++ b/test/unit/renderer/viz/expressions/ramp.test.js
@@ -1,6 +1,6 @@
 import { validateStaticType, validateStaticTypeErrors, validateDynamicTypeErrors, validateMaxArgumentsError } from './utils';
 import * as cartocolor from 'cartocolor';
-import { ramp, buckets, palettes, globalQuantiles, linear, namedColor, property, rgb, now, sin } from '../../../../../src/renderer/viz/expressions';
+import { ramp, buckets, palettes, globalQuantiles, linear, namedColor, property, rgb, now, sin, imageList, BICYCLE, CAR, BUILDING } from '../../../../../src/renderer/viz/expressions';
 import { hexToRgb } from '../../../../../src/renderer/viz/expressions/utils';
 import Metadata from '../../../../../src/renderer/Metadata';
 
@@ -25,6 +25,21 @@ describe('src/renderer/viz/expressions/ramp', () => {
 
     describe('.eval', () => {
         describe('when palettes are color arrays', () => {
+            const METADATA = new Metadata({
+                properties: {
+                    grade: {
+                        type: 'category',
+                        categories: [
+                            { name: 'A' },
+                            { name: 'B' },
+                            { name: 'C' },
+                            { name: 'D' },
+                            { name: 'E' }
+                        ]
+                    }
+                }
+            });
+
             describe('and values are numeric', () => {
                 const values = [31, 57];
                 let actual;
@@ -33,7 +48,7 @@ describe('src/renderer/viz/expressions/ramp', () => {
                 it('should get the first value', () => {
                     const r = ramp(0, values);
 
-                    r._bindMetadata();
+                    r._bindMetadata(METADATA);
                     actual = r.eval();
                     expected = values[0];
 
@@ -43,7 +58,7 @@ describe('src/renderer/viz/expressions/ramp', () => {
                 it('should be able to get the second value', () => {
                     const r = ramp(1, values);
 
-                    r._bindMetadata();
+                    r._bindMetadata(METADATA);
                     actual = r.eval();
                     expected = values[1];
 
@@ -60,7 +75,7 @@ describe('src/renderer/viz/expressions/ramp', () => {
                 it('should get the first value', () => {
                     const r = ramp(0, [firstColor, secondColor]);
 
-                    r._bindMetadata();
+                    r._bindMetadata(METADATA);
                     actual = r.eval();
                     expected = firstColor.color;
 
@@ -70,7 +85,7 @@ describe('src/renderer/viz/expressions/ramp', () => {
                 it('should get the second value', () => {
                     const r = ramp(1, [firstColor, secondColor]);
 
-                    r._bindMetadata();
+                    r._bindMetadata(METADATA);
                     actual = r.eval();
                     expected = secondColor.color;
 
@@ -295,6 +310,21 @@ describe('src/renderer/viz/expressions/ramp', () => {
             });
 
             describe('when categories are quantitative', () => {
+                const METADATA = new Metadata({
+                    properties: {
+                        grade: {
+                            type: 'category',
+                            categories: [
+                                { name: 'A' },
+                                { name: 'B' },
+                                { name: 'C' },
+                                { name: 'D' },
+                                { name: 'E' }
+                            ]
+                        }
+                    }
+                });
+
                 const red = namedColor('red');
                 const blue = namedColor('blue');
                 const yellow = namedColor('yellow');
@@ -313,7 +343,7 @@ describe('src/renderer/viz/expressions/ramp', () => {
                     it('should not show interpolation', () => {
                         r = ramp(buckets(1, RANGES), COLORS);
 
-                        r._bindMetadata();
+                        r._bindMetadata(METADATA);
                         actual = r.eval();
                         expected = COLORS[0].color;
 
@@ -321,7 +351,7 @@ describe('src/renderer/viz/expressions/ramp', () => {
 
                         r = ramp(buckets(11, RANGES), COLORS);
 
-                        r._bindMetadata();
+                        r._bindMetadata(METADATA);
                         actual = r.eval();
                         expected = COLORS[1].color;
 
@@ -329,7 +359,7 @@ describe('src/renderer/viz/expressions/ramp', () => {
 
                         r = ramp(buckets(21, RANGES), COLORS);
 
-                        r._bindMetadata();
+                        r._bindMetadata(METADATA);
                         actual = r.eval();
                         expected = COLORS[2].color;
 
@@ -339,7 +369,7 @@ describe('src/renderer/viz/expressions/ramp', () => {
                     it('should ignore the remaining colors and use the last color for the rest of the buckets', () => {
                         r = ramp(buckets(31, RANGES), COLORS);
 
-                        r._bindMetadata();
+                        r._bindMetadata(METADATA);
                         actual = r.eval();
                         expected = orange.color;
                     });
@@ -356,7 +386,7 @@ describe('src/renderer/viz/expressions/ramp', () => {
                     it('should not show interpolation', () => {
                         r = ramp(buckets(1, RANGES), COLORS);
 
-                        r._bindMetadata();
+                        r._bindMetadata(METADATA);
                         actual = r.eval();
                         expected = COLORS[0].color;
 
@@ -364,7 +394,7 @@ describe('src/renderer/viz/expressions/ramp', () => {
 
                         r = ramp(buckets(11, RANGES), COLORS);
 
-                        r._bindMetadata();
+                        r._bindMetadata(METADATA);
                         actual = r.eval();
                         expected = COLORS[1].color;
 
@@ -372,7 +402,7 @@ describe('src/renderer/viz/expressions/ramp', () => {
 
                         r = ramp(buckets(21, RANGES), COLORS);
 
-                        r._bindMetadata();
+                        r._bindMetadata(METADATA);
                         actual = r.eval();
                         expected = COLORS[2].color;
 
@@ -382,7 +412,7 @@ describe('src/renderer/viz/expressions/ramp', () => {
                     it('should use the last color for the rest of the buckets', () => {
                         r = ramp(buckets(31, RANGES), COLORS);
 
-                        r._bindMetadata();
+                        r._bindMetadata(METADATA);
                         actual = r.eval();
                         expected = yellow.color;
                     });
@@ -399,7 +429,7 @@ describe('src/renderer/viz/expressions/ramp', () => {
                     it('should show interpolation', () => {
                         r = ramp(buckets(1, RANGES), COLORS);
 
-                        r._bindMetadata();
+                        r._bindMetadata(METADATA);
                         actual = r.eval();
                         expected = COLORS[0].color;
 
@@ -407,7 +437,7 @@ describe('src/renderer/viz/expressions/ramp', () => {
 
                         r = ramp(buckets(11, RANGES), COLORS);
 
-                        r._bindMetadata();
+                        r._bindMetadata(METADATA);
                         actual = r.eval();
                         expected = COLORS[1].color;
 
@@ -415,7 +445,7 @@ describe('src/renderer/viz/expressions/ramp', () => {
 
                         r = ramp(buckets(21, RANGES), COLORS);
 
-                        r._bindMetadata();
+                        r._bindMetadata(METADATA);
                         actual = r.eval();
                         expected = COLORS[2].color;
 
@@ -425,7 +455,7 @@ describe('src/renderer/viz/expressions/ramp', () => {
                     it('should use the default color for the rest', () => {
                         r = ramp(buckets(51, RANGES), COLORS);
 
-                        r._bindMetadata();
+                        r._bindMetadata(METADATA);
                         actual = r.eval();
                         expected = DEFAULT_COLOR.color;
 
@@ -948,6 +978,135 @@ describe('src/renderer/viz/expressions/ramp', () => {
                         expect(actual).not.toEqual(expected);
                     });
                 });
+            });
+        });
+    });
+
+    describe('.getLegend', () => {
+        describe('when it is a linear input', () => {
+            const METADATA = new Metadata({
+                properties: {
+                    price: { type: 'number', min: 1, max: 13 }
+                },
+                sample: [
+                    { price: 1 },
+                    { price: 2 },
+                    { price: 3 },
+                    { price: 4 },
+                    { price: 5 },
+                    { price: 6 },
+                    { price: 7 },
+                    { price: 8 },
+                    { price: 9 },
+                    { price: 10 },
+                    { price: 11 },
+                    { price: 12 },
+                    { price: 13 }
+                ]
+            });
+
+            const red = namedColor('red');
+            const blue = namedColor('blue');
+            const yellow = namedColor('yellow');
+            const $price = property('price');
+            let actual;
+            let expected;
+
+            it('should return the 1024 interpolated colors', () => {
+                const r = ramp(linear($price), [red, blue, yellow]);
+
+                r._bindMetadata(METADATA);
+
+                actual = r.getLegend().length;
+                expected = 1024;
+
+                expect(actual).toEqual(expected);
+            });
+        });
+
+        describe('when palette is a color array', () => {
+            const METADATA = new Metadata({
+                properties: {
+                    grade: {
+                        type: 'category',
+                        categories: [
+                            { name: 'A' },
+                            { name: 'B' },
+                            { name: 'C' }
+                        ]
+                    }
+                }
+            });
+
+            let actual;
+            let expected;
+            let $grade = property('grade');
+
+            it('should return the value and the color for each category', () => {
+                const r = ramp(buckets($grade, ['A', 'B', 'C']), imageList([BICYCLE, CAR, BUILDING]));
+
+                r._bindMetadata(METADATA);
+
+                actual = r.getLegend();
+                expected = [
+                    {
+                        name: 'A',
+                        value: BICYCLE.url
+                    }, {
+                        name: 'B',
+                        value: CAR.url
+                    }, {
+                        name: 'C',
+                        value: BUILDING.url
+                    }
+                ];
+
+                expect(actual).toEqual(expected);
+            });
+        });
+
+        describe('when palette is an image array', () => {
+            const METADATA = new Metadata({
+                properties: {
+                    grade: {
+                        type: 'category',
+                        categories: [
+                            { name: 'A' },
+                            { name: 'B' },
+                            { name: 'C' }
+                        ]
+                    }
+                }
+            });
+
+            const red = namedColor('red');
+            const blue = namedColor('blue');
+            const yellow = namedColor('yellow');
+
+            let actual;
+            let expected;
+            let $grade = property('grade');
+
+            it('should return the value and the image url for each category', () => {
+                const r = ramp(buckets($grade, ['A', 'B', 'C']), [red, blue, yellow]);
+
+                r._bindMetadata(METADATA);
+
+                actual = r.getLegend();
+                expected = [
+                    {
+                        name: 'A',
+                        value: red.color
+                    }, {
+                        name: 'B',
+                        value: blue.color
+                    }, {
+                        name: 'C',
+                        value: yellow.color
+                    }
+                ];
+
+                expect(actual).toEqual(expected);
             });
         });
     });


### PR DESCRIPTION
Related with https://github.com/CartoDB/carto-vl/issues/572

This PR adds the `getLegend()` method to the ramp expression. There is an example added (http://127.0.0.1:8080/examples/misc/legends.html), but we need a better example (cc @makella ❤️).

* Code
```js
const s = carto.expressions;
const viz = new carto.Viz({
  color: s.ramp(s.prop('vehicles'), s.palettes.PRISM)
});

layer.on('loaded', () => {
  const legend = layer.getViz().color.getLegend();
  // legend = [
  //   { name: 'Bicycle', value: { r: 95, g: 70, b: 144, a: 1 } },
  //   { name: 'Car', value: { r: 29, g: 105, b: 150, a: 1 } }
  //   { name: 'Bus', value: { r: 56, g: 166, b: 165, a: 1 } }
  //   { name: 'Others', value: { r: 15, g: 133, b: 84, a: 1 } }
  // ]
});
```

* Preview
![legend](https://user-images.githubusercontent.com/3824953/44351078-4179ee80-a4a1-11e8-922b-3071f92b20b6.gif)
 
* [x] Add and fix specs
* [x] Add documentation
* [x] Add Legends example for colors (to be improved)
* [ ] Add Legends example for imageList