### PR TITLE
Add method to check if animation is playing

### DIFF
--- a/src/renderer/viz/expressions/AnimationGeneral.js
+++ b/src/renderer/viz/expressions/AnimationGeneral.js
@@ -239,6 +239,18 @@ export default class AnimationGeneral extends BaseExpression {
     }
 
     /**
+     * Returns whether the animation is playing or not
+     * 
+     * @api
+     * @memberof expressions.Animation
+     * @instance
+     * @name isPlaying
+     */
+    isPlaying () {
+        return this._paused === false;
+    }
+
+    /**
      * Pause the animation
      *
      * @api

--- a/test/unit/renderer/viz/expressions/Animation.test.js
+++ b/test/unit/renderer/viz/expressions/Animation.test.js
@@ -84,6 +84,21 @@ describe('src/renderer/viz/expressions/Animation', () => {
         });
     });
 
+    describe('.isPlaying', () => {
+        it('should return true if animation is not playing', () => {
+            const t = anim(1, 10, s.fade(1));
+            t.play();
+            expect(t.isPlaying()).toBe(true);
+        });
+
+        it('should return false if animation is not playing', () => {
+            const t = anim(1, 10, s.fade(1));
+            t.play();
+            t.pause();
+            expect(t.isPlaying()).toBe(false);
+        });
+    })
+
     describe('.setProgressPct', () => {
         it('should update the simulation progress percentage', () => {
             const t = anim(1, 10, s.fade(1));


### PR DESCRIPTION
I've added a method to query the internal `_paused` variable publicly.

I left a couple of tests, I don't know if I should add more things for documentation