### PR TITLE
Revert "Fix polygon decoding corner case with NaN normals"

### DIFF
--- a/src/renderer/decoder/common.js
+++ b/src/renderer/decoder/common.js
@@ -17,10 +17,6 @@ export function addLineString (lineString, geomBuffer, index, isPolygon, skipCal
         currentPoint = [lineString[2], lineString[3]];
         prevNormal = getLineNormal(prevPoint, currentPoint);
 
-        if (prevPoint[0] === currentPoint[0] && prevPoint[1] === currentPoint[1]) {
-            return index;
-        }
-
         for (let i = 4; i <= lineString.length; i += 2) {
             drawLine = !(skipCallback && skipCallback(i));
 
@@ -62,9 +58,6 @@ export function addLineString (lineString, geomBuffer, index, isPolygon, skipCal
             }
 
             if (nextPoint) {
-                if (nextPoint[0] === currentPoint[0] && nextPoint[1] === currentPoint[1]) {
-                    return index;
-                }
                 nextNormal = getLineNormal(currentPoint, nextPoint);
 
                 if (drawLine) {


### PR DESCRIPTION
This reverts commit 07a3052d0587beff5345a4e7dfc2bd200dad60ba which seems to be the responsible for https://github.com/CartoDB/carto-vl/issues/1107.

It's not clear what that commit was trying to prevent but definitively causes this regression.

Let's discuss what we should try to cover apart from reverting the regression.

Fixes #1107.