### PR TITLE
Fix ramp others

### DIFF
--- a/src/renderer/viz/expressions/Ramp.js
+++ b/src/renderer/viz/expressions/Ramp.js
@@ -108,6 +108,7 @@ export default class Ramp extends BaseExpression {
         checkExpression('ramp', 'palette', 1, palette);
 
         if (others !== DEFAULT_RAMP_OTHERS) {
+            others = implicitCast(others);
             checkExpression('ramp', 'others', 2, others);
         }
 

--- a/src/renderer/viz/expressions/RampGeneric.js
+++ b/src/renderer/viz/expressions/RampGeneric.js
@@ -22,7 +22,9 @@ export default class RampGeneric extends Base {
             this.others = this.palette.type === 'number-list'
                 ? DEFAULT_RAMP_OTHERS_NUMBER
                 : DEFAULT_RAMP_OTHERS_COLOR;
+            this.others._bindMetadata(metadata);
         } else {
+            this.others._bindMetadata(metadata);
             checkType('ramp', 'others', 2, this.palette.childType, this.others);
         }
 
@@ -36,7 +38,6 @@ export default class RampGeneric extends Base {
 
         checkType('ramp', 'input', 0, ['number', 'category'], this.input);
 
-        this.others._bindMetadata(metadata);
         this.childrenNames.push('others');
         this._metadata = metadata;
     }

--- a/test/unit/renderer/viz/expressions/ramp.test.js
+++ b/test/unit/renderer/viz/expressions/ramp.test.js
@@ -19,8 +19,11 @@ describe('src/renderer/viz/expressions/ramp', () => {
 
     describe('type', () => {
         validateDynamicType('ramp', ['number', 'palette'], 'color');
+        validateDynamicType('ramp', ['number', 'number-list', 'number'], 'number');
         validateDynamicType('ramp', ['category', 'palette'], 'color');
+        validateDynamicType('ramp', ['category', 'palette', 'color'], 'color');
         validateDynamicType('ramp', ['category', 'color-list'], 'color');
+        validateDynamicType('ramp', ['category', 'color-list', 'color'], 'color');
         validateDynamicType('ramp', ['category', 'number-list'], 'number');
         validateDynamicType('ramp', ['category', 'image-list'], 'image');
     });


### PR DESCRIPTION
As discovered by @ztephm `ramp` `others` parameter doesn't work well in some circumstances.

One tested example is: `ramp(..., ..., 5)`, which fails due to "invalid types".

This happens because `5` is not implicitly cast to `number(5)`.

While adding regression tests for it I discovered another bug: `others` don't work with feature-dependent expressions because `this.others._bindMetadata(metadata);` was called after the type check, which makes the check fail.