### PR TITLE
Fallback to value when evaluating in a non-FeatureDependent expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix an error when evaluating non-feature-dependent expressions
 
 ## [0.9.1] - 2018-10-09
 ### Fixed

--- a/src/renderer/viz/expressions/base.js
+++ b/src/renderer/viz/expressions/base.js
@@ -66,7 +66,10 @@ export default class Base {
      *
      */
     eval (feature) {
-        throw new CartoRuntimeError('Unimplemented');
+        if (this.isFeatureDependent()) {
+            throw new CartoRuntimeError('Unimplemented');
+        }
+        return this.value;
     }
 
     /**


### PR DESCRIPTION
### Related to https://github.com/CartoDB/carto-vl/issues/1045

This adds a fix to avoid breaking when evaluating an expression for a feature in a non feature-dependent expression.
