### PR TITLE
Set codecs at constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix issue sorting null key in `viewportHistogram`
 - Fix unwanted `Interactivity` events while using dragPan (and performance improvement)
 - Fix `linear` applied to cluster aggregations without explicit limits
+- Fix `MVT` category property returning a numeric value
 
 ### Changed
 - Change examples to use Mapbox GL version 0.52

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -401,9 +401,7 @@ export default class Windshaft {
 
         const idProperty = 'cartodb_id';
 
-        const metadata = new Metadata({ properties, featureCount, sample: stats.sample, geomType, isAggregated: aggregation.mvt, idProperty });
-        metadata.setCodecs();
-        return metadata;
+        return new Metadata({ properties, featureCount, sample: stats.sample, geomType, isAggregated: aggregation.mvt, idProperty });
     }
 }
 

--- a/src/renderer/Metadata.js
+++ b/src/renderer/Metadata.js
@@ -1,3 +1,4 @@
+import CartoRuntimeError from '../errors/carto-runtime-error';
 import IdentityCodec from '../codecs/Identity';
 import { FP32_DESIGNATED_NULL_VALUE } from './viz/expressions/constants';
 
@@ -28,6 +29,10 @@ export default class Metadata {
         });
 
         this.propertyKeys = Object.keys(properties);
+    }
+
+    setCodecs () {
+        throw new CartoRuntimeError('You must call "setCodecs" once you have determined the proper subclass');
     }
 
     categorizeString (propertyName, category, init = false) {

--- a/src/sources/MVT.js
+++ b/src/sources/MVT.js
@@ -42,6 +42,7 @@ export default class MVT extends Base {
             metadata = new MVTMetadata(metadata);
         }
         this._metadata = metadata;
+        this._metadata.setCodecs();
         this._tileClient = new TileClient(templateURL);
         this._options = options;
         this._options.viewportZoomToSourceZoom = this._options.viewportZoomToSourceZoom || Math.ceil;


### PR DESCRIPTION
Configuring the codecs should happen at the constructor because we already have the metadata.

However, this doesn't work because the codecs hold a reference to the metadata. Cloning the source will fail with a JSON circular reference in https://github.com/CartoDB/carto-vl/blob/a2fdec46c9707a3b7b3ab0cb584a256d37ebe9cd/src/sources/MVT.js#L75-L77

We already had [a branch that was removing those references](https://github.com/CartoDB/carto-vl/tree/codecs-metadata-avoid-references). The initial proposition was more about performance, but now we have a better reason to merge that branch: being able to clone the sources without that circular structure issue and configuring the codecs at the right place.

What do you think?