### PR TITLE
Make aggregated values available for labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Allow the use of variables for all classifiers: `globalQuantiles`, `globalEqIntervals`, `globalStandardDev`, `viewportQuantiles`, `viewportEqIntervals` and `viewportStandardDev`
+- Add the variable name to an expression if it is assigned to a variable through the property `variableName`
 
 ### Fixed
 - Fix regression in `Interactivity` using MVT and polygons
+- Fix getting aggregation expression values passed to `viewportFeatures` expression
 
 ## [1.1.1] - 2019-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Allow the use of variables for all classifiers: `globalQuantiles`, `globalEqIntervals`, `globalStandardDev`, `viewportQuantiles`, `viewportEqIntervals` and `viewportStandardDev`
-- Add the variable name to an expression if it is assigned to a variable through the property `variableName`
 
 ### Fixed
 - Fix regression in `Interactivity` using MVT and polygons

--- a/debug/cluster-label-zoom-no-filter.html
+++ b/debug/cluster-label-zoom-no-filter.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Exported map | CARTO VL</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="../../dist/carto-vl.js"></script>
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js"></script>
+    <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css" rel="stylesheet" />
+    <link rel="stylesheet" type="text/css" href="../style.css">
+    <style>
+        html,
+        body {
+            margin: 0;
+        }
+
+        #map {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="map"></div>
+    <script>
+        const map = new mapboxgl.Map({
+            container: 'map',
+            style: carto.basemaps.darkmatter,
+            center: [-93.374509, 35.786814],
+            zoom: 3
+        });
+
+        const nav = new mapboxgl.NavigationControl({
+            showCompass: false
+        });
+        map.addControl(nav, 'top-left');
+
+
+        carto.setDefaultConfig({
+            serverURL: 'https://{user}.carto.com'
+        });
+
+        carto.setDefaultAuth({
+            username: 'cartovl',
+            apiKey: 'default_public'
+        });
+
+
+        const source = new carto.source.SQL(`select * from monarch_migration_1`);
+        const viz = new carto.Viz(`
+
+        @cc: clusterCount()
+        @v_features: viewportFeatures(@cc);
+
+        width: sqrt(@cc)*10
+        color: opacity(ramp(linear(@cc,5,50),redor),0.7)
+        strokeColor: ramp(linear(@cc,5,50),redor)
+        strokeWidth: 1
+        order: asc(width())
+        resolution: 16
+        //filter:ramp(zoomrange([3,4,5,6]),[@cc>20,@cc>10,@cc>5,true])
+
+    `);
+        const layer = new carto.Layer('layer', source, viz);
+
+        // Create labeling layer centroids
+        layer.on('loaded', () => {
+            map.addSource('labels', { type: 'geojson', data: null });
+            const labelSource = map.getSource('labels');
+
+            const layerUpdated = function () {
+                const features = viz.variables.v_features.value;
+                const geojsonFeatures = features.map(f => {
+                    return {
+                        "type": "Feature",
+                        "geometry": {
+                            "type": "Point",
+                            "coordinates": f.getRenderedCentroid()
+                        },
+                        "properties": {
+                            "label_field": `${f.properties['cc']}`,
+                        }
+                    }
+                });
+
+                labelSource.setData({
+                    type: 'FeatureCollection',
+                    features: geojsonFeatures
+                });
+            };
+
+            layer.on('updated', layerUpdated);
+
+            // Style labels
+            map.addLayer({
+                "id": "my-labels",
+                "type": "symbol",
+                "source": "labels",
+                "layout": {
+                    "text-field": "{label_field}",
+                    "text-font": ["Open Sans Bold", "Arial Unicode MS Bold"],
+                    "text-size": 12,
+                    "text-offset": [-0.05, -0.65],
+                    "text-anchor": "top",
+                    "text-max-width": 8,
+                    "text-justify": "center"
+                },
+                "paint": {
+                    "text-color": "white",
+                    "text-halo-width": 0,
+                    "text-halo-blur": 0
+                }
+            });
+        });
+
+        layer.addTo(map, 'watername_ocean');
+    </script>
+</body>
+
+</html>

