### PR TITLE
Ramp GLSL refactor

### DIFF
--- a/src/renderer/viz/expressions/RampGeneric.js
+++ b/src/renderer/viz/expressions/RampGeneric.js
@@ -81,23 +81,41 @@ export default class RampGeneric extends Base {
         const { palette, others } = this._getPalette();
         const GLSLPalette = palette.map(color => color._applyToShaderSource(getGLSLforProperty));
         const GLSLOthers = others._applyToShaderSource(getGLSLforProperty);
-        const GLSLBlend = this.palette.type === 'number-list'
-            ? _getInlineGLSLBlend(GLSLPalette)
-            : _getInlineColorGLSLBlend(GLSLPalette);
 
         const rampFnReturnType = this.palette.type === 'number-list' ? 'float' : 'vec4';
         const inline = `ramp_color${this._uid}(${input.inline})`;
-
+        const maxValues = GLSLPalette.length - 1;
         const preface = this._prefaceCode(`
             ${input.preface}
             ${CIELabGLSL}
             ${GLSLPalette.map(elem => elem.preface).join('\n')}
             ${GLSLOthers.preface}
 
+            ${rampFnReturnType} ramp_colorBlend${this._uid}(float x){
+                float minIndex = floor(x*${maxValues.toFixed(20)});
+                float maxIndex = ceil(x*${maxValues.toFixed(20)});
+                float m = fract(x*${maxValues.toFixed(20)});
+                ${rampFnReturnType} min;
+                ${rampFnReturnType} max;
+
+                ${GLSLPalette.map((p, index) => `
+                    if (minIndex == ${index}.){
+                        min = ${p.inline};
+                }`).join('\n')
+}
+                ${GLSLPalette.map((p, index) => `
+                    if (maxIndex == ${index}.){
+                        max = ${p.inline};
+                }`).join('\n')
+}
+
+                return mix(min, max, m);
+            }
+
             ${rampFnReturnType} ramp_color${this._uid}(float x){
                 return x==${OTHERS_GLSL_VALUE}
                     ? ${GLSLOthers.inline}
-                    : ${GLSLBlend};
+                    : ramp_colorBlend${this._uid}(x);
             }`
         );
 
@@ -118,32 +136,4 @@ export default class RampGeneric extends Base {
             others: this._defaultOthers && subPalette.othersColor ? subPalette.othersColor : this.others
         };
     }
-}
-
-function _getInlineGLSLBlend (GLSLPalette) {
-    return _generateGLSLBlend(GLSLPalette.map(elem => elem.inline));
-}
-
-function _getInlineColorGLSLBlend (GLSLPalette) {
-    return `cielabToSRGBA(${_generateGLSLBlend(GLSLPalette.map(elem => `sRGBAToCieLAB(${elem.inline})`))})`;
-}
-
-function _generateGLSLBlend (list, index = 0) {
-    const currentValue = list[index];
-
-    if (index === list.length - 1) {
-        return currentValue;
-    }
-
-    const nextBlend = _generateGLSLBlend(list, index + 1);
-
-    return _mixClampGLSL(currentValue, nextBlend, index, list.length);
-}
-
-function _mixClampGLSL (currentValue, nextBlend, index, listLength) {
-    const min = (index / (listLength - 1)).toFixed(20);
-    const max = (1 / (listLength - 1)).toFixed(20);
-    const clamp = `clamp((x - ${min})/${max}, 0., 1.)`;
-
-    return `mix(${currentValue}, ${nextBlend}, ${clamp})`;
 }

--- a/src/renderer/viz/expressions/linear.js
+++ b/src/renderer/viz/expressions/linear.js
@@ -86,13 +86,13 @@ export default class Linear extends BaseExpression {
 
             const smin = (min - inputMin) / inputDiff;
             const smax = (max - inputMin) / inputDiff;
-            this.inlineMaker = (inline) => `((${inline.input}-(${smin.toFixed(20)}))/(${(smax - smin).toFixed(20)}))`;
+            this.inlineMaker = (inline) => `clamp((${inline.input}-(${smin.toFixed(20)}))/(${(smax - smin).toFixed(20)}), 0., 1.)`;
         } else {
             checkType('linear', 'input', 0, 'number', this.input);
             checkType('linear', 'min', 1, 'number', this.min);
             checkType('linear', 'max', 2, 'number', this.max);
 
-            this.inlineMaker = (inline) => `((${inline.input}-${inline.min})/(${inline.max}-${inline.min}))`;
+            this.inlineMaker = (inline) => `clamp((${inline.input}-${inline.min})/(${inline.max}-${inline.min}), 0., 1.)`;
         }
     }
 


### PR DESCRIPTION
This refactor `ramp` GLSL code generation to avoid so many calls to `mix`. I thought this was going to improve performance, but it isn't, upon closer look,  it doesn't seem that the current `ramp` is impacting performance at all.

However, since I already done it, we can discuss if this code is easier or not.

The code still lacks the cielab transformation, it would be super easy to add, but I don't want to keep working on this if this is not going to get merged.