### PR TITLE
Make links in guides  relative

### DIFF
--- a/docs/guides/01-getting-started.md
+++ b/docs/guides/01-getting-started.md
@@ -43,7 +43,7 @@ The easiest way to use CARTO VL is to include the required files from our CDN as
 
 Then, you will need to add Mapbox GL JavaScript and CSS files. This will let you use both `carto` and `mapboxgl` in your code.
 
-> Currently, not every Mapbox GL version is compatible with CARTO VL. We highly recommend the following combination. If you are importing CARTO VL from npm, you have to use our Mapbox GL fork. Read more about how to do this in [the advanced guide](https://carto.com/developers/carto-vl/guides/advanced)
+> Currently, not every Mapbox GL version is compatible with CARTO VL. We highly recommend the following combination. If you are importing CARTO VL from npm, you have to use our Mapbox GL fork. Read more about how to do this in [the advanced guide](/developers/carto-vl/guides/advanced)
 
 #### Add map container
 
@@ -94,7 +94,7 @@ At this point you will have a basic map:
 <div class="example-map">
     <iframe
         id="getting-started-step-1"
-        src="https://carto.com/developers/carto-vl/examples/maps/guides/getting-started/step-1.html"
+        src="/developers/carto-vl/examples/maps/guides/getting-started/step-1.html"
         width="100%"
         height="500"
         frameBorder="0">
@@ -103,9 +103,9 @@ At this point you will have a basic map:
 
 ### Define user
 
-In order to render data from CARTO you need to create a CARTO account and then get the necessary [credentials](https://carto.com/developers/fundamentals/authorization/).
+In order to render data from CARTO you need to create a CARTO account and then get the necessary [credentials](/developers/fundamentals/authorization/).
 
-The first thing you need to do is [authenticate the client](https://carto.com/developers/carto-vl/reference/#cartosetdefaultauth) with your `user` and `apiKey`. For guides and examples, we provide a public CARTO account that you can use to try out the library:
+The first thing you need to do is [authenticate the client](/developers/carto-vl/reference/#cartosetdefaultauth) with your `user` and `apiKey`. For guides and examples, we provide a public CARTO account that you can use to try out the library:
 
 ```js
 carto.setDefaultAuth({
@@ -116,7 +116,7 @@ carto.setDefaultAuth({
 
 ### Define source
 
-The next step is to define the [`source`](https://carto.com/developers/carto-vl/guides/02-using-sources) from your account to be displayed on the map. In the example below, the `source` is a dataset named `populated_places` with all the populated places around the world.
+The next step is to define the [`source`](/developers/carto-vl/guides/02-using-sources) from your account to be displayed on the map. In the example below, the `source` is a dataset named `populated_places` with all the populated places around the world.
 
 ```js
 const source = new carto.source.Dataset('populated_places');
@@ -124,7 +124,7 @@ const source = new carto.source.Dataset('populated_places');
 
 ### Define Viz object
 
-A [`Viz object`](https://carto.com/developers/carto-vl/reference/#cartoviz) is one of the core elements of CARTO VL. It defines how the data will be styled, displayed, and processed. In this case you have to create an empty Viz object, that will use the style set by default.
+A [`Viz object`](/developers/carto-vl/reference/#cartoviz) is one of the core elements of CARTO VL. It defines how the data will be styled, displayed, and processed. In this case you have to create an empty Viz object, that will use the style set by default.
 
 ```js
 const viz = new carto.Viz();
@@ -132,14 +132,14 @@ const viz = new carto.Viz();
 
 ### Define map layer
 
-Now that you have defined a `source` and a `Viz object`, you need to create a new [`layer`](https://carto.com/developers/carto-vl/reference/#cartolayer) that can be added to the map.
+Now that you have defined a `source` and a `Viz object`, you need to create a new [`layer`](/developers/carto-vl/reference/#cartolayer) that can be added to the map.
 
 ```js
 const layer = new carto.Layer('layer', source, viz);
 ```
 
 ### Add map layer
-Once you have the layer, you need to use the [`addTo`](https://carto.com/developers/carto-vl/reference/#cartolayeraddto) method to add it to the map.
+Once you have the layer, you need to use the [`addTo`](/developers/carto-vl/reference/#cartolayeraddto) method to add it to the map.
 
 ```js
 layer.addTo(map);
@@ -158,14 +158,14 @@ const viz = new carto.Viz(`
 `);
 ```
 
-For more information about styling, check out the guide [Introduction to Styling](https://carto.com/developers/carto-vl/guides/introduction-to-styling/).
+For more information about styling, check out the guide [Introduction to Styling](/developers/carto-vl/guides/introduction-to-styling/).
 
 ### All together
 
 <div class="example-map">
     <iframe
         id="getting-started-step-2"
-        src="https://carto.com/developers/carto-vl/examples/maps/guides/getting-started/step-2.html"
+        src="/developers/carto-vl/examples/maps/guides/getting-started/step-2.html"
         width="100%"
         height="500"
         frameBorder="0">

--- a/docs/guides/01-getting-started.md
+++ b/docs/guides/01-getting-started.md
@@ -7,7 +7,7 @@ Welcome to the CARTO VL guides! This documentation is meant to lead you from the
 <div class="example-map">
     <iframe
         id="getting-started-final-result"
-        src="https://carto.com/developers/carto-vl/examples/maps/guides/getting-started/step-2.html"
+        src="/developers/carto-vl/examples/maps/guides/getting-started/step-2.html"
         width="100%"
         height="500"
         frameBorder="0">

--- a/docs/guides/02-using-sources.md
+++ b/docs/guides/02-using-sources.md
@@ -1,7 +1,7 @@
 ## Using data in your visualization with Sources
 In this guide you will learn how to use different data sources for your CARTO VL visualizations. After practicing with it, you will be able to connect to your datasets in several ways, and you will know which is the better option for you.
 
-This guide assumes that you have previously gone through the [Getting Started Guide](https://carto.com/developers/carto-vl/guides/getting-started), so you already know how to make a simple map.
+This guide assumes that you have previously gone through the [Getting Started Guide](/developers/carto-vl/guides/getting-started), so you already know how to make a simple map.
 
 
 ### How to get data
@@ -15,16 +15,16 @@ Our library currently supports these three options:
 Every option is a different kind of **Source**, and CARTO VL provides you with a suitable object in its API to connect to them under the namespace `carto.source` (for example `carto.source.Dataset`).
 
 Both *Dataset* and *SQL* are based in [Vector Tiles](https://carto.com/help/glossary/#vector-tile), following *Mapbox Vector Tile Specification* or [MVT](https://www.mapbox.com/vector-tiles/specification/). This is an advanced technology which allows transferring geographic data from the server to your browser in small chunks, allowing a good performance and powerful dynamic styling.
-> In fact, there is a fourth type of source in CARTO VL called [MVT](https://carto.com/developers/carto-vl/reference/#cartosourcemvt) but it is not meant to be used directly by the users, except in very precise / advance cases.
+> In fact, there is a fourth type of source in CARTO VL called [MVT](/developers/carto-vl/reference/#cartosourcemvt) but it is not meant to be used directly by the users, except in very precise / advance cases.
 
 
 Now you will see how to use the main three type of sources, but first let's create a basic map.
 
-You can start from this [basemap](https://carto.com/developers/carto-vl/examples/getting-started/basemap). Go ahead and clone its source code into a new file called `sources.html`, we will wait for you...
+You can start from this [basemap](/developers/carto-vl/examples/getting-started/basemap). Go ahead and clone its source code into a new file called `sources.html`, we will wait for you...
 
 
 ### Dataset
-A `Dataset` can be managed using [carto.source.Dataset](https://carto.com/developers/carto-vl/reference/#cartosourcedataset). It is a source with information regarding to an specific topic (such as *stores*, *streets* or *counties*). If you have a GIS background, this is like a vector file with points, lines or polygons, but hosted at CARTO. If you don't, you can imagine it as a simple table at the server, with a geometry field you can map.
+A `Dataset` can be managed using [carto.source.Dataset](/developers/carto-vl/reference/#cartosourcedataset). It is a source with information regarding to an specific topic (such as *stores*, *streets* or *counties*). If you have a GIS background, this is like a vector file with points, lines or polygons, but hosted at CARTO. If you don't, you can imagine it as a simple table at the server, with a geometry field you can map.
 
 #### Add a Dataset
 You already know how to add a `Dataset` thanks to *Getting Started* guide:
@@ -61,7 +61,7 @@ The result should look like this:
 <div class="example-map">
     <iframe
         id="guides-sources-step-1"
-        src="https://carto.com/developers/carto-vl/examples/maps/guides/sources/step-1.html"
+        src="/developers/carto-vl/examples/maps/guides/sources/step-1.html"
         width="100%"
         height="500"
         frameBorder="0">
@@ -73,7 +73,7 @@ You have a CARTO account, with several custom datasets, and you want to easily v
 
 
 ### GeoJSON
-A `GeoJSON` can be used in CARTO VL with [carto.source.GeoJSON](https://carto.com/developers/carto-vl/reference/#cartosourcegeojson). GeoJSON is an standard format to encode geographic data using JavaScript. It is indeed a common JSON, extended with spatial features, and you can easily create some *.geojson* contents online at [geojson.io](http://geojson.io/).
+A `GeoJSON` can be used in CARTO VL with [carto.source.GeoJSON](/developers/carto-vl/reference/#cartosourcegeojson). GeoJSON is an standard format to encode geographic data using JavaScript. It is indeed a common JSON, extended with spatial features, and you can easily create some *.geojson* contents online at [geojson.io](http://geojson.io/).
 
 With the next steps, you'll create a new layer with this format, in this case visualizing the main *CARTO offices*.
 
@@ -125,7 +125,7 @@ const offices = {
     ]
 };
 ```
-> If your dataset is much bigger, you would probably store that content in an external file (see this [External GeoJSON layer](https://carto.com/developers/carto-vl/examples/#example-external-geojson-layer) example).
+> If your dataset is much bigger, you would probably store that content in an external file (see this [External GeoJSON layer](/developers/carto-vl/examples/#example-external-geojson-layer) example).
 
 And then use it within a GeoJSON source, like this:
 ```js
@@ -154,7 +154,7 @@ Now the map should look like this:
 <div class="example-map">
     <iframe
         id="guides-sources-source-geojson"
-        src="https://carto.com/developers/carto-vl/examples/maps/guides/sources/step-2.html"
+        src="/developers/carto-vl/examples/maps/guides/sources/step-2.html"
         width="100%"
         height="500"
         frameBorder="0">
@@ -208,7 +208,7 @@ Congrats! You have finished this guide. The final map should look like this:
 <div class="example-map">
     <iframe
         id="guides-sources-source-sql"
-        src="https://carto.com/developers/carto-vl/examples/maps/guides/sources/step-3.html"
+        src="/developers/carto-vl/examples/maps/guides/sources/step-3.html"
         width="100%"
         height="500"
         frameBorder="0">

--- a/examples/guides/getting-started/step-1.html
+++ b/examples/guides/getting-started/step-1.html
@@ -15,7 +15,6 @@
             height: 100%;
             width: 100%;
         }
-
     </style>
 </head>
 
@@ -26,7 +25,7 @@
         // Add basemap and set properties
         const map = new mapboxgl.Map({
             container: 'map',
-            style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
+            style: carto.basemaps.voyager,
             center: [0, 30],
             zoom: 2,
             dragRotate: false,


### PR DESCRIPTION
Changes to fix developer-center's links (that's useful when using for example a link from one guide to another).

We remove <del>**`https://carto.com/developers/....wadus`**</del> and just use **`/developers/...wadus`** in the links.

This way we can have a full - working copy at staging, when making our changes to the tech-doc, as in #950 