### PR TITLE
Fix feature `reset()` by ignoring rejected changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix `viewportPercentile` (styling by it was broken)
 - Fix `viewport*` functions to take clustering into account
 - Fix wrong `expressionName` due to mangled `this.constructor.name` in the minified version
+- Fix a regression error related to `blendTo` when using feature `reset`.
 
 ## [0.9.1] - 2018-10-09
 ### Fixed

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -221,6 +221,7 @@ export default class Layer {
         if (majorChange) {
             uid = { major: this._majorNextUID, minor: 0 };
             this._majorNextUID++;
+            this._minorNextUID = 1;
         } else {
             uid = { major: this._majorCurrentUID, minor: this._minorNextUID };
             this._minorNextUID++;

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -139,7 +139,7 @@ export default class Viz {
                     expr = implicitCast(expr);
                 }
                 this['_' + propertyName] = expr;
-                this._changed();
+                this._changed().catch(() => {});
             }
         });
 
@@ -155,7 +155,7 @@ export default class Viz {
                     obj[prop] = value;
                     this['__cartovl_variable_' + prop] = value;
                     if (init) {
-                        this._changed();
+                        this._changed().catch(() => {});
                     }
                     return true;
                 }
@@ -196,8 +196,9 @@ export default class Viz {
         this._resolveAliases();
         this._validateAliasDAG();
         if (this._changeCallback) {
-            this._changeCallback(this);
+            return this._changeCallback(this);
         }
+        return Promise.resolve(null);
     }
 
     _updateRootExpressionList () {

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -126,6 +126,14 @@ export default class Viz {
         return Promise.all(this._getRootExpressions().map(expr => expr.loadImages()));
     }
 
+    /*
+     * There are cases when promise rejections are fine, such as when using
+     * `blendTo` to change the viz synchronously.
+    */
+    _ignoreChangeRejections () {
+        return {};
+    }
+
     // Define a viz property, setting all the required getters, setters and creating a proxy for the variables object
     // These setters and the proxy allow us to re-render without requiring further action from the user
     _defineProperty (propertyName, propertyValue) {
@@ -139,7 +147,7 @@ export default class Viz {
                     expr = implicitCast(expr);
                 }
                 this['_' + propertyName] = expr;
-                this._changed().catch(() => {});
+                this._changed().catch(this._ignoreChangeRejections);
             }
         });
 
@@ -155,7 +163,7 @@ export default class Viz {
                     obj[prop] = value;
                     this['__cartovl_variable_' + prop] = value;
                     if (init) {
-                        this._changed().catch(() => {});
+                        this._changed().catch(this._ignoreChangeRejections);
                     }
                     return true;
                 }

--- a/src/renderer/viz/expressions/base.js
+++ b/src/renderer/viz/expressions/base.js
@@ -297,7 +297,7 @@ export default class Base {
         this[name] = replacer;
         replacer.parent = this;
         replacer.notify = toReplace.notify;
-        replacer.notify().catch(() => {});
+        replacer.notify().catch(() => { }); // ignore change rejections when using blend
     }
 
     _blendFrom (final, duration = 500, interpolator = null) {

--- a/src/renderer/viz/expressions/base.js
+++ b/src/renderer/viz/expressions/base.js
@@ -151,7 +151,7 @@ export default class Base {
     }
 
     notify () {
-        this.parent.notify();
+        return this.parent.notify();
     }
 
     accumViewportAgg (feature) {
@@ -297,6 +297,7 @@ export default class Base {
         this[name] = replacer;
         replacer.parent = this;
         replacer.notify = toReplace.notify;
+        replacer.notify().catch(() => {});
     }
 
     _blendFrom (final, duration = 500, interpolator = null) {

--- a/src/renderer/viz/expressions/blend.js
+++ b/src/renderer/viz/expressions/blend.js
@@ -81,7 +81,6 @@ export default class Blend extends BaseExpression {
         super._preDraw(...args);
         if (this.originalMix.isA(Transition) && !this.originalMix.isAnimated()) {
             this.parent.replaceChild(this, this.b);
-            this.notify();
         }
     }
 }

--- a/test/unit/viz.test.js
+++ b/test/unit/viz.test.js
@@ -213,7 +213,10 @@ describe('api/viz', () => {
                 filter: expected
             });
             numberA.blendTo(numberB, 999);
-            viz.onChange(done);
+            viz.onChange(() => {
+                done();
+                return Promise.resolve(null);
+            });
             const t = Date.now() + 1000;
             Date.now = () => t;
             viz.filter._preDraw(null, {}, { uniform1f: () => { } });
@@ -223,7 +226,10 @@ describe('api/viz', () => {
     describe('resolution changes', () => {
         it('should be effective and notify observers', done => {
             const viz = new Viz();
-            viz.onChange(done);
+            viz.onChange(() => {
+                done();
+                return Promise.resolve(null);
+            });
             viz.resolution = 8;
             expect(viz.resolution).toEqual(8);
         });


### PR DESCRIPTION
Fix the issue described https://github.com/CartoDB/carto-vl/pull/1085#issuecomment-433468670

Uncaught exceptions were being thrown when using the feature's `reset` method.

This was due to our recent changes in `Layer`. Basically, we informed of "overridden" updates by rejecting the update promise. This doesn't make sense from the `blendTo` point of view since that changes the viz synchronously.

Therefore, this PR ignores those rejections when the call to update has been the result of a `blendTo`.

I don't know if this will be easier to test within #1085 , maybe we could merge this to that instead of `master`.

@VictorVelarde What do you think? Could you help with the regression test?

TODO:
- [x] Add regression test