### PR TITLE
Add default export to index.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add default export to allow `import carto from '@carto/carto-vl';`
 
 ## [0.7.0] - 2018-08-24
 ### Added

--- a/docs/reference/04-loading-the-library.md
+++ b/docs/reference/04-loading-the-library.md
@@ -17,4 +17,6 @@ npm install @carto/carto-vl
 yarn add @carto/carto-vl
 
 var carto = require('@carto/carto-vl');
+// or (ES6)
+import carto from '@carto/carto-vl';
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -46,4 +46,4 @@ import { version } from '../package.json';
 
 const source = { Dataset, SQL, GeoJSON, MVT };
 
-export { version, on, off, setDefaultAuth, setDefaultConfig, source, expressions, Layer, Viz, Map, Interactivity };
+export default { version, on, off, setDefaultAuth, setDefaultConfig, source, expressions, Layer, Viz, Map, Interactivity };

--- a/src/index.js
+++ b/src/index.js
@@ -46,4 +46,5 @@ import { version } from '../package.json';
 
 const source = { Dataset, SQL, GeoJSON, MVT };
 
+export { version, on, off, setDefaultAuth, setDefaultConfig, source, expressions, Layer, Viz, Map, Interactivity };
 export default { version, on, off, setDefaultAuth, setDefaultConfig, source, expressions, Layer, Viz, Map, Interactivity };

--- a/test/integration/user/test/MVT.test.js
+++ b/test/integration/user/test/MVT.test.js
@@ -1,4 +1,4 @@
-import * as carto from '../../../../src/';
+import carto from '../../../../src/';
 import * as util from '../../util';
 
 describe('Layer', () => {

--- a/test/integration/user/test/events.test.js
+++ b/test/integration/user/test/events.test.js
@@ -1,4 +1,4 @@
-import * as carto from '../../../../src/';
+import carto from '../../../../src/';
 import * as util from '../../util';
 
 const featureData = {

--- a/test/integration/user/test/expressions.test.js
+++ b/test/integration/user/test/expressions.test.js
@@ -1,4 +1,4 @@
-import * as carto from '../../../../src/index';
+import carto from '../../../../src/index';
 import * as util from '../../util';
 
 const featureData = {

--- a/test/integration/user/test/interactivity.test.js
+++ b/test/integration/user/test/interactivity.test.js
@@ -1,4 +1,4 @@
-import * as carto from '../../../../src';
+import carto from '../../../../src';
 import * as util from '../../util';
 
 // More info: https://github.com/CartoDB/carto-vl/wiki/Interactivity-tests

--- a/test/integration/user/test/layer.test.js
+++ b/test/integration/user/test/layer.test.js
@@ -1,4 +1,4 @@
-import * as carto from '../../../../src/';
+import carto from '../../../../src/';
 import { layerVisibility } from '../../../../src/constants/layer';
 import * as util from '../../util';
 

--- a/test/integration/user/test/viewportFeatures.test.js
+++ b/test/integration/user/test/viewportFeatures.test.js
@@ -1,4 +1,4 @@
-import * as carto from '../../../../src';
+import carto from '../../../../src';
 import * as util from '../../util';
 
 const feature1 = {

--- a/test/integration/user/test/viewportHistogramTop.test.js
+++ b/test/integration/user/test/viewportHistogramTop.test.js
@@ -1,4 +1,4 @@
-import * as carto from '../../../../src/index';
+import carto from '../../../../src/index';
 import * as util from '../../util';
 
 const feature1 = {
@@ -42,7 +42,7 @@ const feature3 = {
 
 const features = {
     type: 'FeatureCollection',
-    features: [ feature1, feature2, feature3 ]
+    features: [feature1, feature2, feature3]
 };
 
 describe('viewportHistogram() with top()', () => {
@@ -63,8 +63,8 @@ describe('viewportHistogram() with top()', () => {
     it('should return the valid histogram', (done) => {
         layer.on('loaded', () => {
             expect(viz.variables.histogram.value).toEqual([
-                {x: 'a', y: 2},
-                {x: 'CARTOVL_TOP_OTHERS_BUCKET', y: 1}
+                { x: 'a', y: 2 },
+                { x: 'CARTOVL_TOP_OTHERS_BUCKET', y: 1 }
             ]);
             done();
         });

--- a/test/unit/api.test.js
+++ b/test/unit/api.test.js
@@ -1,4 +1,4 @@
-import * as carto from '../../src/index';
+import carto from '../../src/index';
 import { version } from '../../package.json';
 
 describe('api', () => {


### PR DESCRIPTION
### Related to https://github.com/CartoDB/carto-vl/issues/900
### Context
There is currently no default export in our library (*index.js*). This means that:
* `const carto = require('@carto/carto-vl');` works
* but `import carto from '@carto/carto-vl';` **fails**.

You can workaround it with `import * as carto from '@carto/carto-vl';` but it feels less natural, so we are adding the main object as default export.