--- a/debug/cluster-label-zoom-with-filter.html
+++ b/debug/cluster-label-zoom-with-filter.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Exported map | CARTO VL</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="../../dist/carto-vl.js"></script>
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js"></script>
+    <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css" rel="stylesheet" />
+    <link rel="stylesheet" type="text/css" href="../style.css">
+    <style>
+        html,
+        body {
+            margin: 0;
+        }
+
+        #map {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="map"></div>
+    <script>
+        const map = new mapboxgl.Map({
+            container: 'map',
+            style: carto.basemaps.darkmatter,
+            center: [-93.374509, 35.786814],
+            zoom: 3
+        });
+
+        const nav = new mapboxgl.NavigationControl({
+            showCompass: false
+        });
+        map.addControl(nav, 'top-left');
+
+
+        carto.setDefaultConfig({
+            serverURL: 'https://{user}.carto.com'
+        });
+
+        carto.setDefaultAuth({
+            username: 'cartovl',
+            apiKey: 'default_public'
+        });
+
+
+        const source = new carto.source.SQL(`select * from monarch_migration_1`);
+        const viz = new carto.Viz(`
+
+        @cc: clusterCount()
+        @v_features: viewportFeatures(@cc);
+
+        width: sqrt(@cc)*10
+        color: opacity(ramp(linear(@cc,5,50),redor),0.7)
+        strokeColor: ramp(linear(@cc,5,50),redor)
+        strokeWidth: 1
+        order: asc(width())
+        resolution: 16
+        filter:ramp(zoomrange([3,4,5,6]),[@cc>20,@cc>10,@cc>5,true])
+
+    `);
+        const layer = new carto.Layer('layer', source, viz);
+
+        // Create labeling layer centroids
+        layer.on('loaded', () => {
+            map.addSource('labels', { type: 'geojson', data: null });
+            const labelSource = map.getSource('labels');
+
+            const layerUpdated = function () {
+                const features = viz.variables.v_features.value;
+                const geojsonFeatures = features.map(f => {
+                    return {
+                        "type": "Feature",
+                        "geometry": {
+                            "type": "Point",
+                            "coordinates": f.getRenderedCentroid()
+                        },
+                        "properties": {
+                            "label_field": `${f.properties['cc']}`,
+                        }
+                    }
+                });
+
+                labelSource.setData({
+                    type: 'FeatureCollection',
+                    features: geojsonFeatures
+                });
+            };
+
+            layer.on('updated', layerUpdated);
+
+            // Style labels
+            map.addLayer({
+                "id": "my-labels",
+                "type": "symbol",
+                "source": "labels",
+                "layout": {
+                    "text-field": "{label_field}",
+                    "text-font": ["Open Sans Bold", "Arial Unicode MS Bold"],
+                    "text-size": 12,
+                    "text-offset": [-0.05, -0.65],
+                    "text-anchor": "top",
+                    "text-max-width": 8,
+                    "text-justify": "center"
+                },
+                "paint": {
+                    "text-color": "white",
+                    "text-halo-width": 0,
+                    "text-halo-blur": 0
+                }
+            });
+        });
+
+        layer.addTo(map, 'watername_ocean');
+    </script>
+</body>
+
+</html>

--- a/examples/labeling/point-aggregation-cluster-count.html
+++ b/examples/labeling/point-aggregation-cluster-count.html
@@ -23,7 +23,7 @@
 <script>
     const map = new mapboxgl.Map({
         container: 'map',
-        style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
+        style: carto.basemaps.darkmatter,
         center: [2.1694138650888135, 41.37286330558891],
         zoom: 21.611075639862133
     });
@@ -44,7 +44,7 @@
         strokeWidth: 0
         resolution: 0.25
         width: @cc * 15
