### PR TITLE
Add clusterCount expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add new `clusterCount()` expression
+
 
 ## [0.7.0] - 2018-08-24
 ### Added

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -4,12 +4,11 @@ import Metadata from '../renderer/Metadata';
 import schema from '../renderer/schema';
 import Time from '../renderer/viz/expressions/time';
 import * as windshaftFiltering from './windshaft-filtering';
+import { CLUSTER_FEATURE_COUNT } from '../renderer/schema';
 
 const SAMPLE_ROWS = 1000;
 const MIN_FILTERING = 2000000;
 const REQUEST_GET_MAX_URL_LENGTH = 2048;
-
-export const CLUSTER_FEATURE_COUNT = '_cdb_feature_count';
 
 export default class Windshaft {
     constructor (source) {

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -193,19 +193,12 @@ export default class Windshaft {
             }
         };
         this.urlTemplates = urlTemplates;
-
-        this._addClusterCountPropertyTo(metadata);
         this.metadata = metadata;
         this._mvtClient._metadata = metadata;
         this._MNS = MNS;
         this.filtering = filters;
         this.resolution = resolution;
         this._checkLayerMeta(MNS);
-    }
-
-    _addClusterCountPropertyTo (metadata) {
-        metadata.propertyKeys.push(CLUSTER_FEATURE_COUNT);
-        metadata.properties[CLUSTER_FEATURE_COUNT] = { type: 'number' };
     }
 
     async _instantiate (MNS, resolution, filters, choices, metadata) {
@@ -376,6 +369,10 @@ export default class Windshaft {
                 });
             }
         });
+
+        if (geomType === 'point') {
+            properties[CLUSTER_FEATURE_COUNT] = { type: 'number' };
+        }
 
         const idProperty = 'cartodb_id';
 

