### PR TITLE
Set bundle size warning over 425KB

### DIFF
--- a/webpack/webpack.min.config.js
+++ b/webpack/webpack.min.config.js
@@ -52,7 +52,7 @@ module.exports = {
         new webpack.BannerPlugin(banner)
     ],
     performance: {
-        maxEntrypointSize: 409600,
-        maxAssetSize: 409600
+        maxEntrypointSize: 435200,
+        maxAssetSize: 435200
     }
 };


### PR DESCRIPTION
### Related with: https://github.com/CartoDB/carto-vl/pull/1066

After that PR, the bundle size for the min has grown, so we need to adjust our warning size