### PR TITLE
Update jsep fork with latest changes from upstream

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "cartocolor": "^4.0.0",
     "earcut": "^2.1.2",
     "gl-matrix": "^2.8.1",
-    "jsep": "CartoDB/jsep#additional-char-ids-packaged",
+    "jsep": "CartoDB/jsep#additional-char-ids-packaged-update-1",
     "lineclip": "^1.1.5",
     "lru-cache": "^4.1.1",
     "mitt": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3839,9 +3839,9 @@ jsdoc@^3.5.5:
     taffydb "2.6.2"
     underscore "~1.8.3"
 
-jsep@CartoDB/jsep#additional-char-ids-packaged:
+jsep@CartoDB/jsep#additional-char-ids-packaged-update-1:
   version "0.3.4"
-  resolved "https://codeload.github.com/CartoDB/jsep/tar.gz/f27e7f181518ee94fcfb808a73b76b105b0cebb0"
+  resolved "https://codeload.github.com/CartoDB/jsep/tar.gz/f9873387e0165333c2d03b3a01a77f545982a587"
 
 jsesc@^2.5.1:
   version "2.5.1"


### PR DESCRIPTION
### Fixes #1073 

We are still using our own fork, with a different just-updated branch.

We have also pinged the original project owners, to see if the open PR we have there could be merged with our changes... see https://github.com/soney/jsep/pull/89