### PR TITLE
Add tests to check for compatibility with several MGL versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Enable user-defined buckets in `viewportHistogram`
 - Add and improve examples (legends, widgets, labeling and basemaps)
 - Add helpers to validate browser support (`isBrowserSupported` & `unsupportedBrowserReasons`)
+- Add tests to check for compatibility with several MGL versions
 
 ### Fixed
 - Fix `linear` error when evaluating a date property in a feature

--- a/package.json
+++ b/package.json
@@ -127,5 +127,9 @@
     "defaults",
     "not ie <12",
     "not edge <17"
+  ],
+  "previousMapboxGLVersions": [
+    "v0.50.0",
+    "v0.51.0"
   ]
 }

--- a/test/common/util.js
+++ b/test/common/util.js
@@ -9,6 +9,11 @@ const testFile = 'scenario.js';
 const sources = loadGeoJSONSources();
 const PORT = 5000;
 
+const mapboxVersion = {
+    js: `http://localhost:${PORT}/` + path.join('node_modules', 'mapbox-gl', 'dist', 'mapbox-gl.js'),
+    css: `http://localhost:${PORT}/` + path.join('node_modules', 'mapbox-gl', 'dist', 'mapbox-gl.css')
+};
+
 function loadFiles (directory) {
     testsDir = directory;
     let files = [];
@@ -59,8 +64,8 @@ function getDeviceScaleFactor (file) {
     return 1;
 }
 
-async function testSST (file, template, browser) {
-    writeTemplate(file, template);
+async function testSST (file, template, browser, mapbox = mapboxVersion) {
+    writeTemplate(file, template, mapbox);
     let options = loadOptions();
     options.url = `http://localhost:${PORT}/test/${getLocalhostURL(file)}/scenario.html`;
     options.input = `${getPNG(file)}`;
@@ -96,14 +101,14 @@ async function testSST (file, template, browser) {
     return result;
 }
 
-function writeTemplate (file, template) {
+function writeTemplate (file, template, mapbox = mapboxVersion) {
     const bundle = process.env.MIN ? 'carto-vl.min' : 'carto-vl';
     fs.writeFileSync(getHTML(file), template({
         file: `http://localhost:${PORT}/test/${getLocalhostURL(file)}/scenario.js`,
         sources: sources,
         cartovl: `http://localhost:${PORT}/dist/${bundle}.js`,
-        mapboxgl: `http://localhost:${PORT}/` + path.join('node_modules', 'mapbox-gl', 'dist', 'mapbox-gl.js'),
-        mapboxglcss: `http://localhost:${PORT}/` + path.join('node_modules', 'mapbox-gl', 'dist', 'mapbox-gl.css'),
+        mapboxgl: mapbox.js,
+        mapboxglcss: mapbox.css,
         glmatrix: `http://localhost:${PORT}/` + path.join('node_modules', 'gl-matrix', 'dist', 'gl-matrix-min.js')
     }));
 }

--- a/test/integration/render/render.test.js
+++ b/test/integration/render/render.test.js
@@ -11,6 +11,8 @@ const exquisite = require('exquisite-sst');
 const files = util.loadFiles(path.join(__dirname, 'scenarios'));
 const template = util.loadTemplate(path.join(__dirname, 'render.html.tpl'));
 
+const currentPackage = require('../../../package.json');
+
 describe('Render tests:', () => {
     let server;
     let browser;
@@ -24,11 +26,36 @@ describe('Render tests:', () => {
         });
     });
 
+    console.log(`Tests will run for current mapbox-gl version: ${currentPackage.devDependencies['mapbox-gl']}`);
     files.forEach(file => {
         it(util.getName(file), () => {
             const actual = util.testSST(file, template, browser);
             // Temporary threshold (1px) to cover small renderer differences between Mac & Linux
             return chai.expect(actual).to.eventually.be.at.most(1);
+        });
+    });
+
+    describe('with previous Mapbox GL versions...', () => {
+        const previousVersions = currentPackage.previousMapboxGLVersions; // TODO push up in config.
+        console.log(`Tests will run these previous versions: ${previousVersions.join(', ')}`);
+        const mapboxVersions = previousVersions.map((version) => {
+            return {
+                name: version,
+                js: `https://api.tiles.mapbox.com/mapbox-gl-js/${version}/mapbox-gl.js`,
+                css: `https://api.tiles.mapbox.com/mapbox-gl-js/${version}/mapbox-gl.css`
+            };
+        });
+
+        mapboxVersions.forEach((mapboxVersion) => {
+            describe(mapboxVersion.name, () => {
+                files.forEach(file => {
+                    it(util.getName(file), () => {
+                        const actual = util.testSST(file, template, browser, mapboxVersion);
+                        // Temporary threshold (1px) to cover small renderer differences between Mac & Linux
+                        return chai.expect(actual).to.eventually.be.at.most(1);
+                    });
+                });
+            });
         });
     });
 


### PR DESCRIPTION
### Closes #1220 

This PR runs the **whole set of render tests** with the current version (as before) AND with all the Mapbox GL versions configured in **package.json** (currently: v0.50.0 and v0.51.0)

*The goods*: It's easy to setup the relevant MGL versions to test and we have lots of tests
*The bads*: test-render time x3

