### PR TITLE
Fix regressions on Layer:updated

### DIFF
--- a/debug/layer-updated.html
+++ b/debug/layer-updated.html
@@ -79,10 +79,10 @@
       console.log('animation: loaded');
       animationViz.variables.animation.pause(); // start with a paused animation
     });
-    animationLayer.on('updated', () => {
+    animationLayer.on('updated', (eventData) => {
       const animation = animationViz.variables.animation;
-
-      console.log('* animation: updated - progress', animation.getProgressPct());
+      console.log(`* animation: updated (${eventData})`);
+      console.log('* animation: progress', animation.getProgressPct());
       document.getElementById('js-animationDate').innerText = animation.getProgressValue().toISOString();
     });
     animationLayer.addTo(map, 'watername_ocean');
@@ -101,15 +101,23 @@
       console.log('simple layer: loaded');
     });
     let firstTimeUpdate = true;
-    simpleLayer.on('updated', () => {
-      console.log('* simple layer: updated');
+    simpleLayer.on('updated', (eventData) => {
+      console.log(`* simple layer: updated (${eventData})`);
+
       const features = simpleViz.variables.features.value;
       if (firstTimeUpdate) {
         firstTimeUpdate = false;
         console.log('1 feature blendTo & reset change');
-        features[0].blendTo({ color: 'red' });
-        features[0].strokeColor.blendTo('orange');
-        features[0].reset();
+
+        // several blendTo
+        features[0].blendTo({
+          color: 'red',
+          strokeColor: 'orange',
+          strokeWidth: 80
+        });
+        setTimeout(() => {
+          features[0].reset();
+        }, 2000);
       }
     });
     simpleLayer.addTo(map, 'animation');

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -474,12 +474,22 @@ export default class Layer {
         this._renderWaiters.forEach(resolve => resolve());
 
         if (this.isAnimated()) {
-            this._needRefresh().then(() => {
-                if (this.isPlaying()) {
-                    this._fire('updated');
-                }
-            });
+            if (this.isPlaying()) {
+                this._needRefresh().then(() => {
+                    this._fire('updated', 'animation is playing');
+                });
+            } else {
+                this._keepTimestampIfPaused();
+            }
         }
+    }
+
+    _keepTimestampIfPaused () {
+        let timestamp = this.renderer.timestamp;
+        // to avoid 'jumps' after resume playing.
+        this._viz._getRootStyleExpressions().forEach(vizExpr => {
+            vizExpr._setTimestamp(timestamp);
+        });
     }
 
     _paintLayer () {

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -446,8 +446,7 @@ export default class Layer {
     }
 
     _checkSourceRequestsAndFireEvents (isNewMatrix) {
-        const viewport = computeViewportFromCameraMatrix(this._cameraMatrix);
-        const checkForDataframesUpdate = this._source.requestData(this._getZoom(), viewport);
+        const checkForDataframesUpdate = this._source.requestData(this._getZoom(), this._getViewport());
 
         checkForDataframesUpdate.then(dataframesHaveChanged => {
             if (dataframesHaveChanged) {
@@ -464,6 +463,10 @@ export default class Layer {
                 }
             }
         });
+    }
+
+    _getViewport () {
+        return computeViewportFromCameraMatrix(this._cameraMatrix);
     }
 
     /**

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -521,7 +521,7 @@ export default class Layer {
     }
 
     _needRefresh () {
-        if (this._state !== states.INIT) {
+        if (this._state === states.IDLE) {
             this._state = states.UPDATING;
         }
         return new Promise(resolve => {

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -429,19 +429,11 @@ export default class Layer {
      * Custom Layer API: `prerender` function
      */
     prerender (gl, matrix) {
-        const isNewMatrix = this._isNewMatrix(matrix);
+        const isNewCameraMatrix = this.renderer.isNewMatrix(matrix);
         this.renderer.matrix = matrix;
         if (this._source && this.visible) {
-            this._checkSourceRequestsAndFireEvents(isNewMatrix);
+            this._checkSourceRequestsAndFireEvents(isNewCameraMatrix);
         }
-    }
-
-    _isNewMatrix (matrix) {
-        const currentMatrix = this.renderer.matrix;
-        if (!currentMatrix) {
-            return true;
-        }
-        return !mat4.exactEquals(matrix, currentMatrix);
     }
 
     _checkSourceRequestsAndFireEvents (isNewMatrix) {

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -92,7 +92,7 @@ export default class Layer {
         this.map.setLayoutProperty(this.id, 'visibility', visible ? 'visible' : 'none');
         this._visible = visible;
         if (visible !== initial) {
-            this._fire('updated');
+            this._fire('updated', 'visibility change');
         }
     }
 
@@ -447,11 +447,11 @@ export default class Layer {
                         this._state = states.IDLE;
                         this._fire('loaded');
                     }
-                    this._fire('updated');
+                    this._fire('updated', 'different dataframes required from source');
                 });
             } else {
                 if (isNewMatrix) {
-                    this._fire('updated');
+                    this._fire('updated', 'new camara view');
                 }
             }
         });

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -482,6 +482,11 @@ export default class Layer {
             } else {
                 this._keepTimestampIfPaused();
             }
