### PR TITLE
E2e subdomainless docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,7 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
             - ./node_modules
-      - run: echo "127.0.0.1 localhost.localhost.lan" | sudo tee -a  /etc/hosts
-      - run: yarn build:min && yarn wait-on http://localhost.localhost.lan:8181 && MIN=1 yarn mocha test/acceptance/e2e.test.js --timeout 25000
+      - run: yarn build:min && yarn wait-on http://127.0.0.1:8181 && MIN=1 yarn mocha test/acceptance/e2e.test.js --timeout 25000
 
   test-unit-lint-docs:
     docker:

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -102,8 +102,6 @@ This end to end tests cover the entire library by performing tests against real 
 
 To install Docker, follow the instructions on https://docs.docker.com/install/
 
-You'll also need to add `127.0.0.1 localhost.localhost.lan` your `/etc/hosts/` file.
-
 ```bash
 # Running the tests
 $ yarn test:e2e

--- a/scripts/run-local-e2e.sh
+++ b/scripts/run-local-e2e.sh
@@ -7,10 +7,6 @@ if [ "$ALREADY_UP" -eq "0" ]; then
     docker run -d -p 127.0.0.1:8181:8181 -v `pwd`/test/acceptance/docker:/mnt carto/windshaft-cartovl-testing ./deploy.sh > .docker.run
 fi
 
-TESTS_HOSTNAME=localhost.localhost.lan
-valid_hostname() {
-    node -e "const hostname = '${TESTS_HOSTNAME}'; require('dns').lookup(hostname, (err, address) => { if (err) { console.error('Could not resolve hostname \"%s\", reason %s', hostname, err.message); return process.exit(1); } })"
-}
-valid_hostname && yarn build:dev && yarn wait-on "http://${TESTS_HOSTNAME}:8181" && mocha test/acceptance/e2e.test.js --timeout 15000 "$@";
+yarn build:dev && yarn wait-on "http://127.0.0.1:8181" && mocha test/acceptance/e2e.test.js --timeout 15000 "$@";
 
 # docker kill `cat .docker.run`

--- a/test/acceptance/docker/config/environments/test.js
+++ b/test/acceptance/docker/config/environments/test.js
@@ -72,8 +72,8 @@ let config = {
     //  2. {{=it.user}}: will use the username as extraced from `user_from_host` or `routes`.
     //  3. {{=it.port}}: will use the `port` from this very same configuration file.
     resources_url_templates: {
-        http: 'http://{{=it.user}}.localhost.lan:{{=it.port}}/api/v1/map',
-        https: 'http://{{=it.user}}.localhost.lan:{{=it.port}}/api/v1/map'
+        http: 'http://127.0.0.1:{{=it.port}}/user/{{=it.user}}/api/v1/map/',
+        https: 'http://127.0.0.1:{{=it.port}}/user/{{=it.user}}/api/v1/map/'
     },
 
     // Maximum number of connections for one process

--- a/test/acceptance/docker/deploy.sh
+++ b/test/acceptance/docker/deploy.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 git clone https://github.com/CartoDB/Windshaft-cartodb.git ;
+git checkout master
+git pull origin master
 
 cp /srv/config/environments/test.js Windshaft-cartodb/config/environments/development.js
 cd ./Windshaft-cartodb/

--- a/test/acceptance/docker/deploy.sh
+++ b/test/acceptance/docker/deploy.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 git clone https://github.com/CartoDB/Windshaft-cartodb.git ;
-git checkout master
-git pull origin master
 
 cp /srv/config/environments/test.js Windshaft-cartodb/config/environments/development.js
 cd ./Windshaft-cartodb/

--- a/test/acceptance/docker/deploy.sh
+++ b/test/acceptance/docker/deploy.sh
@@ -4,6 +4,10 @@ git clone https://github.com/CartoDB/Windshaft-cartodb.git ;
 
 cp /srv/config/environments/test.js Windshaft-cartodb/config/environments/development.js
 cd ./Windshaft-cartodb/
+
+git checkout master
+git pull origin master
+
 yarn
 
 cd /srv

--- a/test/acceptance/e2e/cluster-aggr/scenario.js
+++ b/test/acceptance/e2e/cluster-aggr/scenario.js
@@ -8,7 +8,7 @@ carto.setDefaultAuth({
     apiKey: '1234'
 });
 carto.setDefaultConfig({
-    serverURL: 'http://{user}.localhost.lan:8181'
+    serverURL: 'http://127.0.0.1:8181/user/{user}'
 });
 
 const source = new carto.source.Dataset('monarch_migration_1');

--- a/test/acceptance/e2e/mnmappluto/scenario.js
+++ b/test/acceptance/e2e/mnmappluto/scenario.js
@@ -10,7 +10,7 @@ carto.setDefaultAuth({
     apiKey: '1234'
 });
 carto.setDefaultConfig({
-    serverURL: 'http://{user}.localhost.lan:8181'
+    serverURL: 'http://127.0.0.1:8181/user/{user}'
 });
 const source = new carto.source.Dataset('mnmappluto');
 const viz = new carto.Viz(`

--- a/test/acceptance/e2e/pop_density_points/scenario.js
+++ b/test/acceptance/e2e/pop_density_points/scenario.js
@@ -10,7 +10,7 @@ carto.setDefaultAuth({
     apiKey: '1234'
 });
 carto.setDefaultConfig({
-    serverURL: 'http://{user}.localhost.lan:8181'
+    serverURL: 'http://127.0.0.1:8181/user/{user}'
 });
 
 const source = new carto.source.Dataset('pop_density_points');

--- a/test/acceptance/e2e/sf_stclines/scenario.js
+++ b/test/acceptance/e2e/sf_stclines/scenario.js
@@ -10,7 +10,7 @@ carto.setDefaultAuth({
     apiKey: '1234'
 });
 carto.setDefaultConfig({
-    serverURL: 'http://{user}.localhost.lan:8181'
+    serverURL: 'http://127.0.0.1:8181/user/{user}'
 });
 
 const source = new carto.source.Dataset('sf_stclines');

--- a/test/acceptance/e2e/sql/scenario.js
+++ b/test/acceptance/e2e/sql/scenario.js
@@ -8,7 +8,7 @@ carto.setDefaultAuth({
     apiKey: '1234'
 });
 carto.setDefaultConfig({
-    serverURL: 'http://{user}.localhost.lan:8181'
+    serverURL: 'http://127.0.0.1:8181/user/{user}'
 });
 
 const source = new carto.source.SQL(

--- a/test/acceptance/e2e/undefined-geometry-type/scenario.js
+++ b/test/acceptance/e2e/undefined-geometry-type/scenario.js
@@ -10,7 +10,7 @@ carto.setDefaultAuth({
     apiKey: '1234'
 });
 carto.setDefaultConfig({
-    serverURL: 'http://{user}.localhost.lan:8181'
+    serverURL: 'http://127.0.0.1:8181/user/{user}'
 });
 const source = new carto.source.SQL('SELECT 1 cartodb_id, null::geometry the_geom_webmercator LIMIT 0');
 const viz = new carto.Viz();


### PR DESCRIPTION
This uses subdomainless configuration in the Maps API to avoid requiring a new hostname configured in `/etc/hosts`.

It also `checkout`s and `pull`s latest changes from the master branch.