### PR TITLE
Fix request tiles & Fix interactivity corner case & Fix perf regression

### DIFF
--- a/debug/viewportAggPluto.html
+++ b/debug/viewportAggPluto.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Add layer | CARTO</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="UTF-8">
+  <!-- Include CARTO VL JS -->
+  <script src="../dist/carto-vl.js"></script>
+  <!-- Include Mapbox GL JS -->
+  <script src="https://libs.cartocdn.com/mapbox-gl/v0.48.0-carto1/mapbox-gl.js"></script>
+  <!-- Include Mapbox GL CSS -->
+  <link href="https://libs.cartocdn.com/mapbox-gl/v0.48.0-carto1/mapbox-gl.css" rel="stylesheet" />
+  <link rel="stylesheet" type="text/css" href="../examples/style.css">
+</head>
+<body>
+  <div id="map"></div>
+  <aside class="toolbox">
+    <div class="box">
+      <header>
+        <h1>Add layer</h1>
+      </header>
+      <section>
+        <p class="description open-sans">Show viewport aggregations</p>
+      </section>
+      <footer class="js-footer"></footer>
+    </div>
+  </aside>
+  <div id="loader">
+    <div class="CDB-LoaderIcon CDB-LoaderIcon--big">
+      <svg class="CDB-LoaderIcon-spinner" viewBox="0 0 50 50">
+        <circle class="CDB-LoaderIcon-path" cx="25" cy="25" r="20" fill="none"></circle>
+      </svg>
+    </div>
+  </div>
+  <script>
+    const map = new mapboxgl.Map({
+      container: 'map',
+      style: carto.basemaps.voyager,
+      center: [-73.98076101209858, 40.751681063],
+      zoom: 13,
+      scrollZoom: false,
+    });
+
+    const nav = new mapboxgl.NavigationControl({
+      showCompass: false
+    });
+    map.addControl(nav, 'top-left');
+
+    // Define user
+    carto.setDefaultAuth({
+      user: 'cartovl',
+      apiKey: 'default_public'
+    });
+
+    // Define layer
+    const source = new carto.source.Dataset('mnmappluto');
+    const viz = new carto.Viz(`
+        color: ramp(linear(log($numfloors), 1, 4), Earth)
+        @avg: viewportMax($numfloors)
+        filter: 0.51
+    `);
+    const layer = new carto.Layer('layer', source, viz);
+    const interactivity = new carto.Interactivity(layer);
+    interactivity.on('featureHover', f=>{
+      console.log(f);
+    });
+    layer.on('updated', ()=>{
+        console.log(viz.variables.avg.value);
+    });
+
+    layer.addTo(map, 'watername_ocean');
+    layer.on('loaded', hideLoader);
+
+    function hideLoader() {
+      document.getElementById('loader').style.opacity = '0';
+    }
+  </script>
+</body>
+</html>

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -196,9 +196,8 @@ export default class Layer {
         }
 
         this._source = source;
-        if (this._matrix) {
-            this.requestData();
-        }
+        this._noFirstRequestData = false;
+        this.requestData();
 
         viz.setDefaultsIfRequired(this.metadata.geomType);
         await this._context;

