### PR TITLE
Add Rotate and undocumented transform chaining

### DIFF
--- a/src/Layer.js
+++ b/src/Layer.js
@@ -239,17 +239,7 @@ export default class Layer {
         viz.setDefaultsIfRequired(this.metadata.geomType);
         if (this._viz && !this._source.requiresNewMetadata(viz)) {
             Object.keys(this._viz.variables).map(varName => {
-                // If an existing variable is not re-declared we add it to the new viz
-                if (!viz.variables[varName]) {
-                    viz.variables[varName] = this._viz.variables[varName];
-                }
-            });
-
-            Object.keys(viz.variables).map(varName => {
-                // If the variable existed, we need to blend it, nothing to do if not
-                if (this._viz.variables[varName]) {
-                    viz.variables[varName]._blendFrom(this._viz.variables[varName], ms, interpolator);
-                }
+                viz.variables[varName] = this._viz.variables[varName];
             });
 
             viz.color._blendFrom(this._viz.color, ms, interpolator);

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -566,8 +566,8 @@ function checkVizPropertyTypes (viz) {
     if (viz.symbolPlacement.type !== 'placement') {
         throw new Error(`Viz property 'symbolPlacement:' must be of type 'placement' but it was of type ${viz.symbolPlacement.type}`);
     }
-    if (viz.transform.type !== 'translation') {
-        throw new Error(`Viz property 'transform:' must be of type 'translation' but it was of type ${viz.transform.type}`);
+    if (viz.transform.type !== 'transformation') {
+        throw new Error(`Viz property 'transform:' must be of type 'transformation' but it was of type ${viz.transform.type}`);
     }
 }
 

--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -374,6 +374,7 @@ export default class Renderer {
             gl.bindTexture(gl.TEXTURE_2D, dataframe.texFilter);
             gl.uniform1i(renderer.filterTexture, freeTexUnit);
             freeTexUnit++;
+            gl.uniform2f(renderer.resolution, gl.canvas.width, gl.canvas.height);
 
             if (!viz.symbol.default) {
                 const textureId = viz.symbolShader.textureIds.get(viz);
@@ -393,8 +394,6 @@ export default class Renderer {
                     gl.uniform1i(textureId[name], freeTexUnit);
                     freeTexUnit++;
                 });
-
-                gl.uniform2f(renderer.resolution, gl.canvas.width, gl.canvas.height);
             } else if (dataframe.type !== 'line') {
                 // Lines don't support stroke
                 gl.activeTexture(gl.TEXTURE0 + freeTexUnit);

--- a/src/renderer/shaders/geometry/line/lineVertexShader.glsl
+++ b/src/renderer/shaders/geometry/line/lineVertexShader.glsl
@@ -7,6 +7,7 @@ attribute vec2 normal;
 uniform vec2 vertexScale;
 uniform vec2 vertexOffset;
 uniform vec2 normalScale;
+uniform vec2 resolution;
 
 uniform sampler2D colorTex;
 uniform sampler2D widthTex;
@@ -36,7 +37,7 @@ void main(void) {
     z = z * 2. - 1.;
 
     vec4 p = vec4(vertexScale*(vertexPosition)+normalScale*normal*size-vertexOffset, z, 1.);
-    p.xy += normalScale*($transform_inline);
+    p.xy = $transform_inline(p.xy*resolution)/resolution;
     if (size==0. || color.a==0.){
         p.x=10000.;
     }

--- a/src/renderer/shaders/geometry/point/pointVertexShader.glsl
+++ b/src/renderer/shaders/geometry/point/pointVertexShader.glsl
@@ -8,6 +8,7 @@ uniform vec2 vertexOffset;
 uniform float orderMinWidth;
 uniform float orderMaxWidth;
 uniform vec2 normalScale;
+uniform vec2 resolution;
 
 uniform sampler2D colorTex;
 uniform sampler2D widthTex;
@@ -29,6 +30,10 @@ float decodeWidth(vec2 enc) {
 
 $propertyPreface
 $transform_preface
+
+vec2 transform(vec2 p){
+    return $transform_inline(p*resolution)/resolution;
+}
 
 void main(void) {
   color = texture2D(colorTex, abs(featureID));
@@ -53,18 +58,17 @@ void main(void) {
 
   vec2 size2 = (2.*size+4.)*normalScale;
 
-  if (featureID.y<0.){
-      pointCoord = vec2(0.866025, -0.5)*2.*sizeNormalizer;
-      p.xy += size2*vec2(0.866025, -0.5);
-  }else if (featureID.x<0.){
-      pointCoord = vec2(-0.866025, -0.5)*2.*sizeNormalizer;
-      p.xy += size2*vec2(-0.866025, -0.5);
-  }else{
-      pointCoord = vec2(0., 1.)*2.*sizeNormalizer;
-      p.y += size2.y;
-  }
+    if (featureID.y<0.){
+        pointCoord = vec2(0.866025, -0.5)*2.*sizeNormalizer;
+        p.xy += transform(size2*vec2(0.866025, -0.5));
+    }else if (featureID.x<0.){
+        pointCoord = vec2(-0.866025, -0.5)*2.*sizeNormalizer;
+        p.xy += transform(size2*vec2(-0.866025, -0.5));
+    }else{
+        pointCoord = vec2(0., 1.)*2.*sizeNormalizer;
+        p.xy += transform(vec2(0.,size2.y));
+    }
 
-  p.xy += normalScale*($transform_inline);
   if (size == 0. || (stroke.a == 0. && color.a == 0.) || size < orderMinWidth || size >= orderMaxWidth) {
     p.x = 10000.;
   }

--- a/src/renderer/shaders/geometry/polygon/polygonVertexShader.glsl
+++ b/src/renderer/shaders/geometry/polygon/polygonVertexShader.glsl
@@ -7,6 +7,7 @@ attribute vec2 normal;
 uniform vec2 vertexScale;
 uniform vec2 vertexOffset;
 uniform vec2 normalScale;
+uniform vec2 resolution;
 
 uniform sampler2D colorTex;
 uniform sampler2D strokeColorTex;
@@ -40,7 +41,7 @@ void main(void) {
     float size = decodeWidth(texture2D(strokeWidthTex, featureID).rg);
 
     vec4 p = vec4(vertexScale*(vertexPosition)+normalScale*normal*size-vertexOffset, z, 1.);
-    p.xy += normalScale*($transform_inline);
+    p.xy = $transform_inline(p.xy*resolution)/resolution;
 
     if (c.a==0.){
         p.x=10000.;

--- a/src/renderer/shaders/symbolizer/symbolizerVertexShader.glsl
+++ b/src/renderer/shaders/symbolizer/symbolizerVertexShader.glsl
@@ -28,6 +28,10 @@ $symbolPlacement_preface
 $propertyPreface
 $transform_preface
 
+vec2 transform(vec2 p){
+    return $transform_inline(p*resolution)/resolution;
+}
+
 void main(void) {
     featureIDVar = abs(featureID);
     color = texture2D(colorTex, abs(featureID));
@@ -43,18 +47,19 @@ void main(void) {
 
     if (featureID.y<0.){
         pointCoord = vec2(0.866025, -0.5)*2.*sizeNormalizer;
-        p.xy += size2*vec2(0.866025, -0.5);
+        p.xy += transform(size2*vec2(0.866025, -0.5));
     }else if (featureID.x<0.){
         pointCoord = vec2(-0.866025, -0.5)*2.*sizeNormalizer;
-        p.xy += size2*vec2(-0.866025, -0.5);
+        p.xy += transform(size2*vec2(-0.866025, -0.5));
     }else{
         pointCoord = vec2(0., 1.)*2.*sizeNormalizer;
-        p.y += size2.y;
+        p.xy += transform(vec2(0.,size2.y));
     }
     pointCoord.y = -pointCoord.y;
 
+
     p.xy += ($symbolPlacement_inline)*size/resolution;
-    p.xy += normalScale*($transform_inline);
+
 
     vec4 noOverrideColor = vec4(0.);
     if (size==0. || (color.a==0. && color != noOverrideColor) || size<orderMinWidth || size>=orderMaxWidth){

--- a/src/renderer/viz/expressions.js
+++ b/src/renderer/viz/expressions.js
@@ -254,6 +254,7 @@ import Zoomrange from './expressions/Zoomrange';
 import Scaled from './expressions/Scaled';
 import AlphaNormalize from './expressions/AlphaNormalize';
 import Translate from './expressions/transformation/Translate';
+import Rotate from './expressions/transformation/Rotation';
 
 /* Expose classes as constructor functions */
 
@@ -397,6 +398,7 @@ export const zoomrange = (...args) => new Zoomrange(...args);
 
 export const placement = (...args) => new Placement(...args);
 export const translate = (...args) => new Translate(...args);
+export const rotate = (...args) => new Rotate(...args);
 export const alphaNormalize = (...args) => new AlphaNormalize(...args);
 
 export const HOLD = new Constant(Number.MAX_SAFE_INTEGER);

--- a/src/renderer/viz/expressions/ListTransform.js
+++ b/src/renderer/viz/expressions/ListTransform.js
@@ -1,0 +1,29 @@
+import Base from './base';
+import { checkType } from './utils';
+
+export default class ListTransform extends Base {
+    _bindMetadata (meta) {
+        super._bindMetadata(meta);
+        this._getChildren().forEach((image, i) => checkType('ListTransformation', `ListTransformation[${i}]`, 0, 'transformation', image));
+        this.type = 'transformation';
+    }
+
+    eval (feature) {
+        return this.elems.map(elem => elem.eval(feature));
+    }
+
+    _applyToShaderSource (getGLSLforProperty) {
+        const childGLSL = this.elems.map(elem => elem._applyToShaderSource(getGLSLforProperty));
+        return {
+            preface: this._prefaceCode(`
+                ${childGLSL.map(c => c.preface).join('\n')}
+
+                vec2 listTransform${this._uid}(vec2 p) {
+                    ${childGLSL.map(c => `p = ${c.inline}(p);`).join('\n')}
+                    return p;
+                }
+            `),
+            inline: `listTransform${this._uid}`
+        };
+    }
+}

--- a/src/renderer/viz/expressions/basic/List.js
+++ b/src/renderer/viz/expressions/basic/List.js
@@ -9,11 +9,24 @@ const SUPPORTED_CHILD_TYPES = ['number', 'category', 'color', 'time', 'image', '
 /**
  * Wrapper around arrays. Explicit usage is unnecessary since CARTO VL will wrap implicitly all arrays using this function.
  *
- * @param {Number[]|Category[]|Color[]|Date[]|Image[]} elements
- * @returns {List}
+ * When used with Transformation expressions, the returned value will be a Transformation that will chain each single transformation one after another.
+ *
+ * @example <caption>Rotate then translate.</caption>
+ * const s = carto.expressions;
+ * const viz = new carto.Viz({
+ *   transform: [s.rotate(90), s.translate(10, 20)]
+ * });
+ *
+ * @example <caption>Rotate then translate. (String)</caption>
+ * const viz = new carto.Viz(`
+ *   transform: [rotate(90), translate(10, 20)]
+ * `);
+ *
+ * @param {Number[]|Category[]|Color[]|Date[]|Image[]|Transform[]} elements
+ * @returns {List|Transform}
  *
  * @memberof carto.expressions
- * @name array
+ * @name list
  * @function
  * @api
  */

--- a/src/renderer/viz/expressions/basic/List.js
+++ b/src/renderer/viz/expressions/basic/List.js
@@ -2,8 +2,9 @@ import Base from '../base';
 import { checkExpression, implicitCast, getOrdinalFromIndex, checkMaxArguments } from '../utils';
 import ListImage from '../ListImage';
 import ListGeneric from './ListGeneric';
+import ListTransform from '../ListTransform';
 
-const SUPPORTED_CHILD_TYPES = ['number', 'category', 'color', 'time', 'image'];
+const SUPPORTED_CHILD_TYPES = ['number', 'category', 'color', 'time', 'image', 'transformation'];
 
 /**
  * Wrapper around arrays. Explicit usage is unnecessary since CARTO VL will wrap implicitly all arrays using this function.
@@ -61,6 +62,9 @@ export default class List extends Base {
         switch (this.elems[0].type) {
             case 'image':
                 Object.setPrototypeOf(this, ListImage.prototype);
+                break;
+            case 'transformation':
+                Object.setPrototypeOf(this, ListTransform.prototype);
                 break;
             default:
                 Object.setPrototypeOf(this, ListGeneric.prototype);

--- a/src/renderer/viz/expressions/basic/List.js
+++ b/src/renderer/viz/expressions/basic/List.js
@@ -14,11 +14,13 @@ const SUPPORTED_CHILD_TYPES = ['number', 'category', 'color', 'time', 'image', '
  * @example <caption>Rotate then translate.</caption>
  * const s = carto.expressions;
  * const viz = new carto.Viz({
+ *   symbol: s.CROSS
  *   transform: [s.rotate(90), s.translate(10, 20)]
  * });
  *
  * @example <caption>Rotate then translate. (String)</caption>
  * const viz = new carto.Viz(`
+ *   symbol: cross
  *   transform: [rotate(90), translate(10, 20)]
  * `);
  *

--- a/src/renderer/viz/expressions/transformation/Rotation.js
+++ b/src/renderer/viz/expressions/transformation/Rotation.js
@@ -1,0 +1,73 @@
+import BaseExpression from '../base';
+import { checkType, implicitCast, checkMaxArguments } from '../utils';
+
+/**
+ * Rotate. Define a rotation in degrees.
+ *
+ * Limitation: only supported in combination with `symbol:`.
+ *
+ * @param {Number} angle - angle to rotate in degrees in clockwise direction
+ * @return {Transform}
+ *
+ * @example <caption>Rotate 30 degrees in clockwise direction.</caption>
+ * const s = carto.expressions;
+ * const viz = new carto.Viz({
+ *   symbol: cross
+ *   transform: s.rotate(30)
+ * });
+ *
+ * @example <caption>Rotate 30 degrees in clockwise direction. (String)</caption>
+ * const viz = new carto.Viz(`
+ *   symbol: cross
+ *   transform: rotate(30)
+ * `);
+ *
+ * @memberof carto.expressions
+ * @name rotate
+ * @function
+ * @api
+ */
+
+export default class Rotate extends BaseExpression {
+    constructor (angle) {
+        checkMaxArguments(arguments, 1, 'rotate');
+
+        angle = implicitCast(angle);
+        super({ angle });
+        this.type = 'transformation';
+    }
+
+    _applyToShaderSource (getGLSLforProperty) {
+        const angle = this.angle._applyToShaderSource(getGLSLforProperty);
+        return {
+            preface: this._prefaceCode(`
+                ${angle.preface}
+
+                #ifndef DEGREES_TO_RADIANS
+                #define DEGREES_TO_RADIANS
+                float degreesToRadians(float degrees){
+                    return degrees/360.*2.*3.14159265359;
+                }
+                #endif
+                
+                vec2 rotate${this._uid}(vec2 p){
+                    float angle = degreesToRadians(${angle.inline});
+                    mat2 M = mat2(cos(angle), -sin(angle),
+                                  sin(angle),  cos(angle));
+                    return M * p;
+                }`),
+
+            inline: `rotate${this._uid}`
+        };
+    }
+
+    eval (feature) {
+        // TODO
+        return [0, 0];
+    }
+
+    _bindMetadata (meta) {
+        super._bindMetadata(meta);
+        checkType('rotate', 'angle', 0, 'number', this.angle);
+    }
+}

--- a/src/renderer/viz/expressions/transformation/Translate.js
+++ b/src/renderer/viz/expressions/transformation/Translate.js
@@ -32,8 +32,23 @@ export default class Translate extends BaseExpression {
         x = implicitCast(x);
         y = implicitCast(y);
         super({ x, y });
-        this.inlineMaker = inline => `vec2(${inline.x}, ${inline.y})`;
-        this.type = 'translation';
+        this.type = 'transformation';
+    }
+
+    _applyToShaderSource (getGLSLforProperty) {
+        const x = this.x._applyToShaderSource(getGLSLforProperty);
+        const y = this.y._applyToShaderSource(getGLSLforProperty);
+        return {
+            preface: this._prefaceCode(`
+                ${x.preface}
+                ${y.preface}
+
+                vec2 translate${this._uid}(vec2 p){
+                    return p+vec2(${x.inline}, ${y.inline});
+                }`),
+
+            inline: `translate${this._uid}`
+        };
     }
 
     eval (value) {


### PR DESCRIPTION
To partially fix https://github.com/CartoDB/carto-vl/issues/361

The first commit is actually unrelated. I'm not sure, but I think it may have actually finally fixed the variable-related bug that was being described in multiple tickets. Each time it appeared (I think) it caused a different issue, but the root cause (I think) was the same: when issuing a `blendToViz` variables where being interpolated too. I removed that interpolation/blending/animation. That means that changes in variables won't be animated, but I think that's a much better place to be than having multiple difficult to debug bugs.

In the future, we may come up with a better solution.

Regarding the second commit (yep, it wasn't a good idea to mix both commits on the same branch), it adds:
- Rotate (supported for symbols)
- ListTransform, a way to chain multiple transformations (`rotate` and `translate`) one after another