### PR TITLE
Change images names to be consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Improve featureIDBuffer generation by 20%
 - Trigger feature events (hover, enter, leave) when layers are updated
 - ramp($category, ...) implementation is fixed when using multiple categorical properties
+- Use undescore in image constants.
 
 ### Removed
 - Removed XYZ expression

--- a/src/renderer/viz/parser.js
+++ b/src/renderer/viz/parser.js
@@ -1,6 +1,6 @@
 
 import jsep from 'jsep';
-import * as functions from './expressions';
+import * as expressions from './expressions';
 import { implicitCast } from './expressions/utils';
 import { CSS_COLOR_NAMES } from './expressions/color/cssColorNames';
 import NamedColor from './expressions/color/NamedColor';
@@ -10,37 +10,38 @@ import Hex from './expressions/color/hex';
 
 const aggFns = [];
 
-const lowerCaseFunctions = {};
-Object.keys(functions)
-    .filter(name => name[0] === name[0].toLowerCase()) // Only get functions starting with lowercase
-    .map(name => { lowerCaseFunctions[name.toLocaleLowerCase()] = functions[name]; });
-lowerCaseFunctions.true = functions.TRUE;
-lowerCaseFunctions.false = functions.FALSE;
-lowerCaseFunctions.align_center = functions.ALIGN_CENTER;
-lowerCaseFunctions.align_bottom = functions.ALIGN_BOTTOM;
+const lowerCaseExpressions = {};
+Object.keys(expressions)
+    .filter(name => name[0] === name[0].toLowerCase()) // Only get expressions starting with lowercase
+    .map(name => { lowerCaseExpressions[name.toLocaleLowerCase()] = expressions[name]; });
 
-lowerCaseFunctions.pi = functions.PI;
-lowerCaseFunctions.e = functions.E;
-lowerCaseFunctions.hold = functions.HOLD;
+lowerCaseExpressions.true = expressions.TRUE;
+lowerCaseExpressions.false = expressions.FALSE;
+lowerCaseExpressions.align_center = expressions.ALIGN_CENTER;
+lowerCaseExpressions.align_bottom = expressions.ALIGN_BOTTOM;
 
