### PR TITLE
Scaled fix

### DIFF
--- a/src/renderer/viz/expressions/Scaled.js
+++ b/src/renderer/viz/expressions/Scaled.js
@@ -40,9 +40,9 @@ export default class Scaled extends BaseExpression {
         return this.scale.eval();
     }
     _bindMetadata (metadata) {
+        super._bindMetadata(metadata);
         checkType('scaled', 'width', 0, 'number', this.scale.a.a);
         checkType('scaled', 'zoomlevel', 1, 'number', this.scale.b);
-        super._bindMetadata(metadata);
     }
     _preDraw (program, drawMetadata, gl) {
         this.scale.a.b.expr = Math.pow(2, drawMetadata.zoomLevel);

--- a/test/unit/renderer/viz/expressions/Scaled.test.js
+++ b/test/unit/renderer/viz/expressions/Scaled.test.js
@@ -2,7 +2,8 @@ import { validateStaticType } from './utils';
 
 describe('src/renderer/viz/expressions/Scaled', () => {
     describe('type', () => {
-        validateStaticType('scaled', [1], 'number');
+        validateStaticType('scaled', ['number'], 'number');
+        validateStaticType('scaled', ['number', 'number'], 'number');
     });
 
     describe('error control', () => {


### PR DESCRIPTION
As reported by @makella `scaled` was broken when the parameters were feature dependent.