### PR TITLE
Fix Content-Type for files deployed to CDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Fix regression in `viewportFeatures` including hidden polygons
+- Fix Content-Type for files deployed to CDN
 
 ## [1.1.0] - 2019-01-15
 

--- a/scripts/cdn/publish.js
+++ b/scripts/cdn/publish.js
@@ -121,7 +121,8 @@ async function uploadFileToS3 (filePath, gzFileContent) {
         Bucket: secrets.AWS_S3_BUCKET,
         Key: filePath,
         Body: gzFileContent,
-        ContentEncoding: 'gzip'
+        ContentEncoding: 'gzip',
+        ContentType: getContentTypeFor(filePath)
     };
 
     await S3.upload(s3Params, function (err, data) {
@@ -131,6 +132,18 @@ async function uploadFileToS3 (filePath, gzFileContent) {
             console.log(`[${filePath}] uploaded!`);
         }
     });
+}
+
+function getContentTypeFor (filePath) {
+    const ext = path.extname(filePath);
+    switch (ext) {
+        case '.js':
+            return 'application/javascript';
+        case '.map':
+            return 'application/json';
+        default:
+            throw new Error(`Unexpected extension ${ext} for file being uploaded. Double check it!`);
+    }
 }
 
 async function gzippedFileContent (fileName) {


### PR DESCRIPTION
### Closes #1231 

It can be currently tested with: https://libs.cartocdn.com/carto-vl/branches/1231-proper-content-type/carto-vl.js