### PR TITLE
Add helpers to validate browser support

### DIFF
--- a/examples/basics/browser-support.html
+++ b/examples/basics/browser-support.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Check for browser support | CARTO</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="UTF-8">
+  <script src="../../dist/carto-vl.js"></script>
+  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js"></script>
+  <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css" rel="stylesheet" />
+  <link rel="stylesheet" type="text/css" href="../style.css">
+</head>
+
+<body>
+  <div id="map"></div>
+  <aside class="toolbox">
+    <div class="box">
+      <header>
+        <h1>Check for browser support</h1>
+      </header>
+      <section>
+        <p class="description open-sans">Check if the browser supports CARTO VL and get the reasons if it doesn't.</p>
+      </section>
+      <footer class="js-footer"></footer>
+    </div>
+  </aside>
+  <div id="loader">
+    <div class="CDB-LoaderIcon CDB-LoaderIcon--big">
+      <svg class="CDB-LoaderIcon-spinner" viewBox="0 0 50 50">
+        <circle class="CDB-LoaderIcon-path" cx="25" cy="25" r="20" fill="none"></circle>
+      </svg>
+    </div>
+  </div>
+  <script>
+    if (!carto.isBrowserSupported()) {
+      const reasons = carto.unsupportedBrowserReasons();
+      document.getElementById('loader').innerHTML = `
+        <div class="open-sans text-white">
+          <h3>Oops! Something went wrong.</h3>
+          <p>Your browser doesn't support CARTO VL:</p>
+          <ul>
+              ${reasons.map(r => `<li>${r.message}.</li>`).join('')}
+          </ul>
+        </div>
+      `;
+    } else {
+      const map = new mapboxgl.Map({
+        container: 'map',
+        style: carto.basemaps.voyager,
+        center: [0, 0],
+        zoom: 1,
+        scrollZoom: false,
+      });
+
+      carto.setDefaultAuth({
+        username: 'cartovl',
+        apiKey: 'default_public'
+      });
+
+      const source = new carto.source.Dataset('populated_places');
+      const viz = new carto.Viz();
+      const layer = new carto.Layer('layer', source, viz);
+
+      layer.addTo(map, 'watername_ocean');
+      layer.on('loaded', hideLoader);
+
+      function hideLoader() {
+        document.getElementById('loader').style.opacity = '0';
+      }
+    }
+  </script>
+</body>
+
+</html>

--- a/examples/examples.json
+++ b/examples/examples.json
@@ -25,6 +25,10 @@
                 {
                     "title": "Select layer",
                     "file": "basics/select-layer.html"
+                },
+                {
+                    "title": "Check for browser support",
+                    "file": "basics/browser-support.html"
                 }
             ]
         },

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ import GeoJSON from './sources/GeoJSON';
 import MVT from './sources/MVT';
 import SQL from './sources/SQL';
 import { on, off } from './utils/events';
