### PR TITLE
Fix viewport counting

### DIFF
--- a/src/renderer/Dataframe.js
+++ b/src/renderer/Dataframe.js
@@ -60,6 +60,10 @@ export default class Dataframe {
                         aabb = _updateAABBForGeometry(feature[j], aabb, type);
                     }
 
+                    if (aabb.minx === Number.POSITIVE_INFINITY) {
+                        aabb = null;
+                    }
+
                     aabbList.push(aabb);
                 }
 
@@ -259,6 +263,10 @@ export default class Dataframe {
     }
 
     _compareAABBs (featureAABB, viewportAABB, stroke) {
+        if (featureAABB === null) {
+            return AABBTestResults.OUTSIDE;
+        }
+
         const featureStrokeAABB = {
             minx: featureAABB.minx - stroke,
             miny: featureAABB.miny - stroke,
@@ -357,13 +365,13 @@ export default class Dataframe {
             if (i === 0 || i >= breakpoints[featureIndex]) {
                 featureIndex++;
                 const feature = this.getFeature(featureIndex);
-                let offset = {x: 0, y: 0};
+                let offset = { x: 0, y: 0 };
                 if (!viz.offset.default) {
                     const vizOffset = viz.offset.eval(feature);
                     offset.x = vizOffset[0] * widthScale;
                     offset.y = vizOffset[1] * widthScale;
                 }
-                pointWithOffset = {x: point.x - offset.x, y: point.y - offset.y};
+                pointWithOffset = { x: point.x - offset.x, y: point.y - offset.y };
                 if (!pointInRectangle(pointWithOffset, this._aabb[featureIndex]) ||
                     this._isFeatureFiltered(feature, viz.filter)) {
                     i = breakpoints[featureIndex] - 6;
@@ -547,7 +555,7 @@ function _updateAABBLine (line, aabb) {
 }
 
 function _updateAABBPolygon (polygon, aabb) {
-    const [ vertices, numVertices ] = [ polygon.flat, polygon.holes[0] || polygon.flat.length / 2 ];
+    const [vertices, numVertices] = [polygon.flat, polygon.holes[0] || polygon.flat.length / 2];
 
     for (let i = 0; i < numVertices; i++) {
         aabb.minx = Math.min(aabb.minx, vertices[2 * i + 0]);
@@ -561,12 +569,12 @@ function _updateAABBPolygon (polygon, aabb) {
 
 function _isFeatureAABBInsideViewport (featureAABB, viewportAABB) {
     return (featureAABB.minx >= viewportAABB.minx && featureAABB.maxx <= viewportAABB.maxx &&
-            featureAABB.miny >= viewportAABB.miny && featureAABB.maxy <= viewportAABB.maxy);
+        featureAABB.miny >= viewportAABB.miny && featureAABB.maxy <= viewportAABB.maxy);
 }
 
 function _isFeatureAABBOutsideViewport (featureAABB, viewportAABB) {
     return (featureAABB.minx > viewportAABB.maxx || featureAABB.miny > viewportAABB.maxy ||
-            featureAABB.maxx < viewportAABB.minx || featureAABB.maxy < viewportAABB.miny);
+        featureAABB.maxx < viewportAABB.minx || featureAABB.maxy < viewportAABB.miny);
 }
 
 function _isPolygonCollidingViewport (vertices, normals, start, end, strokeWidthScale, viewportAABB) {

--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -244,6 +244,8 @@ export default class Renderer {
             zoom: gl.drawingBufferHeight / (this._zoom * 1024 * (window.devicePixelRatio || 1)) // Used by zoom expression
         };
 
+        this._runViewportAggregations(renderLayer);
+
         if (!tiles.length) {
             return;
         }
@@ -255,8 +257,6 @@ export default class Renderer {
         gl.disable(gl.STENCIL_TEST);
         gl.depthMask(false);
         gl.bindFramebuffer(gl.FRAMEBUFFER, this.auxFB);
-
-        this._runViewportAggregations(renderLayer);
 
         const styleDataframe = (tile, tileTexture, shader, vizExpr) => {
             const textureId = shader.textureIds.get(viz);

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -120,6 +120,9 @@ export function pointInCircle (p, center, scale) {
 }
 
 export function pointInRectangle (point, bbox) {
+    if (bbox === null) {
+        return false;
+    }
     const p = {
         x: point.x.toFixed(2),
         y: point.y.toFixed(2)


### PR DESCRIPTION
Two corner cases have been fixed for issue https://github.com/CartoDB/carto-vl/issues/858

- Fix viewport counting with polygons with zero vertices. (Yes, we were receiving zero-vertex polygons from Maps API :joy:, cc: @jgoizueta @rochoa @Algunenano ). In fact, this was the most visible issue.
- Fix viewport counting when there were no tiles