### PR TITLE
Remove babel-loader from development build

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -10,22 +10,10 @@ module.exports = {
         library: 'carto',
         libraryTarget: 'umd'
     },
-    devtool: 'sourcemap',
+    devtool: 'source-map',
     mode: 'development',
     module: {
         rules: [
-            {
-                test: /\.js$/,
-                exclude: /node_modules/,
-                use: {
-                    loader: 'babel-loader',
-                    options: {
-                        presets: [
-                            '@babel/preset-env'
-                        ]
-                    }
-                }
-            },
             { test: /\.glsl$/, use: 'webpack-glsl-loader' },
             { test: /\.svg$/, use: 'svg-inline-loader' },
             {


### PR DESCRIPTION
### Related to https://github.com/CartoDB/carto-vl/issues/1039

Remove babel-loader from webpack configuration in `build:dev`