+import { isBrowserSupported, unsupportedBrowserReasons } from './renderer/Renderer';
 
 /**
  *  @namespace carto.basemaps
@@ -68,5 +69,5 @@ import { version } from '../package.json';
 
 const source = { Dataset, SQL, GeoJSON, MVT };
 
-export { version, on, off, setDefaultAuth, setDefaultConfig, source, expressions, Layer, Viz, Interactivity, basemaps };
+export { version, on, off, isBrowserSupported, unsupportedBrowserReasons, setDefaultAuth, setDefaultConfig, source, expressions, Layer, Viz, Interactivity, basemaps };
 export default { version, on, off, setDefaultAuth, setDefaultConfig, source, expressions, Layer, Viz, Interactivity, basemaps };

--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -434,7 +434,7 @@ export function unsupportedBrowserReasons (canvas, gl, early = false) {
         if (!canvas) {
             canvas = document.createElement('canvas');
         }
-        gl = canvas.getContext('webgl');
+        gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
     }
     if (!gl) {
         reasons.push(new CartoRuntimeError(`${crt.WEB_GL} WebGL 1 is unsupported`));

--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -425,7 +425,7 @@ function getValidWebGLContextOrThrow (canvas, gl) {
 
 export function isBrowserSupported (canvas, gl) {
     const reasons = unsupportedBrowserReasons(canvas, gl);
-    return reasons.length > 0;
+    return reasons.length === 0;
 }
 
 export function unsupportedBrowserReasons (canvas, gl, early = false) {

--- a/test/unit/renderer/renderer.test.js
+++ b/test/unit/renderer/renderer.test.js
@@ -1,0 +1,58 @@
+import Renderer from '../../../src/renderer/Renderer';
+import { RTT_WIDTH } from '../../../src/renderer/Renderer';
+
+describe('src/renderer/Renderer', () => {
+    describe('WebGL errors', () => {
+        const webGLWithNoExtensions = {
+            getExtension: () => null
+        };
+        const webGLWithInvalidParameter = {
+            getExtension: () => ({}),
+            getParameter: () => RTT_WIDTH - 1
+        };
+
+        const canvasWithNoWebGL = { getContext: () => null };
+        const canvasWithNoExtensions = {
+            getContext: () => webGLWithNoExtensions
+        };
+        const canvasWithInvalidParameter = {
+            getContext: () => webGLWithInvalidParameter
+        };
+
+        describe('Constructor', () => {
+            it('should throw when there is no webgl context', () => {
+                expect(() => {
+                    new Renderer(canvasWithNoWebGL);
+                }).toThrowError(/WebGL 1 is unsupported/);
+            });
+
+            it('should throw when the "OES_texture_float" extension is not available', () => {
+                expect(() => {
+                    new Renderer(canvasWithNoExtensions);
+                }).toThrowError(/WebGL extension 'OES_texture_float' is unsupported/);
+            });
+
+            it('should throw when the "MAX_RENDERBUFFER_SIZE" parameter is not big enough', () => {
+                expect(() => {
+                    new Renderer(canvasWithInvalidParameter);
+                }).toThrowError(/WebGL parameter 'gl\.MAX_RENDERBUFFER_SIZE' is below the requirement.*/);
+            });
+        });
+
+        describe('initialize', () => {
+            it('should throw when the "OES_texture_float" extension is not available', () => {
+                expect(() => {
+                    const renderer = new Renderer();
+                    renderer.initialize(webGLWithNoExtensions);
+                }).toThrowError(/WebGL extension 'OES_texture_float' is unsupported/);
+            });
+
+            it('should throw when the "MAX_RENDERBUFFER_SIZE" parameter is not big enough', () => {
+                expect(() => {
+                    const renderer = new Renderer();
+                    renderer.initialize(webGLWithInvalidParameter);
+                }).toThrowError(/WebGL parameter 'gl\.MAX_RENDERBUFFER_SIZE' is below the requirement.*/);
+            });
+        });
+    });
+});

--- a/test/unit/renderer/renderer.test.js
+++ b/test/unit/renderer/renderer.test.js
@@ -1,5 +1,5 @@
 import Renderer from '../../../src/renderer/Renderer';
-import { RTT_WIDTH } from '../../../src/renderer/Renderer';
+import { RTT_WIDTH, isBrowserSupported } from '../../../src/renderer/Renderer';
 
 describe('src/renderer/Renderer', () => {
     describe('WebGL errors', () => {
@@ -9,6 +9,10 @@ describe('src/renderer/Renderer', () => {
         const webGLWithInvalidParameter = {
             getExtension: () => ({}),
             getParameter: () => RTT_WIDTH - 1
+        };
+        const webGLValidContext = {
+            getExtension: () => ({}),
+            getParameter: () => RTT_WIDTH
         };
 
         const canvasWithNoWebGL = { getContext: () => null };
@@ -52,6 +56,12 @@ describe('src/renderer/Renderer', () => {
                     const renderer = new Renderer();
                     renderer.initialize(webGLWithInvalidParameter);
                 }).toThrowError(/WebGL parameter 'gl\.MAX_RENDERBUFFER_SIZE' is below the requirement.*/);
+            });
+        });
+
+        describe('isBrowserSupported', () => {
+            it('should return true for valid WebGL context', () => {
+                expect(isBrowserSupported(null, webGLValidContext)).toBe(true);
             });
         });
     });

--- a/test/unit/renderer/renderer.test.js
+++ b/test/unit/renderer/renderer.test.js
@@ -79,6 +79,10 @@ describe('src/renderer/Renderer', () => {
                     expect(isBrowserSupported(null, ctx)).toBe(false);
                 });
             });
