### PR TITLE
Change example for animated-viz guide so it allows 0 duration

### DIFF
--- a/examples/guides/animated-viz/step-5.html
+++ b/examples/guides/animated-viz/step-5.html
@@ -170,7 +170,7 @@
         </header>
         <section>
             <p>Progress <input type="range" id="js-progress-range" min="0" max="1" step="0.01"></p>
-            <p>Duration <input type="range" id="js-duration-range" class="white-thumb" min="1" max="10" step="1"></p>
+            <p>Duration <input type="range" id="js-duration-range" class="white-thumb" min="0" max="10" step="1"></p>
         </section>
         <section>
             <p>Current: <span id="js-current-time" class="open-sans"></span></p>


### PR DESCRIPTION
Related to https://github.com/CartoDB/carto-vl/issues/1070

I have checked with current master (v1.0.0) and that error doesn't appear anymore, so I have changed the example to allow a 0 duration, which presents a nice 'all-data-view'