### PR TITLE
Label guide

### DIFF
--- a/debug/label-guide.html
+++ b/debug/label-guide.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Add layer | CARTO</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8">
+    <!-- Include CARTO VL JS -->
+    <script src="../dist/carto-vl.js"></script>
+    <!-- Include Mapbox GL JS -->
+    <script src="https://libs.cartocdn.com/mapbox-gl/v0.45.0-carto1/mapbox-gl.js"></script>
+    <!-- Include Mapbox GL CSS -->
+    <link href="https://libs.cartocdn.com/mapbox-gl/v0.45.0-carto1/mapbox-gl.css" rel="stylesheet" />
+    <link rel="stylesheet" type="text/css" href="../examples/style.css">
+</head>
+
+<body>
+    <div id="map"></div>
+    <aside class="toolbox">
+        <div class="box">
+            <header>
+                <h1>Add layer</h1>
+            </header>
+            <section>
+                <p class="description open-sans">Add one CARTO layer to your map</p>
+            </section>
+            <footer class="js-footer"></footer>
+        </div>
+    </aside>
+    <script>
+        const map = new mapboxgl.Map({
+            container: 'map',
+            style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
+            center: [-74, 40.7],
+            zoom: 0
+        });
+
+        async function loadMVT() {
+            const mapConfig = {
+                buffersize: { mvt: 0 },
+                layers: [
+                    {
+                        id: 'myCartoLayer2',
+                        type: 'mapnik',
+                        options: {
+                            sql: 'SELECT * FROM pop_density_points'
+                        }
+                    }
+                ]
+            };
+            const response = await fetch('https://cartovl.carto.com/api/v1/map', {
+                method: 'POST',
+                headers: {
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(mapConfig)
+            });
+            const layergroup = await response.json();
+            const tilejson = layergroup.metadata.tilejson.vector;
+
+            map.on('load', function () {
+                map.addLayer({
+                    "id": "myCartoLayerMGLID",
+                    "type": "symbol",
+                    "source": {
+                        "type": "vector",
+                        "tiles": tilejson.tiles,
+                    },
+                    "source-layer": "myCartoLayer2",
+                    "layout": {
+                        "text-field": "{dn}",
+                        "text-size": 20,
+                        "text-offset": [0, 0.6],
+                    },
+                    "paint": {
+                        "text-color": "#FFF"
+                    }
+                });
+            });
+
+
+            const source = new carto.source.MVT(tilejson.tiles[0], {
+                properties: {
+                    dn:{
+                        type: 'number'
+                    }
+                }
+            },
+                {
+                    layerID: 'myCartoLayer2'
+                }
+            );
+
+            const viz = new carto.Viz(`
+                color: ramp(linear($dn, 0, 300), temps)
+                strokeColor: black
+            `);
+            const layer = new carto.Layer('myCartoLayer2', source, viz);
+
+            layer.addTo(map);
+            layer.on('loaded', () => {
+                window.loaded = true;
+            });
+        }
+
+        loadMVT();
+
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
Fix https://github.com/CartoDB/carto-vl/issues/704

Incomplete!

I made a PoC that works by instantiating the map and using a custom MVT source in CARTO VL.

I think that we could add a `getTilesURL` function to Maps API source to avoid the need to instantiate the map directly and allow the usage of the easier Maps API sources. cc: @rochoa 

Regarding cartography, the example is just a PoC to see that the approach works, so it would be better to have a good map that really benefits from the labels. cc: @makella 

Also, after doing those two points we will need to add the real guide with all the documentation.