--- a/src/renderer/Dataframe.js
+++ b/src/renderer/Dataframe.js
@@ -98,6 +98,9 @@ export default class Dataframe extends DummyDataframe {
     }
 
     getFeaturesAtPosition (pos, viz) {
+        if (!this.matrix) {
+            return [];
+        }
         switch (this.type) {
             case 'point':
                 return this._getPointsAtPosition(pos, viz);

--- a/src/renderer/Dataframe.js
+++ b/src/renderer/Dataframe.js
@@ -464,9 +464,9 @@ export default class Dataframe extends DummyDataframe {
         };
         const pointAABB = {
             minx: ndcPoint.x + ox - widthScale * 2 / WIDTH,
-            miny: ndcPoint.y + oy - widthScale * 2 / HEIGHT,
+            miny: ndcPoint.y - oy - widthScale * 2 / HEIGHT,
             maxx: ndcPoint.x + ox + widthScale * 2 / WIDTH,
-            maxy: ndcPoint.y + oy + widthScale * 2 / HEIGHT
+            maxy: ndcPoint.y - oy + widthScale * 2 / HEIGHT
         };
 
         return !_isFeatureAABBOutsideViewport(ndcAABB, pointAABB);

--- a/src/renderer/Dataframe.js
+++ b/src/renderer/Dataframe.js
@@ -580,14 +580,3 @@ function _isFeatureAABBOutsideViewport (featureAABB, viewportAABB) {
     return (featureAABB.minx > viewportAABB.maxx || featureAABB.miny > viewportAABB.maxy ||
         featureAABB.maxx < viewportAABB.minx || featureAABB.maxy < viewportAABB.miny);
 }
-
-// Multiply a vector of the form `vec4(a[0], a[1], 0, 1)` by a 4x4 matrix
-// Storing the result on `out`, returning `out`
-function transformMat4Vec2 (out, vector, matrix) {
-    const x = vector[0];
-    const y = vector[1];
-    out[0] = matrix[0] * x + matrix[4] * y + matrix[12];
-    out[1] = matrix[1] * x + matrix[5] * y + matrix[13];
-    out[3] = matrix[3] * x + matrix[7] * y + matrix[15];
-    return out;
-}

--- a/src/renderer/Dataframe.js
+++ b/src/renderer/Dataframe.js
@@ -179,13 +179,18 @@ export default class Dataframe extends DummyDataframe {
         if (!this.matrix) {
             return false;
         }
+        const matrix = this.matrix;
         const x = this.decodedGeom.vertices[6 * featureIndex + 0];
         const y = this.decodedGeom.vertices[6 * featureIndex + 1];
+
+        const ox = matrix[0] * x + matrix[4] * y + matrix[12];
+        const oy = matrix[1] * x + matrix[5] * y + matrix[13];
+        const ow = matrix[3] * x + matrix[7] * y + matrix[15];
+
         // Transform to Clip Space
-        const p = transformMat4Vec2(this.t1, [x, y], this.matrix);
         // Check in Clip Space if the point is inside the viewport
         // See https://www.khronos.org/opengl/wiki/Vertex_Post-Processing#Clipping
-        return p[0] > -p[3] && p[0] < p[3] && p[1] > -p[3] && p[1] < p[3];
+        return ox > -ow && ox < ow && oy > -ow && oy < ow;
     }
 
     _isPolygonInViewport (featureIndex) {

--- a/src/renderer/Dataframe.js
+++ b/src/renderer/Dataframe.js
@@ -114,6 +114,9 @@ export default class Dataframe extends DummyDataframe {
     }
 
     inViewport (featureIndex) {
+        if (!this.matrix) {
+            return false;
+        }
         switch (this.type) {
             case 'point':
                 return this._isPointInViewport(featureIndex);
@@ -176,9 +179,6 @@ export default class Dataframe extends DummyDataframe {
     }
 
     _isPointInViewport (featureIndex) {
-        if (!this.matrix) {
-            return false;
-        }
         const matrix = this.matrix;
         const x = this.decodedGeom.vertices[6 * featureIndex + 0];
         const y = this.decodedGeom.vertices[6 * featureIndex + 1];
@@ -208,32 +208,28 @@ export default class Dataframe extends DummyDataframe {
     }
 
     _compareAABBs (featureAABB) {
-        if (featureAABB === null || !this.matrix) {
+        if (featureAABB === null) {
             return AABBTestResults.OUTSIDE;
         }
 
-        const corners = [
-            this._projectToNDC(this.t1, [featureAABB.minx, featureAABB.miny]),
-            this._projectToNDC(this.t2, [featureAABB.minx, featureAABB.maxy]),
-            this._projectToNDC(this.t3, [featureAABB.maxx, featureAABB.miny]),
-            this._projectToNDC(this.t4, [featureAABB.maxx, featureAABB.maxy])
-        ];
+        const corners1 = this._projectToNDC(featureAABB.minx, featureAABB.miny);
+        const corners2 = this._projectToNDC(featureAABB.minx, featureAABB.maxy);
+        const corners3 = this._projectToNDC(featureAABB.maxx, featureAABB.miny);
+        const corners4 = this._projectToNDC(featureAABB.maxx, featureAABB.maxy);
 
         const featureStrokeAABB = {
-            minx: Math.min(corners[0][0], corners[1][0], corners[2][0], corners[3][0]),
-            miny: Math.min(corners[0][1], corners[1][1], corners[2][1], corners[3][1]),
-            maxx: Math.max(corners[0][0], corners[1][0], corners[2][0], corners[3][0]),
-            maxy: Math.max(corners[0][1], corners[1][1], corners[2][1], corners[3][1])
+            minx: Math.min(corners1.x, corners2.x, corners3.x, corners4.x),
+            miny: Math.min(corners1.y, corners2.y, corners3.y, corners4.y),
+            maxx: Math.max(corners1.x, corners2.x, corners3.x, corners4.x),
+            maxy: Math.max(corners1.y, corners2.y, corners3.y, corners4.y)
         };
 
-        // NDC viewport (by definition)
         const viewportAABB = {
             minx: -1,
             miny: -1,
             maxx: 1,
             maxy: 1
         };
-
         switch (true) {
             case _isFeatureAABBInsideViewport(featureStrokeAABB, viewportAABB):
                 return AABBTestResults.INSIDE;
@@ -250,30 +246,19 @@ export default class Dataframe extends DummyDataframe {
         }
         const aabb = {minx: -1, miny: -1, maxx: 1, maxy: 1};
         for (let i = start; i < end; i += 6) {
-            const v1 = this._projectToNDC(this.t1, [
-                vertices[i + 0],
-                vertices[i + 1]
-            ]);
-
-            const v2 = this._projectToNDC(this.t2, [
-                vertices[i + 2],
-                vertices[i + 3]
-            ]);
-
-            const v3 = this._projectToNDC(this.t3, [
-                vertices[i + 4],
-                vertices[i + 5]
-            ]);
+            const v1 = this._projectToNDC(vertices[i + 0], vertices[i + 1]);
+            const v2 = this._projectToNDC(vertices[i + 2], vertices[i + 3]);
+            const v3 = this._projectToNDC(vertices[i + 4], vertices[i + 5]);
 
             const triangle = [{
-                x: v1[0],
-                y: v1[1]
+                x: v1.x,
+                y: v1.y
             }, {
-                x: v2[0],
-                y: v2[1]
+                x: v2.x,
+                y: v2.y
             }, {
-                x: v3[0],
-                y: v3[1]
+                x: v3.x,
+                y: v3.y
             }];
 
             if (triangleCollides(triangle, aabb)) {
@@ -284,12 +269,14 @@ export default class Dataframe extends DummyDataframe {
         return false;
     }
 
-    _projectToNDC (t, p) {
-        const p2 = transformMat4Vec2(t, p, this.matrix);
+    _projectToNDC (x, y) {
+        const matrix = this.matrix;
+        const ox = matrix[0] * x + matrix[4] * y + matrix[12];
+        const oy = matrix[1] * x + matrix[5] * y + matrix[13];
+        const ow = matrix[3] * x + matrix[7] * y + matrix[15];
+
         // Normalize by W
-        p2[0] /= p2[3];
-        p2[1] /= p2[3];
-        return p2;
+        return {x: ox / ow, y: oy / ow};
     }
 
     _getPointsAtPosition (pos, viz) {
@@ -312,25 +299,25 @@ export default class Dataframe extends DummyDataframe {
                 x: points[i],
                 y: points[i + 1]
             };
-            const c2 = this._projectToNDC(this.t1, [center.x, center.y]);
+            const c2 = this._projectToNDC(center.x, center.y);
 
             // Project to pixel space
-            c2[0] *= 0.5;
-            c2[1] *= -0.5;
-            c2[0] += 0.5;
-            c2[1] += 0.5;
-            c2[0] *= WIDTH;
-            c2[1] *= HEIGHT;
+            c2.x *= 0.5;
+            c2.y *= -0.5;
+            c2.x += 0.5;
+            c2.y += 0.5;
+            c2.x *= WIDTH;
+            c2.y *= HEIGHT;
 
             const radius = this._computePointRadius(feature, viz);
 
             if (!viz.transform.default) {
                 const vizOffset = viz.transform.eval(feature);
-                c2[0] += vizOffset[0];
-                c2[1] -= vizOffset[1];
+                c2.x += vizOffset.x;
+                c2.y -= vizOffset.y;
             }
 
-            const inside = pointInCircle(pos, {x: c2[0], y: c2[1]}, radius);
+            const inside = pointInCircle(pos, c2, radius);
 
             if (inside) {
                 features.push(this.getFeature(featureIndex));
@@ -401,40 +388,40 @@ export default class Dataframe extends DummyDataframe {
                 }
             }
 
-            const v1 = this._projectToNDC(this.t1, [
+            const v1 = this._projectToNDC(
                 vertices[i + 0] + normals[i + 0] * strokeWidthScale,
                 vertices[i + 1] + normals[i + 1] * strokeWidthScale
-            ]);
+            );
 
-            const v2 = this._projectToNDC(this.t2, [
+            const v2 = this._projectToNDC(
                 vertices[i + 2] + normals[i + 2] * strokeWidthScale,
                 vertices[i + 3] + normals[i + 3] * strokeWidthScale
-            ]);
+            );
 
-            const v3 = this._projectToNDC(this.t3, [
+            const v3 = this._projectToNDC(
                 vertices[i + 4] + normals[i + 4] * strokeWidthScale,
                 vertices[i + 5] + normals[i + 5] * strokeWidthScale
-            ]);
+            );
 
-            v1[0] *= 0.5;
-            v1[1] *= -0.5;
-            v1[0] += 0.5;
-            v1[1] += 0.5;
+            v1.x *= 0.5;
+            v1.y *= -0.5;
+            v1.x += 0.5;
+            v1.y += 0.5;
 
-            v2[0] *= 0.5;
-            v2[1] *= -0.5;
-            v2[0] += 0.5;
-            v2[1] += 0.5;
+            v2.x *= 0.5;
+            v2.y *= -0.5;
+            v2.x += 0.5;
+            v2.y += 0.5;
 
-            v3[0] *= 0.5;
-            v3[1] *= -0.5;
-            v3[0] += 0.5;
-            v3[1] += 0.5;
+            v3.x *= 0.5;
+            v3.y *= -0.5;
+            v3.x += 0.5;
+            v3.y += 0.5;
 
             const inside = pointInTriangle(pos,
-                { x: v1[0] * WIDTH + offset.x, y: v1[1] * HEIGHT - offset.y },
-                { x: v2[0] * WIDTH + offset.x, y: v2[1] * HEIGHT - offset.y },
-                { x: v3[0] * WIDTH + offset.x, y: v3[1] * HEIGHT - offset.y });
+                { x: v1.x * WIDTH + offset.x, y: v1.y * HEIGHT - offset.y },
+                { x: v2.x * WIDTH + offset.x, y: v2.y * HEIGHT - offset.y },
+                { x: v3.x * WIDTH + offset.x, y: v3.y * HEIGHT - offset.y });
 
             if (inside) {
                 features.push(this.getFeature(featureIndex));
@@ -453,18 +440,17 @@ export default class Dataframe extends DummyDataframe {
         if (aabb === null || !this.matrix) {
             return false;
         }
-        const corners = [
-            this._projectToNDC(this.t1, [aabb.minx, aabb.miny]),
-            this._projectToNDC(this.t2, [aabb.minx, aabb.maxy]),
-            this._projectToNDC(this.t3, [aabb.maxx, aabb.miny]),
-            this._projectToNDC(this.t4, [aabb.maxx, aabb.maxy])
-        ];
+
+        const corners1 = this._projectToNDC(aabb.minx, aabb.miny);
+        const corners2 = this._projectToNDC(aabb.minx, aabb.maxy);
+        const corners3 = this._projectToNDC(aabb.maxx, aabb.miny);
+        const corners4 = this._projectToNDC(aabb.maxx, aabb.maxy);
 
         const ndcAABB = {
-            minx: Math.min(corners[0][0], corners[1][0], corners[2][0], corners[3][0]),
-            miny: Math.min(corners[0][1], corners[1][1], corners[2][1], corners[3][1]),
-            maxx: Math.max(corners[0][0], corners[1][0], corners[2][0], corners[3][0]),
-            maxy: Math.max(corners[0][1], corners[1][1], corners[2][1], corners[3][1])
+            minx: Math.min(corners1.x, corners2.x, corners3.x, corners4.x),
+            miny: Math.min(corners1.y, corners2.y, corners3.y, corners4.y),
+            maxx: Math.max(corners1.x, corners2.x, corners3.x, corners4.x),
+            maxy: Math.max(corners1.y, corners2.y, corners3.y, corners4.y)
         };
 
         const WIDTH = this.renderer.gl.canvas.width / window.devicePixelRatio;


### PR DESCRIPTION
- Layer.update() was re-instancing, but it wasn't requesting new tiles unless the user moved the map
- Interactivity could throw an error (ignored) if a tile loaded and a user interactivity event was fired before it was rendered for the first time.
- Fix performance regression of dataframe.js with viewport agg. I don't know what happened since this was tested and optimized in the original rotation branch. But when I re-tested it, the performance had regressed.
- Fix interactivity with polygons with offset