--- a/src/renderer/schema.js
+++ b/src/renderer/schema.js
@@ -44,6 +44,8 @@ function simplify (MNS) {
 const AGG_PREFIX = '_cdb_agg_';
 const AGG_PATTERN = new RegExp('^' + AGG_PREFIX + '[a-zA-Z0-9]+_');
 
+export const CLUSTER_FEATURE_COUNT = '_cdb_feature_count';
+
 // column information functions
 export const column = {
     isAggregated: function isAggregated (name) {

--- a/src/renderer/viz/expressions.js
+++ b/src/renderer/viz/expressions.js
@@ -159,6 +159,7 @@ import ClusterMax from './expressions/aggregation/cluster/ClusterMax';
 import ClusterMin from './expressions/aggregation/cluster/ClusterMin';
 import ClusterMode from './expressions/aggregation/cluster/ClusterMode';
 import ClusterSum from './expressions/aggregation/cluster/ClusterSum';
+import ClusterCount from './expressions/aggregation/cluster/ClusterCount';
 
 import Constant from './expressions/basic/constant';
 
@@ -295,6 +296,7 @@ export const clusterMax = (...args) => new ClusterMax(...args);
 export const clusterMin = (...args) => new ClusterMin(...args);
 export const clusterMode = (...args) => new ClusterMode(...args);
 export const clusterSum = (...args) => new ClusterSum(...args);
+export const clusterCount = (...args) => new ClusterCount(...args);
 
 export const constant = (...args) => new Constant(...args);
 

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
@@ -6,20 +6,24 @@ export default class ClusterCount extends BaseExpression {
     constructor () {
         checkMaxArguments(arguments, 0, 'clusterCount');
         super({});
-        this._expressionName = 'clusterCount';
         this.type = 'number';
+        this._expressionName = 'clusterCount';
+        this._hasClusterFeatureCount = false;
     }
 
     eval (feature) {
         return Number(feature[CLUSTER_FEATURE_COUNT]) || 1;
     }
 
-    _resolveAliases () { }
+    _bindMetadata (metadata) {
+        super._bindMetadata(metadata);
+        this._hasClusterFeatureCount = metadata.properties[CLUSTER_FEATURE_COUNT] !== undefined;
+    }
 
     _applyToShaderSource (getGLSLforProperty) {
         return {
             preface: '',
-            inline: `${getGLSLforProperty(CLUSTER_FEATURE_COUNT)}`
+            inline: `${this._hasClusterFeatureCount ? getGLSLforProperty(CLUSTER_FEATURE_COUNT) : '1.'}`
         };
     }
 }

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
@@ -1,0 +1,60 @@
+import BaseExpression from '../../base';
+import { number } from '../../../expressions';
+
+// import PropertyExpression from '../../basic/property';
+// import { checkType, checkInstance } from '../../utils';
+import * as schema from '../../../../schema';
+
+export default class ClusterCount extends BaseExpression {
+    constructor ({ property, expressionName, aggName, aggType }) {
+        // checkInstance(expressionName, 'property', 0, PropertyExpression, property);
+        // super({ property });
+        super({ _value: number(1) }); // <<< ?? clusterCount doesn't have an associated property, default to 1 ??
+
+        // eg. expressionName: 'clusterMax', aggName: 'max', aggType: 'number'
+        this._aggName = 'clusterCount'; // <<< ?? vs just 'count'
+        this._expressionName = 'clusterCount';
+        this.type = 'number';
+    }
+
+    get name () {
+        return this.property.name;
+    }
+
+    get aggName () {
+        return this._aggName;
+    }
+
+    get numCategories () {
+        return this.property.numCategories;
+    }
+
+    eval (feature) {
+        return feature[schema.column.aggColumn(this.property.name, this._aggName)];
+    }
+
+    _bindMetadata (metadata) {
+        super._bindMetadata(metadata);
+        // checkType(this._expressionName, 'property', 0, this.type, this.property);
+    }
+
+    _resolveAliases () { }
+
+    _applyToShaderSource (getGLSLforProperty) {
+        return {
+            preface: '',
+            inline: `${getGLSLforProperty(schema.column.aggColumn(this.property.name, this._aggName))}`
+        };
+    }
+
+    _postShaderCompile () { }
+
+    _getMinimumNeededSchema () {
+        return {
+            [this.property.name]: [{
+                type: 'aggregated',
+                op: this._aggName
+            }]
+        };
+    }
+}

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
@@ -1,41 +1,17 @@
 import BaseExpression from '../../base';
-import { number } from '../../../expressions';
-
-// import PropertyExpression from '../../basic/property';
-// import { checkType, checkInstance } from '../../utils';
-import * as schema from '../../../../schema';
+import { checkMaxArguments } from '../../utils';
+import { CLUSTER_FEATURE_COUNT } from '../../../../../client/windshaft';
 
 export default class ClusterCount extends BaseExpression {
-    constructor ({ property, expressionName, aggName, aggType }) {
-        // checkInstance(expressionName, 'property', 0, PropertyExpression, property);
-        // super({ property });
-        super({ _value: number(1) }); // <<< ?? clusterCount doesn't have an associated property, default to 1 ??
-
-        // eg. expressionName: 'clusterMax', aggName: 'max', aggType: 'number'
-        this._aggName = 'clusterCount'; // <<< ?? vs just 'count'
+    constructor () {
+        checkMaxArguments(arguments, 0, 'clusterCount');
+        super({});
         this._expressionName = 'clusterCount';
         this.type = 'number';
     }
 
-    get name () {
-        return this.property.name;
-    }
-
-    get aggName () {
-        return this._aggName;
-    }
-
-    get numCategories () {
-        return this.property.numCategories;
-    }
-
     eval (feature) {
-        return feature[schema.column.aggColumn(this.property.name, this._aggName)];
-    }
-
-    _bindMetadata (metadata) {
-        super._bindMetadata(metadata);
-        // checkType(this._expressionName, 'property', 0, this.type, this.property);
+        return Number(feature[CLUSTER_FEATURE_COUNT]) || 1;
     }
 
     _resolveAliases () { }
@@ -43,18 +19,7 @@ export default class ClusterCount extends BaseExpression {
     _applyToShaderSource (getGLSLforProperty) {
         return {
             preface: '',
-            inline: `${getGLSLforProperty(schema.column.aggColumn(this.property.name, this._aggName))}`
-        };
-    }
-
-    _postShaderCompile () { }
-
-    _getMinimumNeededSchema () {
-        return {
-            [this.property.name]: [{
-                type: 'aggregated',
-                op: this._aggName
-            }]
+            inline: `${getGLSLforProperty(CLUSTER_FEATURE_COUNT)}`
         };
     }
 }

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
@@ -1,6 +1,6 @@
 import BaseExpression from '../../base';
 import { checkMaxArguments } from '../../utils';
-import { CLUSTER_FEATURE_COUNT } from '../../../../../client/windshaft';
+import { CLUSTER_FEATURE_COUNT } from '../../../../schema';
 
 /**
  * Count of features per cluster.
@@ -9,13 +9,13 @@ import { CLUSTER_FEATURE_COUNT } from '../../../../../client/windshaft';
  *
  * @return {Number} Cluster feature count
  *
- * @example <caption>Use cluster count as width.</caption>
+ * @example <caption>Use cluster count for width.</caption>
  * const s = carto.expressions;
  * const viz = new carto.Viz({
  *   width: s.clusterCount() / 50
  * });
  *
- * @example <caption>Use cluster cluster count as width. (String)</caption>
+ * @example <caption>Use cluster count for width. (String)</caption>
  * const viz = new carto.Viz(`
  *   width: clusterCount() / 50
  * `);
@@ -30,7 +30,6 @@ export default class ClusterCount extends BaseExpression {
         checkMaxArguments(arguments, 0, 'clusterCount');
         super({});
         this.type = 'number';
-        this._expressionName = 'clusterCount';
         this._hasClusterFeatureCount = false;
     }
 
@@ -46,7 +45,7 @@ export default class ClusterCount extends BaseExpression {
     _applyToShaderSource (getGLSLforProperty) {
         return {
             preface: '',
-            inline: `${this._hasClusterFeatureCount ? getGLSLforProperty(CLUSTER_FEATURE_COUNT) : '1.'}`
+            inline: this._hasClusterFeatureCount ? getGLSLforProperty(CLUSTER_FEATURE_COUNT) : '1.'
         };
     }
 }

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
@@ -2,6 +2,29 @@ import BaseExpression from '../../base';
 import { checkMaxArguments } from '../../utils';
 import { CLUSTER_FEATURE_COUNT } from '../../../../../client/windshaft';
 
+/**
+ * Count of features per cluster.
+ *
+ * Note: `clusterCount` has no input parameters and if data is not aggregated, it always returns 1
+ *
+ * @return {Number} Cluster feature count
+ *
+ * @example <caption>Use cluster count as width.</caption>
+ * const s = carto.expressions;
+ * const viz = new carto.Viz({
+ *   width: s.clusterCount() / 50
+ * });
+ *
+ * @example <caption>Use cluster cluster count as width. (String)</caption>
+ * const viz = new carto.Viz(`
+ *   width: clusterCount() / 50
+ * `);
+ *
+ * @memberof carto.expressions
+ * @name clusterCount
+ * @function
+ * @api
+ */
 export default class ClusterCount extends BaseExpression {
     constructor () {
         checkMaxArguments(arguments, 0, 'clusterCount');

--- a/src/sources/MVT.js
+++ b/src/sources/MVT.js
@@ -214,7 +214,7 @@ export default class MVT extends Base {
                 const x = 2 * (geom[0][0].x) / mvtExtent - 1.0;
                 const y = 2 * (1.0 - (geom[0][0].y) / mvtExtent) - 1.0;
                 // Tiles may contain points in the border;
-                // we'll avoid here duplicatend points between tiles by excluding the 1-edge
+                // we'll avoid here duplicated points between tiles by excluding the 1-edge
                 if (x < -1 || x >= 1 || y < -1 || y >= 1) {
                     continue;
                 }
@@ -245,7 +245,12 @@ export default class MVT extends Base {
     }
 
     _initializePropertyArrays (metadata, length) {
-        const properties = {};
+        const propertyNames = this._getPropertyNamesFrom(metadata);
+        const properties = this._getPropertiesFor(propertyNames, length);
+        return { propertyNames, properties };
+    }
+
+    _getPropertyNamesFrom (metadata) {
         const propertyNames = [];
         for (let i = 0; i < metadata.propertyKeys.length; i++) {
             const propertyName = metadata.propertyKeys[i];
@@ -254,7 +259,11 @@ export default class MVT extends Base {
             }
             propertyNames.push(...metadata.propertyNames(propertyName));
         }
+        return propertyNames;
+    }
 
+    _getPropertiesFor (propertyNames, length) {
+        const properties = {};
         const size = Math.ceil(length / RTT_WIDTH) * RTT_WIDTH;
 
         const arrayBuffer = new ArrayBuffer(4 * size * propertyNames.length);
@@ -263,7 +272,7 @@ export default class MVT extends Base {
             properties[propertyName] = new Float32Array(arrayBuffer, i * 4 * size, size);
         }
 
-        return { properties, propertyNames };
+        return properties;
     }
 
     _decodeProperties (propertyNames, properties, feature, i) {

--- a/test/unit/renderer/viz/expressions/aggregation/clusterAggregation.test.js
+++ b/test/unit/renderer/viz/expressions/aggregation/clusterAggregation.test.js
@@ -29,15 +29,13 @@ describe('src/renderer/viz/expressions/clusterAggregation', () => {
         validateMaxArgumentsError('clusterSum', ['number', 'number']);
         validateMaxArgumentsError('clusterAvg', ['number', 'number']);
         validateMaxArgumentsError('clusterMode', ['number', 'number']);
-
-        // validateMaxArgumentsError('clusterCount', ['number']);
+        validateMaxArgumentsError('clusterCount', [0]);
     });
 
     describe('type', () => {
         validateStaticType('clusterMax', ['number-property'], 'number');
         validateStaticType('clusterMode', ['category-property'], 'category');
-
-        // validateStaticType('clusterCount', [], 'number');
+        validateStaticType('clusterCount', [], 'number');
     });
 
     describe('eval', () => {
@@ -66,9 +64,17 @@ describe('src/renderer/viz/expressions/clusterAggregation', () => {
             expect(actual).toEqual(fakeFeature._cdb_agg_sum_price);
         });
 
-        // it('clusterCount() should return fakeFeature._cdb_feature_count', () => {
-        //     const actual = s.clusterCount().eval(fakeFeature);
-        //     expect(actual).toEqual(fakeFeature._cdb_feature_count);
-        // });
+        it('clusterCount() should return fakeFeature._cdb_feature_count if defined', () => {
+            const actual = s.clusterCount().eval(fakeFeature);
+            expect(actual).toEqual(fakeFeature._cdb_feature_count);
+        });
+
+        it('clusterCount() should return 1 if _cdb_feature_count is undefined in the feature', () => {
+            const aFeature = Object.assign({}, fakeFeature);
+            delete aFeature._cdb_feature_count;
+
+            const actual = s.clusterCount().eval(aFeature);
+            expect(actual).toEqual(1);
+        });
     });
 });

--- a/test/unit/renderer/viz/expressions/aggregation/clusterAggregation.test.js
+++ b/test/unit/renderer/viz/expressions/aggregation/clusterAggregation.test.js
@@ -70,10 +70,7 @@ describe('src/renderer/viz/expressions/clusterAggregation', () => {
         });
 
         it('clusterCount() should return 1 if _cdb_feature_count is undefined in the feature', () => {
-            const aFeature = Object.assign({}, fakeFeature);
-            delete aFeature._cdb_feature_count;
-
-            const actual = s.clusterCount().eval(aFeature);
+            const actual = s.clusterCount().eval({});
             expect(actual).toEqual(1);
         });
     });

--- a/test/unit/renderer/viz/expressions/aggregation/clusterAggregation.test.js
+++ b/test/unit/renderer/viz/expressions/aggregation/clusterAggregation.test.js
@@ -7,7 +7,8 @@ describe('src/renderer/viz/expressions/clusterAggregation', () => {
         _cdb_agg_min_price: 2,
         _cdb_agg_avg_price: 3,
         _cdb_agg_sum_price: 4,
-        _cdb_agg_mode_price: 5
+        _cdb_agg_mode_price: 5,
+        _cdb_feature_count: 1
     };
 
     let $price = null;
@@ -28,11 +29,15 @@ describe('src/renderer/viz/expressions/clusterAggregation', () => {
         validateMaxArgumentsError('clusterSum', ['number', 'number']);
         validateMaxArgumentsError('clusterAvg', ['number', 'number']);
         validateMaxArgumentsError('clusterMode', ['number', 'number']);
+
+        // validateMaxArgumentsError('clusterCount', ['number']);
     });
 
     describe('type', () => {
         validateStaticType('clusterMax', ['number-property'], 'number');
         validateStaticType('clusterMode', ['category-property'], 'category');
+
+        // validateStaticType('clusterCount', [], 'number');
     });
 
     describe('eval', () => {
@@ -60,5 +65,10 @@ describe('src/renderer/viz/expressions/clusterAggregation', () => {
             const actual = s.clusterSum($price).eval(fakeFeature);
             expect(actual).toEqual(fakeFeature._cdb_agg_sum_price);
         });
+
+        // it('clusterCount() should return fakeFeature._cdb_feature_count', () => {
+        //     const actual = s.clusterCount().eval(fakeFeature);
+        //     expect(actual).toEqual(fakeFeature._cdb_feature_count);
+        // });
     });
 });


### PR DESCRIPTION
### Related to https://github.com/CartoDB/carto-vl/issues/611
### Context
There is an unused column in aggregations with the number of features in the cluster aggregation (`_cdb_feature_count`). This creates a new expression `clusterCount` to expose it when available, falling back to default value of 1 when it's not.

### Status

- [x] clusterCount() expression
- [x] basic tests
- [x] tests with aggregations
- [x] tests without aggr.
- [x] doc
- [x] CR 

### Example 1: with aggregation
![image](https://user-images.githubusercontent.com/458196/44718248-c5466300-aabf-11e8-9688-4251cc7ebd33.png)

### Example 2: without aggregation (default: 1)
![image](https://user-images.githubusercontent.com/458196/44718258-cbd4da80-aabf-11e8-921a-41b49ff6cfaa.png)