-        @v_features: viewportFeatures($speed, @cc);
+        @v_features: viewportFeatures(@cc);
     `);
     const layer = new carto.Layer('layer', source, viz);
 

--- a/examples/labeling/point-aggregation-cluster-count.html
+++ b/examples/labeling/point-aggregation-cluster-count.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Exported map | CARTO VL</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="../../dist/carto-vl.js"></script>
+<script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js"></script>
+<link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css" rel="stylesheet" />
+<link rel="stylesheet" type="text/css" href="../style.css">
+<style>
+    html, body {
+        margin: 0;
+    }
+    #map {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+    }
+</style>
+</head>
+<body>
+<div id="map"></div>
+<script>
+    const map = new mapboxgl.Map({
+        container: 'map',
+        style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
+        center: [2.1694138650888135, 41.37286330558891],
+        zoom: 21.611075639862133
+    });
+
+    carto.setDefaultConfig({
+        serverURL: 'https://{user}.carto.com'
+    });
+
+    carto.setDefaultAuth({
+        username: 'cartovl',
+        apiKey: 'default_public'
+    });
+
+
+    const source = new carto.source.SQL(`select *, 1 as co from gecat_geodata_copy`);
+    const viz = new carto.Viz(`
+        @cc: clusterCount()
+        strokeWidth: 0
+        resolution: 0.25
+        width: @cc * 15
+        @v_features: viewportFeatures($speed, @cc);
+    `);
+    const layer = new carto.Layer('layer', source, viz);
+
+        // Create labeling layer centroids
+    layer.on('loaded', () => {
+      map.addSource('labels', { type: 'geojson', data: null });
+      const labelSource = map.getSource('labels');
+
+      const layerUpdated = function () {
+        const features = viz.variables.v_features.value;
+        const geojsonFeatures = features.map(f => {
+          return {
+            "type": "Feature",
+            "geometry": {
+              "type": "Point",
+              "coordinates": f.getRenderedCentroid()
+            },
+            "properties": {
+              "label_field": `${f.properties['cc']}`,
+            }
+          }
+        });
+
+        labelSource.setData({
+          type: 'FeatureCollection',
+          features: geojsonFeatures
+        });
+      };
+
+      layer.on('updated', layerUpdated);
+
+      // Style labels
+      map.addLayer({
+        "id": "my-labels",
+        "type": "symbol",
+        "source": "labels",
+        "layout": {
+          "text-field": "{label_field}",
+          "text-font": ["Open Sans Bold", "Arial Unicode MS Bold"],
+          "text-size": 12,
+          "text-offset": [-0.05, -0.65],
+          "text-anchor": "top",
+          "text-max-width": 8,
+          "text-justify": "center"
+        },
+        "paint": {
+          "text-color": "white",
+          "text-halo-width": 0,
+          "text-halo-blur": 0
+        }
+      });
+    });
+
+    layer.addTo(map, 'watername_ocean');
+</script>
+</body>
+</html>

--- a/examples/labeling/point-labels-aggregate-count.html
+++ b/examples/labeling/point-labels-aggregate-count.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Point labels | CARTO</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="UTF-8">
+  <script src="../../dist/carto-vl.js"></script>
+  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js"></script>
+  <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css" rel="stylesheet" />
+  <link rel="stylesheet" type="text/css" href="../style.css">
+</head>
+
+<body>
+  <div id="map"></div>
+
+  <script>
+    const map = new mapboxgl.Map({
+      container: 'map',
+      style: carto.basemaps.darkmatter,
+      center: [-104.994105, 39.745939],
+      zoom: 14
+    });
+
+    const nav = new mapboxgl.NavigationControl({
+      showCompass: false
+    });
+    map.addControl(nav, 'top-left');
+
+    carto.setDefaultAuth({
+      user: 'cartovl',
+      apiKey: 'default_public'
+    });
+
+    // Point layer
+    const source = new carto.source.Dataset('points_of_interest');
+    const viz = new carto.Viz(`
+      color: fuchsia
+      strokeColor: white
+      strokeWidth: 2
+      filter: $major == "YES"
+      @cc: clusterCount()
+      width: @cc * 30
+      @v_features: viewportFeatures($poi_name, @cc)
+    `);
+    const layer = new carto.Layer('points', source, viz);
+
+    // Create labeling layer centroids
+    layer.on('loaded', () => {
+      map.addSource('labels', { type: 'geojson', data: null });
+      const labelSource = map.getSource('labels');
+
+      const layerUpdated = function () {
+        const features = viz.variables.v_features.value;
+        const geojsonFeatures = features.map(f => {
+          return {
+            "type": "Feature",
+            "geometry": {
+              "type": "Point",
+              "coordinates": f.getRenderedCentroid()
+            },
+            "properties": {
+              "label_field": `${f.properties['cc']}`,
+            }
+          }
+        });
+
+        labelSource.setData({
+          type: 'FeatureCollection',
+          features: geojsonFeatures
+        });
+      };
+
+      layer.on('updated', layerUpdated);
+
+      // Style labels
+      map.addLayer({
+        "id": "my-labels",
+        "type": "symbol",
+        "source": "labels",
+        "layout": {
+          "text-field": "{label_field}",
+          "text-font": ["Open Sans Bold", "Arial Unicode MS Bold"],
+          "text-size": 10,
+          "text-offset": [-0.05, -0.65],
+          "text-anchor": "top",
+          "text-max-width": 8,
+          "text-justify": "center"
+        },
+        "paint": {
+          "text-color": "white",
+          "text-halo-color": "white",
+          "text-halo-width": 0.5,
+          "text-halo-blur": 0.5
+        }
+      });
+    });
+
+    layer.addTo(map);
+
+  </script>
+</body>
+
+</html>

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -163,7 +163,7 @@ export default class Viz {
                     value = implicitCast(value);
 
                     if (value instanceof BaseExpression) {
-                        value.variableName = prop;
+                        value._variableName = prop;
                     }
 
                     obj[prop] = value;

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -161,6 +161,11 @@ export default class Viz {
                 },
                 set: (obj, prop, value) => {
                     value = implicitCast(value);
+                    
+                    if (value instanceof BaseExpression) {
+                        value.variableName = prop;
+                    }
+
                     obj[prop] = value;
                     this['__cartovl_variable_' + prop] = value;
                     if (init) {

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -161,7 +161,7 @@ export default class Viz {
                 },
                 set: (obj, prop, value) => {
                     value = implicitCast(value);
-                    
+
                     if (value instanceof BaseExpression) {
                         value.variableName = prop;
                     }

--- a/src/interactivity/lightweightFeature.js
+++ b/src/interactivity/lightweightFeature.js
@@ -11,7 +11,7 @@ import CartoValidationError, { CartoValidationTypes as cvt } from '../errors/car
  * @param {*} renderLayer
  * @returns FeatureLike class
  */
-export function genLightweightFeatureClass (propertyNames, renderLayer) {
+export function genLightweightFeatureClass (names, renderLayer) {
     const cls = class LightweightFeature {
         constructor (rawFeature) {
             this._rawFeature = rawFeature;
@@ -22,7 +22,7 @@ export function genLightweightFeatureClass (propertyNames, renderLayer) {
     _defineIdProperty(cls.prototype, renderLayer);
     _defineVizProperties(cls.prototype, renderLayer);
     _defineVizVariables(cls.prototype, renderLayer);
-    _defineFeatureProperties(cls.prototype, propertyNames);
+    _defineFeatureProperties(cls.prototype, names);
     _defineRootBlendToMethod(cls.prototype);
     _defineRootResetMethod(cls.prototype);
     _defineGetRenderedCentroidMethod(cls.prototype);
@@ -92,14 +92,18 @@ function _defineVizVariables (targetObject, renderLayer) {
     });
 }
 
-function _defineFeatureProperties (targetObject, propertyNames) {
+function _defineFeatureProperties (targetObject, names) {
     Object.defineProperty(targetObject, 'properties', {
         get: function () {
             if (this._featureProperties === null) {
                 this._featureProperties = {};
-                // feature properties
-                propertyNames.forEach(propertyName => {
-                    this._featureProperties[propertyName] = this._rawFeature[propertyName];
+
+                names.forEach(({ property, variable }) => {
+                    if (variable) {
+                        this._featureProperties[variable] = this._rawFeature[property];
+                    } else {
+                        this._featureProperties[property] = this._rawFeature[property];
+                    }
                 });
             }
             return this._featureProperties;

--- a/src/interactivity/lightweightFeature.js
+++ b/src/interactivity/lightweightFeature.js
@@ -99,11 +99,8 @@ function _defineFeatureProperties (targetObject, names) {
                 this._featureProperties = {};
 
                 names.forEach(({ property, variable }) => {
-                    if (variable) {
-                        this._featureProperties[variable] = this._rawFeature[property];
-                    } else {
-                        this._featureProperties[property] = this._rawFeature[property];
-                    }
+                    const propertyName = variable ? variable : property;
+                    this._featureProperties[propertyName] = this._rawFeature[property];
                 });
             }
             return this._featureProperties;

--- a/src/interactivity/lightweightFeature.js
+++ b/src/interactivity/lightweightFeature.js
@@ -11,7 +11,7 @@ import CartoValidationError, { CartoValidationTypes as cvt } from '../errors/car
  * @param {*} renderLayer
  * @returns FeatureLike class
  */
-export function genLightweightFeatureClass (names, renderLayer) {
+export function genLightweightFeatureClass (propertyNames, renderLayer) {
     const cls = class LightweightFeature {
         constructor (rawFeature) {
             this._rawFeature = rawFeature;
@@ -22,7 +22,7 @@ export function genLightweightFeatureClass (names, renderLayer) {
     _defineIdProperty(cls.prototype, renderLayer);
     _defineVizProperties(cls.prototype, renderLayer);
     _defineVizVariables(cls.prototype, renderLayer);
-    _defineFeatureProperties(cls.prototype, names);
+    _defineFeatureProperties(cls.prototype, propertyNames);
     _defineRootBlendToMethod(cls.prototype);
     _defineRootResetMethod(cls.prototype);
     _defineGetRenderedCentroidMethod(cls.prototype);
@@ -92,13 +92,13 @@ function _defineVizVariables (targetObject, renderLayer) {
     });
 }
 
-function _defineFeatureProperties (targetObject, names) {
+function _defineFeatureProperties (targetObject, propertyNames) {
     Object.defineProperty(targetObject, 'properties', {
         get: function () {
             if (this._featureProperties === null) {
                 this._featureProperties = {};
 
-                names.forEach(({ property, variable }) => {
+                propertyNames.forEach(({ property, variable }) => {
                     const propertyName = variable || property;
                     this._featureProperties[propertyName] = this._rawFeature[property];
                 });

--- a/src/interactivity/lightweightFeature.js
+++ b/src/interactivity/lightweightFeature.js
@@ -99,7 +99,7 @@ function _defineFeatureProperties (targetObject, names) {
                 this._featureProperties = {};
 
                 names.forEach(({ property, variable }) => {
-                    const propertyName = variable ? variable : property;
+                    const propertyName = variable || property;
                     this._featureProperties[propertyName] = this._rawFeature[property];
                 });
             }

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
@@ -33,6 +33,16 @@ export default class ClusterCount extends BaseExpression {
         this._hasClusterFeatureCount = false;
     }
 
+    get propertyName () {
+        if (this._hasClusterFeatureCount) {
+            return CLUSTER_FEATURE_COUNT;
+        }
+    }
+
+    isFeatureDependent () {
+        return true;
+    }
+
     eval (feature) {
         return Number(feature[CLUSTER_FEATURE_COUNT]) || 1;
     }
@@ -40,6 +50,7 @@ export default class ClusterCount extends BaseExpression {
     _bindMetadata (metadata) {
         super._bindMetadata(metadata);
         this._hasClusterFeatureCount = metadata.properties[CLUSTER_FEATURE_COUNT] !== undefined;
+        this._metadata = metadata;
     }
 
     _applyToShaderSource (getGLSLforProperty) {
@@ -47,5 +58,9 @@ export default class ClusterCount extends BaseExpression {
             preface: '',
             inline: this._hasClusterFeatureCount ? getGLSLforProperty(CLUSTER_FEATURE_COUNT) : '1.'
         };
+    }
+
+    _getMinimumNeededSchema () {
+        return {}
     }
 }

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
@@ -34,9 +34,7 @@ export default class ClusterCount extends BaseExpression {
     }
 
     get propertyName () {
-        if (this._hasClusterFeatureCount) {
-            return CLUSTER_FEATURE_COUNT;
-        }
+        return CLUSTER_FEATURE_COUNT;
     }
 
     isFeatureDependent () {

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
@@ -48,7 +48,6 @@ export default class ClusterCount extends BaseExpression {
     _bindMetadata (metadata) {
         super._bindMetadata(metadata);
         this._hasClusterFeatureCount = metadata.properties[CLUSTER_FEATURE_COUNT] !== undefined;
-        this._metadata = metadata;
     }
 
     _applyToShaderSource (getGLSLforProperty) {
@@ -56,9 +55,5 @@ export default class ClusterCount extends BaseExpression {
             preface: '',
             inline: this._hasClusterFeatureCount ? getGLSLforProperty(CLUSTER_FEATURE_COUNT) : '1.'
         };
-    }
-
-    _getMinimumNeededSchema () {
-        return {};
     }
 }

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
@@ -61,6 +61,6 @@ export default class ClusterCount extends BaseExpression {
     }
 
     _getMinimumNeededSchema () {
-        return {}
+        return {};
     }
 }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
@@ -63,6 +63,7 @@ export default class GlobalAggregation extends BaseExpression {
     toString () {
         return `${this.expressionName}(${this.property.toString()})`;
     }
+
     isFeatureDependent () {
         return false;
     }

--- a/src/renderer/viz/expressions/base.js
+++ b/src/renderer/viz/expressions/base.js
@@ -29,6 +29,7 @@ export default class Base {
         this.preface = '';
         this._shaderBindings = new Map();
         this.expressionName = _toCamelCase(this.constructor.name);
+        this.variableName = null;
     }
 
     /**

--- a/src/renderer/viz/expressions/base.js
+++ b/src/renderer/viz/expressions/base.js
@@ -29,7 +29,7 @@ export default class Base {
         this.preface = '';
         this._shaderBindings = new Map();
         this.expressionName = _toCamelCase(this.constructor.name);
-        this.variableName = null;
+        this._variableName = null;
     }
 
     /**

--- a/src/renderer/viz/expressions/viewportFeatures.js
+++ b/src/renderer/viz/expressions/viewportFeatures.js
@@ -91,7 +91,7 @@ export default class ViewportFeatures extends BaseExpression {
             }
 
             const names = this._requiredProperties.map((p) => {
-                return { property: p.propertyName,  variable: p.variableName }
+                return { property: p.propertyName, variable: p.variableName };
             });
             this._FeatureProxy = genLightweightFeatureClass(names, renderLayer);
         }

--- a/src/renderer/viz/expressions/viewportFeatures.js
+++ b/src/renderer/viz/expressions/viewportFeatures.js
@@ -2,6 +2,7 @@ import BaseExpression from './base';
 import Property from './basic/property';
 import ClusterTimeDimension from './aggregation/cluster/ClusterTimeDimension';
 import ClusterAggregation from './aggregation/cluster/ClusterAggregation';
+import ClusterCount from './aggregation/cluster/ClusterCount';
 import { implicitCast } from './utils';
 import CartoValidationError, { CartoValidationTypes as cvt } from '../../../errors/carto-validation-error';
 import CartoRuntimeError from '../../../errors/carto-runtime-error';
@@ -60,7 +61,6 @@ export default class ViewportFeatures extends BaseExpression {
         // in order for variables to be resolved.
         // And as an additional bonus we don't need to define _getMinimumNeededSchema
         super(_childrenFromProperties(properties));
-
         this.expr = [];
         this.type = 'featureList';
         this._isViewport = true;
@@ -89,8 +89,11 @@ export default class ViewportFeatures extends BaseExpression {
             if (!this._requiredProperties.every(p => validProperty(p))) {
                 throw new CartoValidationError(`${cvt.INCORRECT_TYPE} viewportFeatures arguments can only be properties`);
             }
-            const columns = this._requiredProperties.map(p => p.propertyName);
-            this._FeatureProxy = genLightweightFeatureClass(columns, renderLayer);
+
+            const names = this._requiredProperties.map((p) => {
+                return { property: p.propertyName,  variable: p.variableName }
+            });
+            this._FeatureProxy = genLightweightFeatureClass(names, renderLayer);
         }
         this.expr = [];
     }
@@ -118,5 +121,7 @@ function _childrenFromProperties (properties) {
 }
 
 function validProperty (property) {
-    return property.isA(Property) || property.isA(ClusterAggregation) || property.isA(ClusterTimeDimension);
+    const validExpressions = [Property, ClusterAggregation, ClusterCount, ClusterTimeDimension];
+
+    return validExpressions.some(expression => property.isA(expression));
 }

--- a/src/renderer/viz/expressions/viewportFeatures.js
+++ b/src/renderer/viz/expressions/viewportFeatures.js
@@ -90,10 +90,10 @@ export default class ViewportFeatures extends BaseExpression {
                 throw new CartoValidationError(`${cvt.INCORRECT_TYPE} viewportFeatures arguments can only be properties`);
             }
 
-            const names = this._requiredProperties.map((p) => {
+            const propertyNames = this._requiredProperties.map((p) => {
                 return { property: p.propertyName, variable: p._variableName };
             });
-            this._FeatureProxy = genLightweightFeatureClass(names, renderLayer);
+            this._FeatureProxy = genLightweightFeatureClass(propertyNames, renderLayer);
         }
         this.expr = [];
     }
@@ -122,6 +122,5 @@ function _childrenFromProperties (properties) {
 
 function validProperty (property) {
     const validExpressions = [Property, ClusterAggregation, ClusterCount, ClusterTimeDimension];
-
     return validExpressions.some(expression => property.isA(expression));
 }

--- a/src/renderer/viz/expressions/viewportFeatures.js
+++ b/src/renderer/viz/expressions/viewportFeatures.js
@@ -91,7 +91,7 @@ export default class ViewportFeatures extends BaseExpression {
             }
 
             const names = this._requiredProperties.map((p) => {
-                return { property: p.propertyName, variable: p.variableName };
+                return { property: p.propertyName, variable: p._variableName };
             });
             this._FeatureProxy = genLightweightFeatureClass(names, renderLayer);
         }

--- a/test/integration/user/test/interactivity.test.js
+++ b/test/integration/user/test/interactivity.test.js
@@ -197,7 +197,7 @@ describe('Interactivity', () => {
                             const moveMouse = debounce(() => {
                                 util.simulateMove({ lng: 0, lat: 0 });
                             }, 500);
-                            
+
                             moveMouse();
 
                             // Click on the feature 1

--- a/test/integration/user/test/interactivity.test.js
+++ b/test/integration/user/test/interactivity.test.js
@@ -632,6 +632,7 @@ describe('regression with blendTo', () => {
         const moveAway = debounce(() => {
             util.simulateMove({ lng: -5, lat: -5 });
         });
+
         interactivity.on('featureEnter', async event => {
             layer.on('updated', moveAway);
 
@@ -644,7 +645,8 @@ describe('regression with blendTo', () => {
             const thereWasAnUpdateError = error && error.reason.message.startsWith('Another `viz change` finished before this one');
             expect(thereWasAnUpdateError).toBeFalsy();
             done();
-        });
+        }, 500);
+
         interactivity.on('featureLeave', async event => {
             layer.off('updated', moveAway);
 

--- a/test/integration/user/test/interactivity.test.js
+++ b/test/integration/user/test/interactivity.test.js
@@ -194,7 +194,12 @@ describe('Interactivity', () => {
                             // Click on the feature 1
                             util.simulateClick({ lng: 5, lat: 5 });
                             // Move the mouse
-                            util.simulateMove({ lng: 0, lat: 0 });
+                            const moveMouse = debounce(() => {
+                                util.simulateMove({ lng: 0, lat: 0 });
+                            }, 500);
+                            
+                            moveMouse();
+
                             // Click on the feature 1
                             util.simulateClick({ lng: -5, lat: -5 });
                         });

--- a/test/integration/user/test/viewportFeatures.test.js
+++ b/test/integration/user/test/viewportFeatures.test.js
@@ -225,6 +225,7 @@ describe('viewportFeatures', () => {
     });
 
     afterEach(() => {
+        map.remove();
         document.body.removeChild(setup.div);
     });
 });
@@ -280,6 +281,7 @@ describe('viewportFeatures on a map with filters', () => {
     });
 
     afterEach(() => {
+        map.remove();
         document.body.removeChild(setup.div);
     });
 });
@@ -334,6 +336,7 @@ describe('viewportFeatures on a zoomed-in map', () => {
     });
 
     afterEach(() => {
+        map.remove();
         document.body.removeChild(setup.div);
     });
 });
@@ -493,9 +496,9 @@ describe('viewportFeatures collision', () => {
         });
     });
 
-    afterEach((done) => {
+    afterEach(() => {
+        map.remove();
         document.body.removeChild(setup.div);
-        done();
     });
 });
 
@@ -509,7 +512,7 @@ describe('viewportFeatures using aggregation expressions', () => {
             source = new carto.source.GeoJSON(aggregationFeatures);
         });
 
-        it('should get the clusterCount of a feature', (done) => {
+        it('should get the clusterCount of a feature', done => {
             viz = new carto.Viz(`
                 @list: viewportFeatures(clusterCount())
             `);
@@ -525,7 +528,7 @@ describe('viewportFeatures using aggregation expressions', () => {
             });
         });
 
-        it('should get the clusterCount of a feature when it is assigned to a variable', (done) => {
+        it('should get the clusterCount of a feature when it is assigned to a variable', done => {
             const variableName = 'cc';
 
             viz = new carto.Viz(`