+
+            it('should return false when WebGL is not available', () => {
+                expect(isBrowserSupported(canvasWithNoWebGL)).toBe(false);
+            });
         });
     });
 });

--- a/test/unit/renderer/renderer.test.js
+++ b/test/unit/renderer/renderer.test.js
@@ -4,10 +4,15 @@ import { RTT_WIDTH, isBrowserSupported } from '../../../src/renderer/Renderer';
 describe('src/renderer/Renderer', () => {
     describe('WebGL errors', () => {
         const webGLWithNoExtensions = {
-            getExtension: () => null
+            getExtension: () => null,
+            getParameter: () => RTT_WIDTH
         };
         const webGLWithInvalidParameter = {
             getExtension: () => ({}),
+            getParameter: () => RTT_WIDTH - 1
+        };
+        const webGLWithNoExtensionsAndInvalidParameter = {
+            getExtension: () => null,
             getParameter: () => RTT_WIDTH - 1
         };
         const webGLValidContext = {
@@ -62,6 +67,17 @@ describe('src/renderer/Renderer', () => {
         describe('isBrowserSupported', () => {
             it('should return true for valid WebGL context', () => {
                 expect(isBrowserSupported(null, webGLValidContext)).toBe(true);
+            });
+
+            const invalidWebGLContextScenarios = [
+                webGLWithNoExtensions,
+                webGLWithInvalidParameter,
+                webGLWithNoExtensionsAndInvalidParameter
+            ];
+            invalidWebGLContextScenarios.forEach((ctx, i) => {
+                it(`should return false for invalid WebGL context (${i})`, () => {
+                    expect(isBrowserSupported(null, ctx)).toBe(false);
+                });
             });
         });
     });

--- a/test/unit/renderer/renderer.test.js
+++ b/test/unit/renderer/renderer.test.js
@@ -1,5 +1,5 @@
 import Renderer from '../../../src/renderer/Renderer';
-import { RTT_WIDTH, isBrowserSupported } from '../../../src/renderer/Renderer';
+import { RTT_WIDTH, isBrowserSupported, unsupportedBrowserReasons } from '../../../src/renderer/Renderer';
 
 describe('src/renderer/Renderer', () => {
     describe('WebGL errors', () => {
@@ -82,6 +82,45 @@ describe('src/renderer/Renderer', () => {
 
             it('should return false when WebGL is not available', () => {
                 expect(isBrowserSupported(canvasWithNoWebGL)).toBe(false);
+            });
+        });
+
+        describe('unsupportedBrowserReasons', () => {
+            it('should return WebGL unavailable error', () => {
+                const reasons = unsupportedBrowserReasons(canvasWithNoWebGL);
+                expect(reasons.length).toBe(1);
+                expect(reasons[0].message).toMatch(/WebGL 1 is unsupported/);
+            });
+
+            const invalidWebGLContextScenarios = [
+                {
+                    ctx: webGLWithNoExtensions,
+                    errors: [
+                        /WebGL extension 'OES_texture_float' is unsupported/
+                    ]
+                },
+                {
+                    ctx: webGLWithInvalidParameter,
+                    errors: [
+                        /WebGL parameter 'gl\.MAX_RENDERBUFFER_SIZE' is below the requirement.*/
+                    ]
+                },
+                {
+                    ctx: webGLWithNoExtensionsAndInvalidParameter,
+                    errors: [
+                        /WebGL extension 'OES_texture_float' is unsupported/,
+                        /WebGL parameter 'gl\.MAX_RENDERBUFFER_SIZE' is below the requirement.*/
+                    ]
+                }
+            ];
+            invalidWebGLContextScenarios.forEach((scenario, i) => {
+                it(`should return false for invalid WebGL context (${i})`, () => {
+                    const reasons = unsupportedBrowserReasons(null, scenario.ctx);
+                    expect(reasons.length).toBe(scenario.errors.length);
+                    scenario.errors.forEach((errorRegex, i) => {
+                        expect(reasons[i]).toMatch(errorRegex);
+                    });
+                });
             });
         });
     });


### PR DESCRIPTION
As per our previous conversation in https://github.com/CartoDB/carto-vl/issues/1149#issuecomment-441287468, I'm planning on adding `isBrowserSupported` and `unsupportedBrowserReasons` to be able to detect browser incompatibilities before creating any visualization.

This will make easier to display error messages to the end-user without having to use try/catch blocks. 