### PR TITLE
Add timestamp to animation controls example

### DIFF
--- a/examples/interactivity/animation-controls.html
+++ b/examples/interactivity/animation-controls.html
@@ -165,7 +165,6 @@
             border: 1px solid #ddd;
             width: 32px;
             height: 32px;
-            ;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -203,6 +202,10 @@
                 <input type="button" id="js-pause-button">
                 <input type="range" id="js-time-range" min="0" max="1" step="0.01">
             </section>
+            <br />
+            <section>
+                <span id="js-current-time" class="open-sans"></span>
+            </section>
             <hr>
             <section>
                 <span style="margin-right: 5px" class="open-sans">Duration (seconds)</span>
@@ -228,9 +231,7 @@
             scrollZoom: false
         });
 
-        const nav = new mapboxgl.NavigationControl({
-            showCompass: false
-        });
+        const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
 
         //** CARTO VL functionality begins here **//
@@ -263,6 +264,8 @@
         const $durationRange = document.getElementById('js-duration-range');
         const $timeRange = document.getElementById('js-time-range');
         const $spanDuration = document.getElementById('js-duration-span');
+        const $currentTime = document.getElementById('js-current-time');
+
         // Save initial time range value
         let last = $timeRange.value;
 
@@ -295,6 +298,7 @@
                 $timeRange.value = viz.variables.animation.getProgressPct();
                 last = $timeRange.value;
             }
+            $currentTime.innerText = viz.variables.animation.getProgressValue().toISOString();
         });
 
         layer.on('loaded', hideLoader);


### PR DESCRIPTION
### Related with https://github.com/CartoDB/carto-vl/issues/936

This PR adds a simple timestamp to the animation controls, like this:

![image](https://user-images.githubusercontent.com/458196/48862993-313b1d80-edc8-11e8-8b29-a7a3b5bda109.png)

