### PR TITLE
Prevent constant triggering of the layer `updated` event

### DIFF
--- a/src/Layer.js
+++ b/src/Layer.js
@@ -263,7 +263,7 @@ export default class Layer {
         this.viz.gl = this.gl;
         this._needRefresh();
 
-        source.bindLayer(this._onDataframeAdded.bind(this), this._onDataLoaded.bind(this));
+        source.bindLayer(this._onDataframeAdded.bind(this));
         if (this._source !== source) {
             this._freeSource();
         }
@@ -442,7 +442,7 @@ export default class Layer {
         if (this._viz) {
             this._viz.setDefaultsIfRequired(dataframe.type);
         }
-        this._needRefresh();
+        dataframe.onActive(this._needRefresh.bind(this));
     }
 
     _needRefresh () {
@@ -450,10 +450,6 @@ export default class Layer {
             this._state = states.UPDATING;
         }
         this.map.triggerRepaint();
-    }
-
-    _onDataLoaded () {
-        this._needRefresh();
     }
 
     _addLayerIdToFeature (feature) {

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -22,10 +22,9 @@ export default class Windshaft {
         this.inProgressInstantiations = {};
     }
 
-    bindLayer (addDataframe, dataLoadedCallback) {
+    bindLayer (addDataframe) {
         this._addDataframe = addDataframe;
-        this._dataLoadedCallback = dataLoadedCallback;
-        this._mvtClient.bindLayer(addDataframe, dataLoadedCallback);
+        this._mvtClient.bindLayer(addDataframe);
     }
 
     _getInstantiationID (MNS, resolution, filtering, choices) {
@@ -169,7 +168,7 @@ export default class Windshaft {
         }
         this._mvtClient = new MVT(urlTemplates);
         this._mvtClient._workerName = 'windshaft';
-        this._mvtClient.bindLayer(this._addDataframe, this._dataLoadedCallback);
+        this._mvtClient.bindLayer(this._addDataframe);
         this.urlTemplates = urlTemplates;
         this.metadata = metadata;
         this._mvtClient._metadata = metadata;

--- a/src/renderer/Dataframe.js
+++ b/src/renderer/Dataframe.js
@@ -109,6 +109,21 @@ export default class Dataframe extends DummyDataframe {
         }
     }
 
+    onActive (callback) {
+        this._onActive = callback;
+    }
+
+    get active () {
+        return this._active;
+    }
+
+    set active (value) {
+        if (this._active !== value) {
+            this._active = value;
+            this._onActive();
+        }
+    }
+
     inViewport (featureIndex) {
         if (!this.matrix) {
             return false;

--- a/src/renderer/Dataframe.js
+++ b/src/renderer/Dataframe.js
@@ -111,6 +111,9 @@ export default class Dataframe extends DummyDataframe {
 
     onActive (callback) {
         this._onActive = callback;
+        if (this.active) {
+            this._onActive();
+        }
     }
 
     get active () {

--- a/src/renderer/DummyDataframe.js
+++ b/src/renderer/DummyDataframe.js
@@ -3,7 +3,7 @@ import { computeAABB } from '../utils/geometry';
 
 export default class DummyDataframe {
     constructor ({ center, scale, geom, properties, type, active, size, metadata }) {
-        this.active = active;
+        this._active = active;
         this.center = center;
         this.properties = properties;
         this.scale = scale;

--- a/src/sources/BaseWindshaft.js
+++ b/src/sources/BaseWindshaft.js
@@ -21,8 +21,8 @@ export default class BaseWindshaft extends Base {
         this._serverURL = this._generateURL(this._auth, this._config);
     }
 
-    bindLayer (...args) {
-        this._client.bindLayer(...args);
+    bindLayer (addDataframe) {
+        this._client.bindLayer(addDataframe);
     }
 
     requiresNewMetadata (viz) {

--- a/src/sources/GeoJSON.js
+++ b/src/sources/GeoJSON.js
@@ -66,9 +66,8 @@ export default class GeoJSON extends Base {
         this._setCoordinatesCenter();
     }
 
-    bindLayer (addDataframe, dataLoadedCallback) {
+    bindLayer (addDataframe) {
         this._addDataframe = addDataframe;
-        this._dataLoadedCallback = dataLoadedCallback;
     }
 
     requestMetadata (viz) {
@@ -97,7 +96,6 @@ export default class GeoJSON extends Base {
         this._boundColumns = new Set(Object.keys(dataframe.properties));
         this._dataframe = dataframe;
         this._addDataframe(dataframe);
-        this._dataLoadedCallback();
     }
 
     requiresNewMetadata () {

--- a/src/sources/MVT.js
+++ b/src/sources/MVT.js
@@ -75,8 +75,8 @@ export default class MVT extends Base {
         return new MVT(this._templateURL, JSON.parse(JSON.stringify(this._metadata)), this._options);
     }
 
-    bindLayer (addDataframe, dataLoadedCallback) {
-        this._tileClient.bindLayer(addDataframe, dataLoadedCallback);
+    bindLayer (addDataframe) {
+        this._tileClient.bindLayer(addDataframe);
     }
 
     async requestMetadata () {

--- a/src/sources/TileClient.js
+++ b/src/sources/TileClient.js
@@ -13,9 +13,8 @@ export default class TileClient {
         this._cache = new DataframeCache();
     }
 
-    bindLayer (addDataframe, dataLoadedCallback) {
+    bindLayer (addDataframe) {
         this._addDataframe = addDataframe;
-        this._dataLoadedCallback = dataLoadedCallback;
     }
 
     requestData (zoom, viewport, urlToDataframeTransformer, viewportZoomToSourceZoom = Math.ceil) {
@@ -55,14 +54,14 @@ export default class TileClient {
                         completedTiles.push(dataframe);
                     }
                     if (completedTiles.length === needToComplete && requestGroupID === this._requestGroupID) {
-                        this._oldDataframes.forEach(d => {
+                        const completedDataframesSet = new Set(completedTiles);
+                        this._oldDataframes.filter(d => !completedDataframesSet.has(d)).forEach(d => {
                             d.active = false;
                         });
-                        completedTiles.map(d => {
+                        completedTiles.forEach(d => {
                             d.active = true;
                         });
                         this._oldDataframes = completedTiles;
-                        this._dataLoadedCallback();
                     }
                 });
         });

--- a/test/unit/source/GeoJSON.test.js
+++ b/test/unit/source/GeoJSON.test.js
@@ -295,7 +295,7 @@ describe('sources/GeoJSON', () => {
         });
     });
 
-    it('should call the dataLoaded callback when the dataframe is added', () => {
+    it('should call the addDataframe callback when the dataframe is added', () => {
         const source = new GeoJSON({
             type: 'Feature',
             geometry: {
@@ -305,10 +305,9 @@ describe('sources/GeoJSON', () => {
         });
 
         const fakeAddDataframe = jasmine.createSpy('addDataframe');
-        const fakeDataLoaded = jasmine.createSpy('dataLoaded');
-        source.bindLayer(fakeAddDataframe, fakeDataLoaded);
-        expect(fakeDataLoaded).not.toHaveBeenCalled();
+        source.bindLayer(fakeAddDataframe);
+        expect(fakeAddDataframe).not.toHaveBeenCalled();
         source.requestData();
-        expect(fakeDataLoaded).toHaveBeenCalled();
+        expect(fakeAddDataframe).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
We introduced this regression in https://github.com/CartoDB/carto-vl/commit/3ab6087171fb079be1e12c335dddb2b51191d6c0.

This takes advantage of the fact that we are already repainting when a dataframe is added.

As an enhancement, we only trigger that event when the dataframe gets activated. This also means we don't need anymore the onDataLoaded callback all across the place.

Profiling before the changes
![before](https://user-images.githubusercontent.com/45346/47497811-92b8ac80-d85b-11e8-9f2f-a8b8f0efda76.png)

Profiling after the changes
![after](https://user-images.githubusercontent.com/45346/47497834-a401b900-d85b-11e8-8b5c-671258775b25.png)
