### PR TITLE
Fix opacity() with variables

### DIFF
--- a/src/renderer/viz/expressions.js
+++ b/src/renderer/viz/expressions.js
@@ -181,7 +181,7 @@ import Now from './expressions/now';
 
 import BaseNumber from './expressions/basic/number';
 
-import Opacity from './expressions/color/opacity';
+import Opacity from './expressions/color/Opacity';
 
 import { Asc } from './expressions/ordering';
 import { Desc } from './expressions/ordering';

--- a/src/renderer/viz/expressions/color/Opacity.js
+++ b/src/renderer/viz/expressions/color/Opacity.js
@@ -1,6 +1,6 @@
 import BaseExpression from '../base';
 import { number } from '../../expressions';
-import { checkLooseType, checkType, checkMaxArguments } from '../utils';
+import { checkType, checkMaxArguments, checkExpression } from '../utils';
 
 /**
  * Override the input color opacity.
@@ -37,8 +37,8 @@ export default class Opacity extends BaseExpression {
         if (Number.isFinite(alpha)) {
             alpha = number(alpha);
         }
-        checkLooseType('opacity', 'color', 0, 'color', color);
-        checkLooseType('opacity', 'alpha', 1, 'number', alpha);
+        checkExpression('opacity', 'color', 0, color);
+        checkExpression('opacity', 'alpha', 1, alpha);
         super({ color, alpha });
         this.type = 'color';
         this.inlineMaker = inline => `vec4((${inline.color}).rgb, ${inline.alpha})`;

--- a/test/unit/renderer/viz/expressions/color/Opacity.test.js
+++ b/test/unit/renderer/viz/expressions/color/Opacity.test.js
@@ -1,12 +1,12 @@
-import { validateStaticType, validateStaticTypeErrors, validateDynamicTypeErrors, validateMaxArgumentsError } from '../utils';
+import { validateStaticType, validateMaxArgumentsError, validateCompileTypeError } from '../utils';
 import { opacity, rgba, mul, variable, rgb } from '../../../../../../src/renderer/viz/expressions';
 
 describe('src/renderer/viz/expressions/opacity', () => {
     describe('error control', () => {
-        validateStaticTypeErrors('opacity', []);
-        validateStaticTypeErrors('opacity', ['number']);
-        validateDynamicTypeErrors('opacity', ['number', 'number']);
-        validateDynamicTypeErrors('opacity', ['color', 'category']);
+        validateCompileTypeError('opacity', []);
+        validateCompileTypeError('opacity', ['number']);
+        validateCompileTypeError('opacity', ['number', 'number']);
+        validateCompileTypeError('opacity', ['color', 'category']);
         validateMaxArgumentsError('opacity', ['red', 'number', 'number']);
     });
 


### PR DESCRIPTION
Address https://github.com/CartoDB/carto-vl/issues/878 for `opacity()` which was broken with variables as experienced by @makella 