@@ -543,6 +546,11 @@ describe('viewportFeatures using aggregation expressions', () => {
                 expect(actual).toEqual(expected);
                 done();
             });
+        });
+
+        afterEach(() => {
+            map.remove();
+            document.body.removeChild(setup.div);
         });
     });
 });

--- a/test/integration/user/test/viewportFeatures.test.js
+++ b/test/integration/user/test/viewportFeatures.test.js
@@ -155,8 +155,8 @@ describe('viewportFeatures', () => {
     it('should get the features properties of another layer', done => {
         layer2.on('loaded', () => {
             const expectedAll = [
-                { id: 1, value: 10, category: 'a' },
-                { id: 2, value: 1000, category: 'b' }
+                { id: 1, value: 10, cat: 'a' },
+                { id: 2, value: 1000, cat: 'b' }
             ];
             const expectedValue = [
                 { value: 10 },


### PR DESCRIPTION
Related issue https://github.com/CartoDB/carto-vl/issues/1244

In this PR we're solving two issues at the same time. This approach adds a new property to the Base expression object: `variableName`. The problem is that when getting the value from an expression assigned to a variable, we use the `propertyName` of the expression, which returns the name of the property we pass as an argument to the expression. For example:

`@v_features: viewportFeatures($poi_name)`

Will get the `poi_name` value from the feature.

However, if do the following:

```
@poi: $poi_name
@v_features: viewportFeatures(@poi)
```

Then it fails, because you don't have access to the property through the variable name, although it should work as well. The same situation happens with expressions where we don't pass a property as an argument, as the `ClusterCount` expression:

```
@clusterCount: clusterCount()
@v_features: viewportFeatures(@clusterCount)
```

Because we get this value through `_cdb_feature_count` from the properties.

**ClusterCount example**
[examples/labeling/point-aggregation-cluster-count.html](https://github.com/CartoDB/carto-vl/blob/1244-make-aggregated-values-available-for-labels/examples/labeling/point-aggregation-cluster-count.html)

![screenshot 2019-02-13 at 10 56 27](https://user-images.githubusercontent.com/3824953/52703252-339fb480-2f7e-11e9-9a1c-5b956ebfeddd.png)

TODO:

- [x] Improve Cluster Count example
- [x] Fix specs
- [x] Add specs