+        } else {
+            if (this._state === states.UPDATING) {
+                this._state = states.IDLE;
+                this._fire('updated', 'updated viz');
+            }
         }
     }
 

--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -380,6 +380,13 @@ export default class Renderer {
         gl.disable(gl.CULL_FACE); // ? not needed from v0.50?
     }
 
+    isNewMatrix (newMatrix) {
+        if (!this.matrix && newMatrix) {
+            return true;
+        }
+        return !mat4.exactEquals(newMatrix, this.matrix);
+    }
+
     _updateDataframeMatrices (dataframes) {
         dataframes.forEach(dataframe => {
             let m2 = [];

--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -380,13 +380,6 @@ export default class Renderer {
         gl.disable(gl.CULL_FACE); // ? not needed from v0.50?
     }
 
-    isNewMatrix (newMatrix) {
-        if (!this.matrix && newMatrix) {
-            return true;
-        }
-        return !mat4.exactEquals(newMatrix, this.matrix);
-    }
-
     _updateDataframeMatrices (dataframes) {
         dataframes.forEach(dataframe => {
             let m2 = [];

--- a/test/integration/user/test/layer.test.js
+++ b/test/integration/user/test/layer.test.js
@@ -42,6 +42,12 @@ describe('Layer', () => {
                 spyOn(layer, '_needRefresh').and.callFake(() => Promise.resolve());
             }
 
+            function resetMocks () {
+                layer._getZoom.calls.reset();
+                layer._getViewport.calls.reset();
+                layer._needRefresh.calls.reset();
+            }
+
             it('should fire an "updated" event when ready', (done) => {
                 layer.on('updated', done);
             });
@@ -67,34 +73,37 @@ describe('Layer', () => {
                     layer.on('updated', update);
 
                     await layer.update(newSource);
-                    layer.prerender();
+                    const currentMatrix = layer.renderer.matrix;
+                    layer.prerender(null, currentMatrix);
 
                     expect(update).toHaveBeenCalledTimes(1);
+                    resetMocks();
                     done();
                 });
             });
 
-            it('should fire a new "updated" after moving the map (even if not requiring new dataframes)', (done) => {
-                mockPrerenderHelpers();
+            // it('should fire a new "updated" after moving the map (even if not requiring new dataframes)', (done) => {
+            //     mockPrerenderHelpers();
 
-                let numberOfUpdates = 0;
-                let update = () => {
-                    numberOfUpdates++;
+            //     let numberOfUpdates = 0;
+            //     let update = () => {
+            //         numberOfUpdates++;
 
-                    if (numberOfUpdates === 2) {
-                        done(); // ...(b) but we should get a second update
-                    }
+            //         if (numberOfUpdates === 2) {
+            //             resetMocks();
+            //             done(); // ...(b) but we should get a second update
+            //         }
 
-                    // Emulate a user interaction, like dragging the map, using the underlying matrix
-                    const matrix = layer.renderer.matrix;
-                    let newMatrix = mat4.create();
-                    mat4.translate(newMatrix, matrix, [10, 0, 0]); // 10 units translation in x
+            //         // Emulate a user interaction, like dragging the map, using the underlying matrix
+            //         const matrix = layer.renderer.matrix;
+            //         let newMatrix = mat4.create();
+            //         mat4.translate(newMatrix, matrix, [10, 0, 0]); // 10 units translation in x
 
-                    // (a) as it is a geojson, no dataframesHaveChange, but...
-                    layer.prerender(null, newMatrix);
-                };
-                layer.on('updated', update);
-            });
+            //         // (a) as it is a geojson, no dataframesHaveChange, but...
+            //         layer.prerender(null, newMatrix);
+            //     };
+            //     layer.on('updated', update);
+            // });
 
             it('should fire an "updated" event when the viz is updated', (done) => {
                 mockPrerenderHelpers();
@@ -103,9 +112,11 @@ describe('Layer', () => {
                     layer.on('updated', update);
 
                     await layer.update(source, new carto.Viz('color: blue'));
-                    layer.prerender();
+                    const currentMatrix = layer.renderer.matrix;
+                    layer.prerender(null, currentMatrix);
 
                     expect(update).toHaveBeenCalled();
+                    resetMocks();
                     done();
                 });
             });
@@ -148,7 +159,8 @@ describe('Layer', () => {
                 layer.on('loaded', () => {
                     const requestDataSourceSpy = spyOn(layer._source, 'requestData');
                     layer.hide();
-                    layer.prerender();
+                    const currentMatrix = layer.renderer.matrix;
+                    layer.prerender(null, currentMatrix);
 
                     expect(requestDataSourceSpy).not.toHaveBeenCalled();
                     done();

--- a/test/integration/user/test/layer.test.js
+++ b/test/integration/user/test/layer.test.js
@@ -82,28 +82,29 @@ describe('Layer', () => {
                 });
             });
 
-            // it('should fire a new "updated" after moving the map (even if not requiring new dataframes)', (done) => {
-            //     mockPrerenderHelpers();
+            it('should fire a new "updated" after moving the map (even if not requiring new dataframes)', (done) => {
+                mockPrerenderHelpers();
 
-            //     let numberOfUpdates = 0;
-            //     let update = () => {
-            //         numberOfUpdates++;
+                let numberOfUpdates = 0;
+                let update = () => {
+                    numberOfUpdates++;
 
-            //         if (numberOfUpdates === 2) {
-            //             resetMocks();
-            //             done(); // ...(b) but we should get a second update
-            //         }
+                    if (numberOfUpdates === 2) {
+                        resetMocks();
+                        done(); // ...(b) we get a second update
+                        return;
+                    }
 
-            //         // Emulate a user interaction, like dragging the map, using the underlying matrix
-            //         const matrix = layer.renderer.matrix;
-            //         let newMatrix = mat4.create();
-            //         mat4.translate(newMatrix, matrix, [10, 0, 0]); // 10 units translation in x
+                    // // Emulate a user interaction, like dragging the map, using the underlying matrix
+                    const matrix = layer.renderer.matrix;
+                    let newMatrix = mat4.create();
+                    mat4.translate(newMatrix, matrix, [10, 0, 0]); // 10 units translation in x
 
-            //         // (a) as it is a geojson, no dataframesHaveChange, but...
-            //         layer.prerender(null, newMatrix);
-            //     };
-            //     layer.on('updated', update);
-            // });
+                    // (a) as it is a geojson, no dataframesHaveChange, but we need a new update anyway...
+                    layer.prerender(null, newMatrix);
+                };
+                layer.on('updated', update);
+            });
 
             it('should fire an "updated" event when the viz is updated', (done) => {
                 mockPrerenderHelpers();

--- a/test/integration/user/test/layer.test.js
+++ b/test/integration/user/test/layer.test.js
@@ -74,6 +74,28 @@ describe('Layer', () => {
                 });
             });
 
+            it('should fire a new "updated" after moving the map (even if not requiring new dataframes)', (done) => {
+                mockPrerenderHelpers();
+
+                let numberOfUpdates = 0;
+                let update = () => {
+                    numberOfUpdates++;
+
+                    if (numberOfUpdates === 2) {
+                        done(); // ...(b) but we should get a second update
+                    }
+
+                    // Emulate a user interaction, like dragging the map, using the underlying matrix
+                    const matrix = layer.renderer.matrix;
+                    let newMatrix = mat4.create();
+                    mat4.translate(newMatrix, matrix, [10, 0, 0]); // 10 units translation in x
+
+                    // (a) as it is a geojson, no dataframesHaveChange, but...
+                    layer.prerender(null, newMatrix);
+                };
+                layer.on('updated', update);
+            });
+
             it('should fire an "updated" event when the viz is updated', (done) => {
                 mockPrerenderHelpers();
                 layer.on('loaded', async () => {


### PR DESCRIPTION
### Fixes #1189 
### Regressions introduced in #1170 

* **regression 1**: the updated event is not fired when the `viewport` changes but no dataframes are added/removed. It should fire always on that kind of change.
* **regression 2**: the updated event is not properly fired after a `blendTo` operation.

---
### Analysis and tasks

- [x] **regression 1** 
In this case, it was a misunderstanding on the need to restrict the `Layer:updated` event to just *dataframe updates*. 
To fix it the tasks are:
   - [x] failing test to illustrate the problem
   - [x] fire event on any 'viewport' change (based on cameraMatrix changes)

---

- [x] **regression 2**
Before #1170 there was an "updated" event emitted on any render call (except on init). See the changes [here](https://github.com/CartoDB/carto-vl/pull/1170/files#diff-b97124864856432df2f3ab3a5fa12871). In that point in time there were some buggy situations, like two layers receiving crossed updates and always-emitting-animations (although *blendTo* operations were working fine). So we removed that event to fix those situations and that has caused some operations updating the viz (eg. `blendTo`) to lose some of their corresponding "updated" events. We also restricted the animation updated events to `isPlaying` (but it was kept "awaken" to keep its timestamp in sync).
Todo:
   - [x] make animations sleep (and resume correctly). See #1102 as a reference.
   - [x] better identification of each 'updated' event and its cause
   - [x] recover events caused by minor viz changes (e.g blendTo)
   - [x] minor refactors in Layer for more clarity

--- 

### Event triggers
I'm also gonna extend / modify here the catalog of 'updated' _events triggers_, indicating if they are implemented or not, in case we need to discuss on them:

- [x] a) layer visibility has changed
- [x] b) viz has been updated
- [x] c) source has been updated
- [x] d) viewport has changed (zoom, center, bearing or pitch) and that requires new dataframes or NOT (**regression 1**)
- [x] e) an animation isPlaying
- [x] f) blendTo updates (**regression 2**).

Note: All cases but a) require the layer to be visible to raise an 'updated' event

