### PR TITLE
Add codec conversion to eval in linear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fix `linear` error when evaluating a date property in a feature.
 
 ## [1.0.0] - 2018-11-08
 

--- a/debug/viewportfeatures-perf.html
+++ b/debug/viewportfeatures-perf.html
@@ -77,7 +77,7 @@
         window.feature && window.feature.width.blendTo(200);
         window.feature && window.feature.color.blendTo('red');
       }
-      console.log(viz.variables.wadus2.value.length);
+      // console.log(viz.variables.wadus2.value.length);
     });
 
     function hideLoader() {

--- a/src/renderer/viz/expressions/linear.js
+++ b/src/renderer/viz/expressions/linear.js
@@ -146,8 +146,8 @@ export default class Linear extends BaseExpression {
             : new IdentityCodec();
         const min = codec.externalToInternal(this.min.eval(feature));
         const max = codec.externalToInternal(this.max.eval(feature));
-        const inputValue = codec.externalToInternal(input);
-        return (inputValue - min) / (max - min);
+        const value = codec.externalToInternal(input);
+        return (value - min) / (max - min);
     }
 
     _bindMetadata (metadata) {

--- a/src/renderer/viz/expressions/linear.js
+++ b/src/renderer/viz/expressions/linear.js
@@ -146,7 +146,8 @@ export default class Linear extends BaseExpression {
             : new IdentityCodec();
         const min = codec.externalToInternal(this.min.eval(feature));
         const max = codec.externalToInternal(this.max.eval(feature));
-        return (input - min) / (max - min);
+        const inputValue = codec.externalToInternal(input);
+        return (inputValue - min) / (max - min);
     }
 
     _bindMetadata (metadata) {

--- a/test/unit/renderer/viz/expressions/linear.test.js
+++ b/test/unit/renderer/viz/expressions/linear.test.js
@@ -3,6 +3,7 @@ import { validateTypeErrors, validateStaticType, validateMaxArgumentsError } fro
 import GlobalMin from '../../../../../src/renderer/viz/expressions/aggregation/global/GlobalMin';
 import GlobalMax from '../../../../../src/renderer/viz/expressions/aggregation/global/GlobalMax';
 import { mockMetadata } from './utils';
+import WindshaftDateCodec from '../../../../../src/codecs/windshaft/WindshaftDate';
 
 describe('src/renderer/viz/expressions/linear', () => {
     describe('error control', () => {
@@ -59,6 +60,26 @@ describe('src/renderer/viz/expressions/linear', () => {
             expect(l.eval({
                 wadus: 0.5
             })).toEqual(1420070396.50025);
+        });
+
+        it('should eval feature correctly when using a date property with a WindshaftDateCodec...', () => {
+            const property = s.prop('wadus');
+            const [min, max] = [s.time('2016-05-01T00:00:07Z'), s.time('2016-05-06T10:40:59Z')];
+            const l = s.linear(property, min, max);
+            const metadata = mockMetadata({
+                properties: {
+                    wadus: {
+                        type: 'date',
+                        min: 1462060807, // Sun May 01 2016 00:00:07 UTC
+                        max: 1462531259 // Fri May 06 2016 10:40:59 UTC
+                    }
+                }
+            });
+            l._bindMetadata(metadata);
+            metadata.codec = () => new WindshaftDateCodec(metadata, 'wadus');
+
+            expect(l.eval({ wadus: new Date('2016-05-01T00:00:07Z') })).toEqual(0);
+            expect(l.eval({ wadus: new Date('2016-05-06T10:40:59Z') })).toEqual(1);
         });
     });
 });


### PR DESCRIPTION
### Related to https://github.com/CartoDB/carto-vl/issues/1145

The underlying cause is a hidden type error inside `linear --> eval(feature)`. It tries to compute the value using different types (and getting unexpected results), as displayed in this snippet:

![image](https://user-images.githubusercontent.com/458196/48860920-896f2100-edc2-11e8-9009-0b45c4290a6f.png)

Linear missed a conversion using the corresponding codec before evaluating the previous operation, so the value to be mapped was wrong. This PR fixes the issue