-lowerCaseFunctions.bicycle = functions.BICYCLE;
-lowerCaseFunctions.building = functions.BUILDING;
-lowerCaseFunctions.bus = functions.BUS;
-lowerCaseFunctions.car = functions.CAR;
-lowerCaseFunctions.circle = functions.CIRCLE;
-lowerCaseFunctions.circleoutline = functions.CIRCLE_OUTLINE;
-lowerCaseFunctions.cross = functions.CROSS;
-lowerCaseFunctions.flag = functions.FLAG;
-lowerCaseFunctions.house = functions.HOUSE;
-lowerCaseFunctions.marker = functions.MARKER;
-lowerCaseFunctions.markeroutline = functions.MARKER_OUTLINE;
-lowerCaseFunctions.plus = functions.PLUS;
-lowerCaseFunctions.square = functions.SQUARE;
-lowerCaseFunctions.squareoutline = functions.SQUARE_OUTLINE;
-lowerCaseFunctions.star = functions.STAR;
-lowerCaseFunctions.staroutline = functions.STAR_OUTLINE;
-lowerCaseFunctions.triangle = functions.TRIANGLE;
-lowerCaseFunctions.triangleoutline = functions.TRIANGLE_OUTLINE;
+lowerCaseExpressions.pi = expressions.PI;
+lowerCaseExpressions.e = expressions.E;
+lowerCaseExpressions.hold = expressions.HOLD;
+
+lowerCaseExpressions.bicycle = expressions.BICYCLE;
+lowerCaseExpressions.building = expressions.BUILDING;
+lowerCaseExpressions.bus = expressions.BUS;
+lowerCaseExpressions.car = expressions.CAR;
+lowerCaseExpressions.circle = expressions.CIRCLE;
+lowerCaseExpressions.circle_outline = expressions.CIRCLE_OUTLINE;
+lowerCaseExpressions.cross = expressions.CROSS;
+lowerCaseExpressions.flag = expressions.FLAG;
+lowerCaseExpressions.house = expressions.HOUSE;
+lowerCaseExpressions.marker = expressions.MARKER;
+lowerCaseExpressions.marker_outline = expressions.MARKER_OUTLINE;
+lowerCaseExpressions.plus = expressions.PLUS;
+lowerCaseExpressions.square = expressions.SQUARE;
+lowerCaseExpressions.square_outline = expressions.SQUARE_OUTLINE;
+lowerCaseExpressions.star = expressions.STAR;
+lowerCaseExpressions.star_outline = expressions.STAR_OUTLINE;
+lowerCaseExpressions.triangle = expressions.TRIANGLE;
+lowerCaseExpressions.triangle_outline = expressions.TRIANGLE_OUTLINE;
 
 export function parseVizExpression (str) {
     prepareJsep();
@@ -96,8 +97,8 @@ function parseFunctionCall (node) {
         return args[0];
     }
     const args = node.arguments.map(arg => parseNode(arg));
-    if (lowerCaseFunctions[name]) {
-        return lowerCaseFunctions[name](...args);
+    if (lowerCaseExpressions[name]) {
+        return lowerCaseExpressions[name](...args);
     }
     throw new Error(`Invalid function name '${node.callee.name}'.`);
 }
@@ -107,37 +108,37 @@ function parseBinaryOperation (node) {
     const right = parseNode(node.right);
     switch (node.operator) {
         case '*':
-            return functions.mul(left, right);
+            return expressions.mul(left, right);
         case '/':
-            return functions.div(left, right);
+            return expressions.div(left, right);
         case '+':
-            return functions.add(left, right);
+            return expressions.add(left, right);
         case '-':
-            return functions.sub(left, right);
+            return expressions.sub(left, right);
         case '%':
-            return functions.mod(left, right);
+            return expressions.mod(left, right);
         case '^':
-            return functions.pow(left, right);
+            return expressions.pow(left, right);
         case '>':
-            return functions.greaterThan(left, right);
+            return expressions.greaterThan(left, right);
         case '>=':
-            return functions.greaterThanOrEqualTo(left, right);
+            return expressions.greaterThanOrEqualTo(left, right);
         case '<':
-            return functions.lessThan(left, right);
+            return expressions.lessThan(left, right);
         case '<=':
-            return functions.lessThanOrEqualTo(left, right);
+            return expressions.lessThanOrEqualTo(left, right);
         case '==':
-            return functions.equals(left, right);
+            return expressions.equals(left, right);
         case '!=':
-            return functions.notEquals(left, right);
+            return expressions.notEquals(left, right);
         case 'and':
-            return functions.and(left, right);
+            return expressions.and(left, right);
         case 'or':
-            return functions.or(left, right);
+            return expressions.or(left, right);
         case 'in':
-            return functions.in(left, right);
+            return expressions.in(left, right);
         case 'nin':
-            return functions.nin(left, right);
+            return expressions.nin(left, right);
         default:
             throw new Error(`Invalid binary operator '${node.operator}'.`);
     }
@@ -146,7 +147,7 @@ function parseBinaryOperation (node) {
 function parseUnaryOperation (node) {
     switch (node.operator) {
         case '-':
-            return functions.mul(-1, parseNode(node.argument));
+            return expressions.mul(-1, parseNode(node.argument));
         case '+':
             return parseNode(node.argument);
         default:
@@ -159,15 +160,15 @@ function parseIdentifier (node) {
         node.name = '__cartovl_variable_' + node.name.substr(1);
     }
     if (node.name.startsWith('__cartovl_variable_')) {
-        return functions.variable(node.name.substr('__cartovl_variable_'.length));
+        return expressions.variable(node.name.substr('__cartovl_variable_'.length));
     } else if (node.name[0] === '#') {
         return new Hex(node.name);
     } else if (node.name[0] === '$') {
-        return functions.property(node.name.substring(1));
-    } else if (functions.palettes[node.name.toUpperCase()]) {
-        return functions.palettes[node.name.toUpperCase()];
-    } else if (lowerCaseFunctions[node.name.toLowerCase()]) {
-        return lowerCaseFunctions[node.name.toLowerCase()];
+        return expressions.property(node.name.substring(1));
+    } else if (expressions.palettes[node.name.toUpperCase()]) {
+        return expressions.palettes[node.name.toUpperCase()];
+    } else if (lowerCaseExpressions[node.name.toLowerCase()]) {
+        return lowerCaseExpressions[node.name.toLowerCase()];
     } else if (CSS_COLOR_NAMES.includes(node.name.toLowerCase())) {
         return new NamedColor(node.name.toLowerCase());
     } else {

--- a/test/integration/render/scenarios/images/builtin/scenario.js
+++ b/test/integration/render/scenarios/images/builtin/scenario.js
@@ -7,7 +7,7 @@ const source = new carto.source.GeoJSON(sources['points']);
 const viz = new carto.Viz(`
 width: 50
 color: ramp(linear($numeric), prism)
-symbol: markerOutline
+symbol: marker_outline
 symbolPlacement: align_bottom
 `);
 const layer = new carto.Layer('layer', source, viz);

--- a/test/unit/renderer/viz/parser.test.js
+++ b/test/unit/renderer/viz/parser.test.js
@@ -99,19 +99,19 @@ describe('src/renderer/viz/parser', () => {
                 @3: bus
                 @4: car
                 @5: circle
-                @6: circleOutline
+                @6: circle_outline
                 @7: cross
                 @8: flag
                 @9: house
                 @10: marker
-                @11: markerOutline
+                @11: marker_outline
                 @12: plus
                 @13: square
-                @14: squareOutline
+                @14: square_outline
                 @15: star
-                @16: starOutline
+                @16: star_outline
                 @17: triangle
-                @18: triangleOutline
+                @18: triangle_outline
             `;
 
             expect(() => parseVizDefinition(str)).not.toThrow();


### PR DESCRIPTION
Related with #850 and https://github.com/CartoDB/carto-vl/pull/885

This PR only changes our image names to be consistent with the rest of the constants. i.e: `circleoutline` -> `circle_outline`.