### PR TITLE
Fix animation integration with MGL

### DIFF
--- a/src/Layer.js
+++ b/src/Layer.js
@@ -207,7 +207,7 @@ export default class Layer {
         this._viz = viz;
         viz.onChange(this._vizChanged.bind(this));
         this._compileShaders(viz, metadata);
-        this.map.triggerRepaint();
+        this._needRefresh();
     }
 
     /**
@@ -389,7 +389,7 @@ export default class Layer {
         this._paintLayer();
 
         if (this.isAnimated()) {
-            this.map.triggerRepaint();
+            this._needRefresh();
         }
     }
 

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -207,6 +207,7 @@ export default class Layer {
         this._viz = viz;
         viz.onChange(this._vizChanged.bind(this));
         this._compileShaders(viz, metadata);
+        this.map.triggerRepaint();
     }
 
     /**
@@ -387,12 +388,8 @@ export default class Layer {
     render (gl, matrix) {
         this._paintLayer();
 
-        // Checking this.map.repaint is needed, because MGL repaint is a setter and
-        // it has the strange quite buggy side-effect of doing a "final" repaint after
-        // being disabled if we disable it every frame, MGL will do a "final" repaint
-        // every frame, which will not disabled it in practice
-        if (!this.isAnimated() && this.map.repaint) {
-            this.map.repaint = false;
+        if (this.isAnimated()) {
+            this.map.triggerRepaint();
         }
     }
 
@@ -438,7 +435,7 @@ export default class Layer {
     }
 
     _needRefresh () {
-        this.map.repaint = true;
+        this.map.triggerRepaint();
     }
 
     /**

--- a/src/maps/Map.js
+++ b/src/maps/Map.js
@@ -195,4 +195,7 @@ export default class Map {
         m[15] = 1;
         return m;
     }
+
+    triggerRepaint () {
+    }
 }

--- a/src/maps/Map.js
+++ b/src/maps/Map.js
@@ -29,7 +29,6 @@ export default class Map {
 
         this._layers = new Set();
         this._hiddenLayers = new Set();
-        this._repaint = true;
         this._canvas = this._createCanvas();
         this._container.appendChild(this._canvas);
         this._gl = this._canvas.getContext('webgl');


### PR DESCRIPTION
As reported by @skgsergio animation is broken in some cases. He has an actual reproducible example (contact him or me for the code).

After debugging we discovered that the cause was that the last layer was not animated and it was overriding the "animatedness" of the other layers. This seems to have been introduced in the new MGL integration.

Fortunately, the MGL team already thought about this and we can remove the old hacky `repaint` with the new method `triggerRepaint` (see the upstream PR for details https://github.com/mapbox/mapbox-gl-js/pull/7039).

We've discussed the need for regression tests, but since this happened because of a very unusual change (the integration one), we decided to avoid them. Anyway, we agreed that animation, in general, is lacking tests.