### PR TITLE
Take clusterCount() into viewport calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Fix an error when evaluating non-feature-dependent expressions
+- Fix viewportPercentile (styling by it was broken)
+- Fix viewport* functions to take clustering into account
 
 ## [0.9.1] - 2018-10-09
 ### Fixed

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportAggregation.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportAggregation.js
@@ -7,7 +7,8 @@ export default class ViewportAggregation extends BaseExpression {
      * @param {*} property
      */
     constructor ({ property }) {
-        super({ property: implicitCast(property), _impostor: number(0) });
+        property = implicitCast(property);
+        super({ property, _impostor: number(0) });
         this._isViewport = true;
         this.type = 'number';
         this.inlineMaker = inline => inline._impostor;

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportAggregation.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportAggregation.js
@@ -14,10 +14,6 @@ export default class ViewportAggregation extends BaseExpression {
         this.inlineMaker = inline => inline._impostor;
     }
 
-    isFeatureDependent () {
-        return false;
-    }
-
     _bindMetadata (metadata) {
         // TODO improve type check
         super._bindMetadata(metadata);

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportAvg.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportAvg.js
@@ -46,7 +46,7 @@ export default class ViewportAvg extends ViewportAggregation {
         const propertyValue = this.property.eval(feature);
 
         if (!Number.isNaN(propertyValue)) {
-            const clusterCount = feature._cdb_feature_count;
+            const clusterCount = feature._cdb_feature_count || 1;
             this._count += clusterCount;
             this._sum += clusterCount * propertyValue;
         }

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportAvg.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportAvg.js
@@ -46,8 +46,9 @@ export default class ViewportAvg extends ViewportAggregation {
         const propertyValue = this.property.eval(feature);
 
         if (!Number.isNaN(propertyValue)) {
-            this._count++;
-            this._sum += propertyValue;
+            const clusterCount = feature._cdb_feature_count;
+            this._count += clusterCount;
+            this._sum += clusterCount * propertyValue;
         }
     }
 

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportAvg.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportAvg.js
@@ -1,5 +1,6 @@
 import ViewportAggregation from './ViewportAggregation';
 import { checkMaxArguments } from '../../utils';
+import { CLUSTER_FEATURE_COUNT } from '../../../../schema';
 
 /**
  * Return the average value of an expression for the features showed in the viewport (features outside the viewport and features that don't pass the filter will be excluded).
@@ -46,7 +47,7 @@ export default class ViewportAvg extends ViewportAggregation {
         const propertyValue = this.property.eval(feature);
 
         if (!Number.isNaN(propertyValue)) {
-            const clusterCount = feature._cdb_feature_count || 1;
+            const clusterCount = feature[CLUSTER_FEATURE_COUNT] || 1;
             this._count += clusterCount;
             this._sum += clusterCount * propertyValue;
         }

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportCount.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportCount.js
@@ -43,7 +43,7 @@ export default class ViewportCount extends ViewportAggregation {
     }
 
     accumViewportAgg (feature) {
-        const clusterCount = feature._cdb_feature_count;
+        const clusterCount = feature._cdb_feature_count || 1;
         this._value += clusterCount;
     }
 

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportCount.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportCount.js
@@ -1,6 +1,7 @@
 import ViewportAggregation from './ViewportAggregation';
 import { number } from '../../../expressions';
 import { checkMaxArguments } from '../../utils';
+import { CLUSTER_FEATURE_COUNT } from '../../../../schema';
 
 /**
  * Return the feature count of the features showed in the viewport (features outside the viewport and features that don't pass the filter will be excluded).
@@ -43,7 +44,7 @@ export default class ViewportCount extends ViewportAggregation {
     }
 
     accumViewportAgg (feature) {
-        const clusterCount = feature._cdb_feature_count || 1;
+        const clusterCount = feature[CLUSTER_FEATURE_COUNT] || 1;
         this._value += clusterCount;
     }
 

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportCount.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportCount.js
@@ -42,8 +42,9 @@ export default class ViewportCount extends ViewportAggregation {
         return this.value;
     }
 
-    accumViewportAgg () {
-        this._value++;
+    accumViewportAgg (feature) {
+        const clusterCount = feature._cdb_feature_count;
+        this._value += clusterCount;
     }
 
     _resetViewportAgg () {

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportHistogram.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportHistogram.js
@@ -66,7 +66,8 @@ export default class ViewportHistogram extends BaseExpression {
         const x = this.x.eval(feature);
 
         if (x !== undefined) {
-            const weight = this.weight.eval(feature);
+            const clusterCount = feature._cdb_feature_count;
+            const weight = clusterCount * this.weight.eval(feature);
             const count = this._histogram.get(x) || 0;
             this._histogram.set(x, count + weight);
         }

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportHistogram.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportHistogram.js
@@ -66,7 +66,7 @@ export default class ViewportHistogram extends BaseExpression {
         const x = this.x.eval(feature);
 
         if (x !== undefined) {
-            const clusterCount = feature._cdb_feature_count;
+            const clusterCount = feature._cdb_feature_count || 1;
             const weight = clusterCount * this.weight.eval(feature);
             const count = this._histogram.get(x) || 0;
             this._histogram.set(x, count + weight);

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportHistogram.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportHistogram.js
@@ -1,6 +1,7 @@
 import BaseExpression from '../../base';
 import { implicitCast } from '../../utils';
 import { checkMaxArguments, checkArray } from '../../utils';
+import { CLUSTER_FEATURE_COUNT } from '../../../../schema';
 
 /**
  * Generates a histogram.
@@ -66,7 +67,7 @@ export default class ViewportHistogram extends BaseExpression {
         const x = this.x.eval(feature);
 
         if (x !== undefined) {
-            const clusterCount = feature._cdb_feature_count || 1;
+            const clusterCount = feature[CLUSTER_FEATURE_COUNT] || 1;
             const weight = clusterCount * this.weight.eval(feature);
             const count = this._histogram.get(x) || 0;
             this._histogram.set(x, count + weight);

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportPercentile.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportPercentile.js
@@ -1,6 +1,7 @@
 import ViewportAggregation from './ViewportAggregation';
 import { number } from '../../../expressions';
 import { implicitCast, clamp, checkMaxArguments } from '../../utils';
+import { CLUSTER_FEATURE_COUNT } from '../../../../schema';
 /**
  * Return the Nth percentile of an expression for the features showed in the viewport (features outside the viewport and features that don't pass the filter will be excluded).
  *
@@ -69,7 +70,7 @@ export default class ViewportPercentile extends ViewportAggregation {
 
     accumViewportAgg (feature) {
         const v = this.property.eval(feature);
-        const clusterCount = feature._cdb_feature_count || 1;
+        const clusterCount = feature[CLUSTER_FEATURE_COUNT] || 1;
         for (let i = 0; i < clusterCount; i++) {
             this._array.push(v);
         }

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportPercentile.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportPercentile.js
@@ -1,6 +1,6 @@
 import ViewportAggregation from './ViewportAggregation';
 import { number } from '../../../expressions';
-import { implicitCast, clamp, checkMaxArguments } from '../../utils';
+import { implicitCast, clamp, checkMaxArguments, checkType } from '../../utils';
 import { CLUSTER_FEATURE_COUNT } from '../../../../schema';
 /**
  * Return the Nth percentile of an expression for the features showed in the viewport (features outside the viewport and features that don't pass the filter will be excluded).
@@ -34,13 +34,15 @@ export default class ViewportPercentile extends ViewportAggregation {
      */
     constructor (property, percentile) {
         checkMaxArguments(arguments, 2, 'viewportPercentile');
-
-        super({ property, _impostor: number(0) });
-
-        this._isViewport = true;
+        super({ property });
         this.percentile = implicitCast(percentile);
-        this.type = 'number';
-        super.inlineMaker = inline => inline._impostor;
+        this.childrenNames.push('percentile');
+    }
+
+    _bindMetadata (metadata) {
+        super._bindMetadata(metadata);
+        checkType('viewportPercentile', 'property', 0, 'number', this.property);
+        checkType('viewportPercentile', 'percentile', 1, 'number', this.percentile);
     }
 
     get value () {

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportPercentile.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportPercentile.js
@@ -51,10 +51,6 @@ export default class ViewportPercentile extends ViewportAggregation {
         checkType('viewportPercentile', 'percentile', 1, 'number', this.percentile);
     }
 
-    get value () {
-        return this.eval();
-    }
-
     eval (feature) {
         if (this._value === null) {
             // See Nearest rank method: https://en.wikipedia.org/wiki/Percentile
@@ -73,10 +69,6 @@ export default class ViewportPercentile extends ViewportAggregation {
         return this._value;
     }
 
-    _getMinimumNeededSchema () {
-        return this.property._getMinimumNeededSchema();
-    }
-
     _resetViewportAgg () {
         this._value = null;
         this._map = new Map();
@@ -88,11 +80,6 @@ export default class ViewportPercentile extends ViewportAggregation {
         const clusterCount = feature[CLUSTER_FEATURE_COUNT] || 1;
         this._map.set(v, (this._map.get(v) || 0) + clusterCount);
         this._total += clusterCount;
-    }
-
-    _preDraw (...args) {
-        this._impostor.expr = this.eval();
-        super._preDraw(...args);
     }
 }
 

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportPercentile.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportPercentile.js
@@ -1,5 +1,4 @@
 import ViewportAggregation from './ViewportAggregation';
-import { number } from '../../../expressions';
 import { implicitCast, clamp, checkMaxArguments, checkType, checkExpression } from '../../utils';
 import { CLUSTER_FEATURE_COUNT } from '../../../../schema';
 /**

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportPercentile.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportPercentile.js
@@ -69,7 +69,10 @@ export default class ViewportPercentile extends ViewportAggregation {
 
     accumViewportAgg (feature) {
         const v = this.property.eval(feature);
-        this._array.push(v);
+        const clusterCount = feature._cdb_feature_count;
+        for (let i = 0; i < clusterCount; i++) {
+            this._array.push(v);
+        }
     }
 
     _preDraw (...args) {

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportPercentile.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportPercentile.js
@@ -69,7 +69,7 @@ export default class ViewportPercentile extends ViewportAggregation {
 
     accumViewportAgg (feature) {
         const v = this.property.eval(feature);
-        const clusterCount = feature._cdb_feature_count;
+        const clusterCount = feature._cdb_feature_count || 1;
         for (let i = 0; i < clusterCount; i++) {
             this._array.push(v);
         }

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportSum.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportSum.js
@@ -45,7 +45,7 @@ export default class ViewportSum extends ViewportAggregation {
         const propertyValue = this.property.eval(feature);
 
         if (!Number.isNaN(propertyValue)) {
-            const clusterCount = feature._cdb_feature_count;
+            const clusterCount = feature._cdb_feature_count || 1;
             this._value = this._value + clusterCount * propertyValue;
         }
     }

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportSum.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportSum.js
@@ -45,7 +45,8 @@ export default class ViewportSum extends ViewportAggregation {
         const propertyValue = this.property.eval(feature);
 
         if (!Number.isNaN(propertyValue)) {
-            this._value = this._value + propertyValue;
+            const clusterCount = feature._cdb_feature_count;
+            this._value = this._value + clusterCount * propertyValue;
         }
     }
 

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportSum.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportSum.js
@@ -1,5 +1,6 @@
 import ViewportAggregation from './ViewportAggregation';
 import { checkMaxArguments } from '../../utils';
+import { CLUSTER_FEATURE_COUNT } from '../../../../schema';
 
 /**
  * Return the sum of an expression for the features showed in the viewport (features outside the viewport and features that don't pass the filter will be excluded).
@@ -45,7 +46,7 @@ export default class ViewportSum extends ViewportAggregation {
         const propertyValue = this.property.eval(feature);
 
         if (!Number.isNaN(propertyValue)) {
-            const clusterCount = feature._cdb_feature_count || 1;
+            const clusterCount = feature[CLUSTER_FEATURE_COUNT] || 1;
             this._value = this._value + clusterCount * propertyValue;
         }
     }

--- a/test/unit/renderer/viz/expressions/aggregation/viewportAggregation.test.js
+++ b/test/unit/renderer/viz/expressions/aggregation/viewportAggregation.test.js
@@ -119,13 +119,16 @@ describe('src/renderer/viz/expressions/viewportAggregation', () => {
             fakeDrawMetadata(viewportPercentile);
             expect(viewportPercentile.value).toEqual(0);
 
+            viewportPercentile = s.viewportPercentile($price, 1);
+            fakeDrawMetadata(viewportPercentile);
+            expect(viewportPercentile.value).toEqual(0);
+
             viewportPercentile = s.viewportPercentile($price, 24);
             fakeDrawMetadata(viewportPercentile);
             expect(viewportPercentile.value).toEqual(0);
             viewportPercentile = s.viewportPercentile($price, 26);
             fakeDrawMetadata(viewportPercentile);
             expect(viewportPercentile.value).toEqual(0.5);
-
             viewportPercentile = s.viewportPercentile($price, 49);
             fakeDrawMetadata(viewportPercentile);
             expect(viewportPercentile.value).toEqual(0.5);
@@ -136,11 +139,16 @@ describe('src/renderer/viz/expressions/viewportAggregation', () => {
             viewportPercentile = s.viewportPercentile($price, 74);
             fakeDrawMetadata(viewportPercentile);
             expect(viewportPercentile.value).toEqual(1.5);
+
             viewportPercentile = s.viewportPercentile($price, 76);
             fakeDrawMetadata(viewportPercentile);
             expect(viewportPercentile.value).toEqual(2);
 
             viewportPercentile = s.viewportPercentile($price, 100);
+            fakeDrawMetadata(viewportPercentile);
+            expect(viewportPercentile.value).toEqual(2);
+
+            viewportPercentile = s.viewportPercentile($price, 999);
             fakeDrawMetadata(viewportPercentile);
             expect(viewportPercentile.value).toEqual(2);
         });

--- a/test/unit/renderer/viz/expressions/classification/classifier.test.js
+++ b/test/unit/renderer/viz/expressions/classification/classifier.test.js
@@ -51,12 +51,20 @@ describe('src/renderer/viz/expressions/classifier', () => {
             validateTypeErrors('viewportStandardDev', ['color', 2]);
             validateTypeErrors('viewportStandardDev', ['number', 'color']);
             validateMaxArgumentsError('viewportStandardDev', ['number', 'number-array', 'number', 'number']);
+
+            validateTypeErrors('viewportPercentile', []);
+            validateTypeErrors('viewportPercentile', ['number', 'category']);
+            validateTypeErrors('viewportPercentile', ['category', 2]);
+            validateTypeErrors('viewportPercentile', ['color', 2]);
+            validateTypeErrors('viewportPercentile', ['number', 'color']);
+            validateMaxArgumentsError('viewportPercentile', ['number', 'number', 'number']);
         });
     });
 
     describe('type', () => {
         validateStaticType('viewportQuantiles', ['number-property', 2], 'category');
         validateStaticType('viewportStandardDev', ['number-property', 2, 0.5], 'category');
+        validateStaticType('viewportPercentile', ['number', 'number'], 'number');
     });
 
     describe('eval', () => {


### PR DESCRIPTION
This fixes the `viewportSum` problem, but requires further effort:
- `ViewportPercentile.` will be super slow after this when the aggregations kick in a lot. This probable can be solved by using something like viewportHistogram implementation.
- `viewportFeatures` may be renamed to accommodate the fact that each "feature" is now a cluster. Obviously, this was the case earlier, but earlier, all viewport functions assume 1 cluster 1 feature. But now, viewportFeatures is the only viewport function that doesn't take the clustering into account directly (it is left to the developer). And we shouldn't change that (by making a super long list) since it will be a performance issue.

cc: @jgoizueta 