### PR TITLE
Fix global aggregation expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Allow the use of variables for all classifiers: `globalQuantiles`, `globalEqIntervals`, `globalStandardDev`, `viewportQuantiles`, `viewportEqIntervals` and `viewportStandardDev`
 - Improve MVT decoding error messages
 - Add interactive filter example
+- Throw error when using `clusterCount()` in a global classifier
 
 ### Fixed
 - Fix regression in `Interactivity` using MVT and polygons
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix getting aggregation expression values passed to `viewportFeatures` expression
 - Fix WebGL incompatibility in Edge
 - Fix regression in `toString` Viz method
+- Fix variables for aggregated values
 
 ## [1.1.1] - 2019-01-16
 

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -349,11 +349,18 @@ export default class Windshaft {
         Object.keys(agg.columns).forEach(aggName => {
             const basename = agg.columns[aggName].aggregated_column;
             const fnName = agg.columns[aggName].aggregate_function;
+
             if (!properties[basename].aggregations) {
                 properties[basename].aggregations = {};
             }
+
             properties[basename].aggregations[fnName] = aggName;
+
+            if (basename !== aggName) {
+                properties[aggName] = JSON.parse(JSON.stringify(properties[basename]));
+            }
         });
+
         Object.keys(agg.dimensions).forEach(dimName => {
             const dimension = agg.dimensions[dimName];
             if (stats.dimensions && stats.dimensions[dimName].type) {
@@ -376,6 +383,10 @@ export default class Windshaft {
                 if (range > 0) {
                     properties[column].dimension.range = ['start', 'end'].map(mode => `${dimName}_${mode}`);
                 }
+
+                // if (dimName !== column) {
+                //     properties[dimName] = properties[column];
+                // }
             }
         });
         Object.values(properties).map(property => {

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -3,15 +3,14 @@ import MVT from '../sources/MVT';
 import Metadata from './WindshaftMetadata';
 import schema from '../renderer/schema';
 import * as windshaftFiltering from './windshaft-filtering';
-import { CLUSTER_FEATURE_COUNT } from '../renderer/schema';
 import CartoValidationError, { CartoValidationTypes as cvt } from '../errors/carto-validation-error';
 import CartoMapsAPIError, { CartoMapsAPITypes as cmt } from '../errors/carto-maps-api-error';
 import { GEOMETRY_TYPE } from '../utils/geometry';
+import { CLUSTER_FEATURE_COUNT } from '../constants/metadata';
 
 const SAMPLE_ROWS = 1000;
 const MIN_FILTERING = 2000000;
 const REQUEST_GET_MAX_URL_LENGTH = 2048;
-
 const TILE_EXTENT = 2048;
 
 export default class Windshaft {

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -380,13 +380,10 @@ export default class Windshaft {
                     max: dimensionStats.max
                 };
                 const range = MNS[column].some(c => c.range);
+
                 if (range > 0) {
                     properties[column].dimension.range = ['start', 'end'].map(mode => `${dimName}_${mode}`);
                 }
-
-                // if (dimName !== column) {
-                //     properties[dimName] = properties[column];
-                // }
             }
         });
         Object.values(properties).map(property => {

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -6,7 +6,7 @@ import * as windshaftFiltering from './windshaft-filtering';
 import CartoValidationError, { CartoValidationTypes as cvt } from '../errors/carto-validation-error';
 import CartoMapsAPIError, { CartoMapsAPITypes as cmt } from '../errors/carto-maps-api-error';
 import { GEOMETRY_TYPE } from '../utils/geometry';
-import { CLUSTER_FEATURE_COUNT } from '../constants/metadata';
+import { CLUSTER_FEATURE_COUNT, aggregationTypes } from '../constants/metadata';
 
 const SAMPLE_ROWS = 1000;
 const MIN_FILTERING = 2000000;
@@ -60,7 +60,7 @@ export default class Windshaft {
         // Force to include `cartodb_id` in the MNS columns.
         // TODO: revisit this request to Maps API
         if (!MNS['cartodb_id']) {
-            MNS['cartodb_id'] = [{ type: 'unaggregated' }];
+            MNS['cartodb_id'] = [{ type: aggregationTypes.UNAGGREGATED }];
         }
     }
 
@@ -76,8 +76,8 @@ export default class Windshaft {
     _checkAcceptableMNS (MNS) {
         Object.keys(MNS).forEach(propertyName => {
             const usages = MNS[propertyName];
-            const aggregatedUsage = usages.some(x => x.type !== 'unaggregated');
-            const unAggregatedUsage = usages.some(x => x.type === 'unaggregated');
+            const aggregatedUsage = usages.some(x => x.type !== aggregationTypes.UNAGGREGATED);
+            const unAggregatedUsage = usages.some(x => x.type === aggregationTypes.UNAGGREGATED);
             if (aggregatedUsage && unAggregatedUsage) {
                 throw new CartoValidationError(`${cvt.INCORRECT_VALUE} Incompatible combination of cluster aggregation usages (${
                     JSON.stringify(usages.filter(x => x.type !== 'aggregated'))
@@ -215,7 +215,7 @@ export default class Windshaft {
     }
 
     _requiresAggregation (MNS) {
-        return Object.values(MNS).some(propertyUsages => propertyUsages.some(u => u.type !== 'unaggregated'));
+        return Object.values(MNS).some(propertyUsages => propertyUsages.some(u => u.type !== aggregationTypes.UNAGGREGATED));
     }
 
     _generateAggregation (MNS, resolution) {

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -76,7 +76,7 @@ export default class Windshaft {
     _checkAcceptableMNS (MNS) {
         Object.keys(MNS).forEach(propertyName => {
             const usages = MNS[propertyName];
-            const aggregatedUsage = usages.some(x => x.type !== aggregationTypes.UNAGGREGATED);
+            const aggregatedUsage = usages.some(x => x.type === aggregationTypes.AGGREGATED);
             const unAggregatedUsage = usages.some(x => x.type === aggregationTypes.UNAGGREGATED);
             if (aggregatedUsage && unAggregatedUsage) {
                 throw new CartoValidationError(`${cvt.INCORRECT_VALUE} Incompatible combination of cluster aggregation usages (${
@@ -215,7 +215,7 @@ export default class Windshaft {
     }
 
     _requiresAggregation (MNS) {
-        return Object.values(MNS).some(propertyUsages => propertyUsages.some(u => u.type !== aggregationTypes.UNAGGREGATED));
+        return Object.values(MNS).some(propertyUsages => propertyUsages.some(u => u.type === aggregationTypes.AGGREGATED));
     }
 
     _generateAggregation (MNS, resolution) {

--- a/src/constants/metadata.js
+++ b/src/constants/metadata.js
@@ -1,0 +1,3 @@
+export const AGG_PREFIX = '_cdb_agg_';
+export const DIM_PREFIX = '_cdb_dim_';
+export const CLUSTER_FEATURE_COUNT = '_cdb_feature_count';

--- a/src/constants/metadata.js
+++ b/src/constants/metadata.js
@@ -1,3 +1,8 @@
 export const AGG_PREFIX = '_cdb_agg_';
 export const DIM_PREFIX = '_cdb_dim_';
 export const CLUSTER_FEATURE_COUNT = '_cdb_feature_count';
+export const aggregationTypes = {
+    AGGREGATED: 'aggregated',
+    UNAGGREGATED: 'unaggregated',
+    UNKNOWN: 'unknown'
+};

--- a/src/renderer/Metadata.js
+++ b/src/renderer/Metadata.js
@@ -82,7 +82,10 @@ export default class Metadata {
     }
 
     codec (propertyName) {
-        // FIXME: default identity code for debugging purposes
-        return this.properties[this.baseName(propertyName)].codec || new IdentityCodec();
+        const name = this.baseName(propertyName);
+
+        return this.properties[name] && this.properties[name].codec
+            ? this.properties[name].codec
+            : new IdentityCodec();
     }
 }

--- a/src/renderer/schema.js
+++ b/src/renderer/schema.js
@@ -1,4 +1,4 @@
-import { AGG_PREFIX, DIM_PREFIX } from "../constants/metadata";
+import { AGG_PREFIX, DIM_PREFIX } from '../constants/metadata';
 
 export const IDENTITY = {};
 

--- a/src/renderer/schema.js
+++ b/src/renderer/schema.js
@@ -1,3 +1,4 @@
+import { AGG_PREFIX, DIM_PREFIX } from "../constants/metadata";
 
 export const IDENTITY = {};
 
@@ -41,13 +42,6 @@ function simplify (MNS) {
     });
     return result;
 }
-
-// TODO: this is Windsshaft-specific, so move to WindshaftMetadata
-
-const AGG_PREFIX = '_cdb_agg_';
-const DIM_PREFIX = '_cdb_dim_';
-
-export const CLUSTER_FEATURE_COUNT = '_cdb_feature_count';
 
 // column information functions
 export const column = {

--- a/src/renderer/viz/expressions/CategoryIndex.js
+++ b/src/renderer/viz/expressions/CategoryIndex.js
@@ -44,8 +44,14 @@ export default class CategoryIndex extends BaseExpression {
     }
 
     get numCategories () {
-        const metaColumn = this._metadata.properties[this.property.name];
-        return metaColumn.categories.length;
+        return this.metaColumn.categories.length;
+    }
+
+    get metaColumn () {
+        const propertyName = this.property.propertyName;
+        return this._metadata.properties[propertyName]
+            ? this._metadata.properties[propertyName]
+            : this._metadata.properties[this.property.name];
     }
 
     get numCategoriesWithoutOthers () {
@@ -107,14 +113,13 @@ export default class CategoryIndex extends BaseExpression {
     }
 
     _calcTranslated () {
-        const metaColumn = this._metadata.properties[this.property.name];
         const numCategories = this.numCategories;
 
         if (this._numTranslatedCategories !== numCategories) {
             this._numTranslatedCategories = numCategories;
 
             for (let i = 0; i < numCategories; i++) {
-                const id = this._metadata.categoryToID.get(metaColumn.categories[i].name);
+                const id = this._metadata.categoryToID.get(this.metaColumn.categories[i].name);
                 const value = i / (numCategories - 1);
                 const vec2Id = {
                     x: id % SQRT_MAX_CATEGORIES_PER_PROPERTY,
@@ -128,7 +133,7 @@ export default class CategoryIndex extends BaseExpression {
     }
 
     getLegendData () {
-        const categories = this._metadata.properties[this.property.name].categories;
+        const categories = this._metadata.properties[this.property.propertyName].categories;
         const categoriesLength = categories.length;
         const divisor = categoriesLength - 1;
         const data = [];

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterAggregation.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterAggregation.js
@@ -56,7 +56,7 @@ export default class ClusterAggregation extends BaseExpression {
 
     _getMinimumNeededSchema () {
         return {
-            [this.property.name]: [{
+            [this.property.propertyName]: [{
                 type: 'aggregated',
                 op: this._aggName
             }]

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterAggregation.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterAggregation.js
@@ -41,10 +41,6 @@ export default class ClusterAggregation extends BaseExpression {
         checkType(this._expressionName, 'property', 0, this.type, this.property);
     }
 
-    _resolveAliases (aliases) {
-        return this._getChildren().map(child => child._resolveAliases(aliases));
-    }
-
     _applyToShaderSource (getGLSLforProperty) {
         return {
             preface: '',

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterAggregation.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterAggregation.js
@@ -2,7 +2,6 @@ import BaseExpression from '../../base';
 import PropertyExpression from '../../basic/property';
 import { checkType, checkInstance, checkExpression } from '../../utils';
 import * as schema from '../../../../schema';
-
 export default class ClusterAggregation extends BaseExpression {
     constructor ({ property, expressionName, aggName, aggType }) {
         checkExpression(expressionName, 'property', 0, property);
@@ -42,7 +41,9 @@ export default class ClusterAggregation extends BaseExpression {
         checkType(this._expressionName, 'property', 0, this.type, this.property);
     }
 
-    _resolveAliases () {}
+    _resolveAliases (aliases) {
+        return this._getChildren().map(child => child._resolveAliases(aliases));
+    }
 
     _applyToShaderSource (getGLSLforProperty) {
         return {

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
@@ -6,7 +6,7 @@ import { CLUSTER_FEATURE_COUNT } from '../../../../../constants/metadata';
  * Count of features per cluster.
  *
  * The `clusterCount` expression has no input parameters and if data is not aggregated, it always returns 1.
- * Currently, it is not possible to use it as an input in global aggregations such as `globalMin` or `globalQuantiles`.
+ * It is not possible to use it as an input in global aggregations such as `globalMin` or `globalQuantiles`.
  *
  * @return {Number} Cluster feature count
  *

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
@@ -5,7 +5,8 @@ import { CLUSTER_FEATURE_COUNT } from '../../../../../constants/metadata';
 /**
  * Count of features per cluster.
  *
- * Note: `clusterCount` has no input parameters and if data is not aggregated, it always returns 1
+ * The `clusterCount` expression has no input parameters and if data is not aggregated, it always returns 1.
+ * Currently, it is not possible to use it as an input in global aggregations such as `globalMin` or `globalQuantiles`.
  *
  * @return {Number} Cluster feature count
  *
@@ -19,6 +20,21 @@ import { CLUSTER_FEATURE_COUNT } from '../../../../../constants/metadata';
  * const viz = new carto.Viz(`
  *   width: clusterCount() / 50
  * `);
+ *
+ * @example <caption>Use cluster count with viewportQuantiles in a ramp for width and color.</caption>
+ * const s = carto.expressions;
+ * const viz = new carto.Viz({
+ *   color: s.ramp(s.viewportQuantiles(s.clusterCount(), 5), [1, 20])
+ *   width: s.ramp(s.viewportQuantiles(s.clusterCount(), 5), s.palettes.PINKYL))
+ * });
+ * // Note: this is not possible with globalQuantiles
+ *
+ * @example <caption>Use cluster count with viewportQuantiles in a ramp for width and color. (String)</caption>
+ * const viz = new carto.Viz(`
+ *   width: ramp(viewportQuantiles(clusterCount(), 5), [1, 20])
+ *   color: ramp(viewportQuantiles(clusterCount(), 5), Pinkyl)
+ * `);
+ * // Note: this is not possible with globalQuantiles
  *
  * @memberof carto.expressions
  * @name clusterCount

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
@@ -1,6 +1,6 @@
 import BaseExpression from '../../base';
 import { checkMaxArguments } from '../../utils';
-import { CLUSTER_FEATURE_COUNT } from '../../../../schema';
+import { CLUSTER_FEATURE_COUNT } from '../../../../../constants/metadata';
 
 /**
  * Count of features per cluster.

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
@@ -45,7 +45,7 @@ export default class ClusterCount extends BaseExpression {
         return Number(feature[CLUSTER_FEATURE_COUNT]) || 1;
     }
 
-    _getLegendData () {
+    getLegendData () {
         return {
             data: this._hasClusterFeatureCount
                 ? this._metadata.properties[CLUSTER_FEATURE_COUNT]

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterCount.js
@@ -45,8 +45,17 @@ export default class ClusterCount extends BaseExpression {
         return Number(feature[CLUSTER_FEATURE_COUNT]) || 1;
     }
 
+    _getLegendData () {
+        return {
+            data: this._hasClusterFeatureCount
+                ? this._metadata.properties[CLUSTER_FEATURE_COUNT]
+                : []
+        };
+    }
+
     _bindMetadata (metadata) {
         super._bindMetadata(metadata);
+        this._metadata = metadata;
         this._hasClusterFeatureCount = metadata.properties[CLUSTER_FEATURE_COUNT] !== undefined;
     }
 

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterTimeDimension.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterTimeDimension.js
@@ -22,7 +22,7 @@ export default class clusterTimeDimension extends BaseExpression {
         checkExpression(expressionName, 'property', 0, property);
         super({ property });
         this._dimension = dimension;
-        this._dimension.propertyName = schema.column.dimColumn(this.property.name, this._dimension.group.units);
+        this._dimension.propertyName = schema.column.dimColumn(this.property.propertyName, this._dimension.group.units);
         this._expressionName = expressionName;
         this.type = type;
         this._range = range;
@@ -37,7 +37,7 @@ export default class clusterTimeDimension extends BaseExpression {
     }
 
     get name () {
-        return this.property.name;
+        return this.property.propertyName;
     }
 
     get propertyName () {

--- a/src/renderer/viz/expressions/aggregation/cluster/ClusterTimeDimension.js
+++ b/src/renderer/viz/expressions/aggregation/cluster/ClusterTimeDimension.js
@@ -74,7 +74,7 @@ export default class clusterTimeDimension extends BaseExpression {
 
     _getMinimumNeededSchema () {
         return {
-            [this.property.name]: [{
+            [this.name]: [{
                 type: 'dimension',
                 dimension: this._dimension,
                 range: !!this._range

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
@@ -89,9 +89,6 @@ export default class GlobalAggregation extends BaseExpression {
 
     _getValueFromStats (metadata, propertyName) {
         let value;
-        if (propertyName === CLUSTER_FEATURE_COUNT) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in ${this.expressionName}.`);
-        }
 
         if (this.baseStats) {
             // Use base stats (pre-aggregation)
@@ -104,6 +101,9 @@ export default class GlobalAggregation extends BaseExpression {
                 value = stats && stats[this.baseStats];
             }
         } else {
+            if (propertyName === CLUSTER_FEATURE_COUNT) {
+                throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in ${this.expressionName}.`);
+            }
             // Use stats from actual column corresponding to this aggregate function
             const stats = metadata.stats(propertyName);
             value = stats && stats[this._name];

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
@@ -53,13 +53,12 @@ export default class GlobalAggregation extends BaseExpression {
      * @param {*} name
      */
     constructor ({ property, name, type, baseStats = false }) {
-        property = implicitCast(property);
-        super({ property, _impostor: number(0) });
-
+        super({ _value: number(0) });
+        this.property = implicitCast(property);
         this._name = name;
         this.type = type;
         this.baseStats = baseStats;
-        super.inlineMaker = inline => inline._impostor;
+        super.inlineMaker = inline => inline._value;
     }
 
     toString () {
@@ -71,7 +70,7 @@ export default class GlobalAggregation extends BaseExpression {
     }
 
     eval () {
-        return this._impostor.expr;
+        return this._value.expr;
     }
 
     _resolveAliases (aliases) {
@@ -85,7 +84,7 @@ export default class GlobalAggregation extends BaseExpression {
         this.property._bindMetadata(metadata);
         const propertyName = this.property.propertyName || this.property.name;
         const value = this._getValueFromStats(metadata, propertyName);
-        this._impostor.expr = metadata.codec(propertyName).sourceToExternal(metadata, value);
+        this._value.expr = metadata.codec(propertyName).sourceToExternal(metadata, value);
     }
 
     _getValueFromStats (metadata, propertyName) {
@@ -117,10 +116,5 @@ export default class GlobalAggregation extends BaseExpression {
 
     _getMinimumNeededSchema () {
         return this.property._getMinimumNeededSchema();
-    }
-
-    _preDraw (...args) {
-        this._impostor.expr = this.eval();
-        super._preDraw(...args);
     }
 }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
@@ -81,8 +81,9 @@ export default class GlobalAggregation extends BaseExpression {
     _bindMetadata (metadata) {
         super._bindMetadata(metadata);
         this.property._bindMetadata(metadata);
+        const valueName = this.property.name;
         const propertyName = this.property.propertyName || this.property.name;
-        const value = this._getValueFromStats(metadata, propertyName);
+        const value = this._getValueFromStats(metadata, valueName);
         this._value.expr = metadata.codec(propertyName).sourceToExternal(metadata, value);
     }
 

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
@@ -89,6 +89,10 @@ export default class GlobalAggregation extends BaseExpression {
 
     _getValueFromStats (metadata, propertyName) {
         let value;
+        if (propertyName === CLUSTER_FEATURE_COUNT) {
+            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in ${this.expressionName}.`);
+        }
+
         if (this.baseStats) {
             // Use base stats (pre-aggregation)
             if (this.baseStats === '_count') {
@@ -101,9 +105,7 @@ export default class GlobalAggregation extends BaseExpression {
             }
         } else {
             // Use stats from actual column corresponding to this aggregate function
-            const stats = propertyName === CLUSTER_FEATURE_COUNT
-                ? metadata.stats('cartodb_id') // FIXME
-                : metadata.stats(propertyName);
+            const stats = metadata.stats(propertyName);
             value = stats && stats[this._name];
         }
 

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
@@ -82,7 +82,7 @@ export default class GlobalAggregation extends BaseExpression {
     _bindMetadata (metadata) {
         super._bindMetadata(metadata);
         this.property._bindMetadata(metadata);
-        const propertyName = this.property.propertyName || this.property.name;
+        const propertyName = this.property.name;
         const value = this._getValueFromStats(metadata, propertyName);
         this._value.expr = metadata.codec(propertyName).sourceToExternal(metadata, value);
     }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
@@ -81,9 +81,8 @@ export default class GlobalAggregation extends BaseExpression {
     _bindMetadata (metadata) {
         super._bindMetadata(metadata);
         this.property._bindMetadata(metadata);
-        const valueName = this.property.name;
         const propertyName = this.property.propertyName || this.property.name;
-        const value = this._getValueFromStats(metadata, valueName);
+        const value = this._getValueFromStats(metadata, propertyName);
         this._value.expr = metadata.codec(propertyName).sourceToExternal(metadata, value);
     }
 

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
@@ -82,7 +82,7 @@ export default class GlobalAggregation extends BaseExpression {
     _bindMetadata (metadata) {
         super._bindMetadata(metadata);
         this.property._bindMetadata(metadata);
-        const propertyName = this.property.name;
+        const propertyName = this.property.name || this.property.propertyName;
         const value = this._getValueFromStats(metadata, propertyName);
         this._value.expr = metadata.codec(propertyName).sourceToExternal(metadata, value);
     }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
@@ -91,12 +91,9 @@ export default class GlobalAggregation extends BaseExpression {
         let value;
 
         if (this.baseStats) {
-            // Use base stats (pre-aggregation)
             if (this.baseStats === '_count') {
-                // Use count
                 value = metadata.featureCount;
             } else {
-                // Use some specific column stat
                 const stats = metadata.stats(this.property.name);
                 value = stats && stats[this.baseStats];
             }
@@ -104,7 +101,6 @@ export default class GlobalAggregation extends BaseExpression {
             if (propertyName === CLUSTER_FEATURE_COUNT) {
                 throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in ${this.expressionName}.`);
             }
-            // Use stats from actual column corresponding to this aggregate function
             const stats = metadata.stats(propertyName);
             value = stats && stats[this._name];
         }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalCount.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalCount.js
@@ -29,14 +29,16 @@ export default class GlobalCount extends GlobalAggregation {
         checkMaxArguments(arguments, 0, 'globalCount');
         super({ name: 'count', type: 'number' });
     }
+
     toString () {
         return `${this.expressionName}()`;
     }
+
     _bindMetadata (metadata) {
         this._value.expr = metadata.featureCount;
     }
+
     _getMinimumNeededSchema () {
-        return {
-        };
+        return {};
     }
 }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalPercentile.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalPercentile.js
@@ -56,7 +56,7 @@ export default class GlobalPercentile extends BaseExpression {
         checkInstance('globalPercentile', 'property', 0, Property, this.property);
         checkFeatureIndependent('globalPercentile', 'percentile', 1, this.percentile);
 
-        this._copySample = metadata.sample.map(s => s[this.property.name]);
+        this._copySample = metadata.sample.map(s => s[this.property.propertyName]);
         this._copySample.sort((x, y) => x - y);
     }
 

--- a/src/renderer/viz/expressions/aggregation/global/GlobalSum.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalSum.js
@@ -36,7 +36,7 @@ import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../.
 export default class GlobalSum extends GlobalAggregation {
     constructor (property) {
         checkMaxArguments(arguments, 1, 'globalSum');
-
+        const type = property.type;
         let baseStats = false;
         if (property && (property.isA(ClusterAggregation) || property.isA(ClusterCount))) {
             if (property.isA(ClusterSum)) {
@@ -48,6 +48,6 @@ export default class GlobalSum extends GlobalAggregation {
             }
         }
 
-        super({ property, name: 'sum', baseStats });
+        super({ property, name: 'sum', baseStats, type });
     }
 }

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportAvg.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportAvg.js
@@ -1,6 +1,6 @@
 import ViewportAggregation from './ViewportAggregation';
 import { checkMaxArguments } from '../../utils';
-import { CLUSTER_FEATURE_COUNT } from '../../../../schema';
+import { CLUSTER_FEATURE_COUNT } from '../../../../../constants/metadata';
 
 /**
  * Return the average value of an expression for the features showed in the viewport (features outside the viewport and features that don't pass the filter will be excluded).

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportCount.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportCount.js
@@ -1,7 +1,7 @@
 import ViewportAggregation from './ViewportAggregation';
 import { number } from '../../../expressions';
 import { checkMaxArguments } from '../../utils';
-import { CLUSTER_FEATURE_COUNT } from '../../../../schema';
+import { CLUSTER_FEATURE_COUNT } from '../../../../../constants/metadata';
 
 /**
  * Return the feature count of the features showed in the viewport (features outside the viewport and features that don't pass the filter will be excluded).

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportPercentile.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportPercentile.js
@@ -1,6 +1,6 @@
 import ViewportAggregation from './ViewportAggregation';
 import { implicitCast, clamp, checkMaxArguments, checkType, checkExpression } from '../../utils';
-import { CLUSTER_FEATURE_COUNT } from '../../../../schema';
+import { CLUSTER_FEATURE_COUNT } from '../../../../../constants/metadata';
 /**
  * Return the Nth percentile of an expression for the features showed in the viewport (features outside the viewport and features that don't pass the filter will be excluded).
  *

--- a/src/renderer/viz/expressions/aggregation/viewport/ViewportSum.js
+++ b/src/renderer/viz/expressions/aggregation/viewport/ViewportSum.js
@@ -1,6 +1,6 @@
 import ViewportAggregation from './ViewportAggregation';
 import { checkMaxArguments } from '../../utils';
-import { CLUSTER_FEATURE_COUNT } from '../../../../schema';
+import { CLUSTER_FEATURE_COUNT } from '../../../../../constants/metadata';
 
 /**
  * Return the sum of an expression for the features showed in the viewport (features outside the viewport and features that don't pass the filter will be excluded).

--- a/src/renderer/viz/expressions/basic/number.js
+++ b/src/renderer/viz/expressions/basic/number.js
@@ -32,9 +32,11 @@ export default class BaseNumber extends BaseExpression {
         this.expr = x;
         this.type = 'number';
     }
+
     get value () {
         return this.eval();
     }
+
     eval () {
         return this.expr;
     }

--- a/src/renderer/viz/expressions/basic/property.js
+++ b/src/renderer/viz/expressions/basic/property.js
@@ -2,6 +2,7 @@ import BaseExpression from '../base';
 import { checkString, checkMaxArguments } from '../utils';
 import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
 import { FP32_DESIGNATED_NULL_VALUE } from '../constants';
+import { aggregationTypes } from '../../../../constants/metadata';
 /**
  * Evaluates the value of a column for every row in the dataset.
  *
@@ -108,10 +109,10 @@ export default class Property extends BaseExpression {
     }
 
     _getMinimumNeededSchema () {
+        const type = aggregationTypes.UNKNOWN;
+
         return {
-            [this.name]: [{
-                type: 'unaggregated'
-            }]
+            [this.name]: [{ type }]
         };
     }
 }

--- a/src/renderer/viz/expressions/basic/property.js
+++ b/src/renderer/viz/expressions/basic/property.js
@@ -109,7 +109,7 @@ export default class Property extends BaseExpression {
     }
 
     _getMinimumNeededSchema () {
-        const type = aggregationTypes.UNKNOWN;
+        const type = aggregationTypes.UNAGGREGATED;
 
         return {
             [this.name]: [{ type }]

--- a/src/renderer/viz/expressions/basic/property.js
+++ b/src/renderer/viz/expressions/basic/property.js
@@ -108,6 +108,10 @@ export default class Property extends BaseExpression {
     }
 
     _getMinimumNeededSchema () {
+        if (this._variableName) {
+            return {};
+        }
+
         return {
             [this.name]: [{
                 type: 'unaggregated'

--- a/src/renderer/viz/expressions/basic/property.js
+++ b/src/renderer/viz/expressions/basic/property.js
@@ -109,7 +109,7 @@ export default class Property extends BaseExpression {
     }
 
     _getMinimumNeededSchema () {
-        const type = aggregationTypes.UNAGGREGATED;
+        const type = aggregationTypes.UNKNOWN;
 
         return {
             [this.name]: [{ type }]

--- a/src/renderer/viz/expressions/basic/property.js
+++ b/src/renderer/viz/expressions/basic/property.js
@@ -108,10 +108,6 @@ export default class Property extends BaseExpression {
     }
 
     _getMinimumNeededSchema () {
-        if (this._variableName) {
-            return {};
-        }
-
         return {
             [this.name]: [{
                 type: 'unaggregated'

--- a/src/renderer/viz/expressions/basic/variable.js
+++ b/src/renderer/viz/expressions/basic/variable.js
@@ -79,8 +79,6 @@ export default function variable (name) {
                     return alias.property ? alias.property.name : alias.propertyName;
                 case 'name':
                     return name;
-                case 'value':
-                    return obj[prop];
                 case 'blendTo':
                     return obj[prop];
                 case '_resolveAliases':

--- a/src/renderer/viz/expressions/basic/variable.js
+++ b/src/renderer/viz/expressions/basic/variable.js
@@ -78,7 +78,7 @@ export default function variable (name) {
                 case 'propertyName':
                     return alias.propertyName;
                 case 'name':
-                    return alias.name ? alias.name : name;
+                    return alias._dimension ? alias.propertyName : alias.name;
                 case 'blendTo':
                     return obj[prop];
                 case '_resolveAliases':

--- a/src/renderer/viz/expressions/basic/variable.js
+++ b/src/renderer/viz/expressions/basic/variable.js
@@ -78,7 +78,7 @@ export default function variable (name) {
                 case 'propertyName':
                     return alias.property ? alias.property.name : alias.propertyName;
                 case 'name':
-                    return name;
+                    return alias.property ? alias.property.name : alias.propertyName;
                 case 'blendTo':
                     return obj[prop];
                 case '_resolveAliases':

--- a/src/renderer/viz/expressions/basic/variable.js
+++ b/src/renderer/viz/expressions/basic/variable.js
@@ -58,17 +58,19 @@ export default function variable (name) {
 
     let aliaser = {
         set: (obj, prop, value) => {
-            if (prop === 'parent') {
-                obj[prop] = value;
-            } else if (prop === 'notify') {
-                obj[prop] = value;
-            } else if (alias && alias[prop]) {
+            if (alias && alias[prop]) {
                 alias[prop] = value;
-            } else {
-                return false;
+                return true;
             }
-            // Indicate success
-            return true;
+
+            switch (prop) {
+                case 'parent':
+                case 'notify':
+                    obj[prop] = value;
+                    return true;
+                default:
+                    return false;
+            }
         },
 
         get: (obj, prop) => {
@@ -80,6 +82,8 @@ export default function variable (name) {
                 case 'name':
                     return alias.property ? alias.property.name : alias.propertyName;
                 case 'blendTo':
+                    return obj[prop];
+                case 'aggType':
                     return obj[prop];
                 case '_resolveAliases':
                     return resolve;

--- a/src/renderer/viz/expressions/basic/variable.js
+++ b/src/renderer/viz/expressions/basic/variable.js
@@ -52,6 +52,10 @@ export default function variable (name) {
         }
     };
 
+    const isA = function (expression) {
+        return expression === Variable;
+    };
+
     const _getDependencies = () => {
         return [alias];
     };
@@ -77,6 +81,8 @@ export default function variable (name) {
                 case 'notify':
                 case 'propertyName':
                     return name;
+                case 'isA':
+                    return isA;
                 case 'blendTo':
                     return obj[prop];
                 case '_resolveAliases':
@@ -98,6 +104,5 @@ export default function variable (name) {
         }
     };
 
-    const proxy = new Proxy(new Variable(), aliaser);
-    return proxy;
+    return new Proxy(new Variable(), aliaser);
 }

--- a/src/renderer/viz/expressions/basic/variable.js
+++ b/src/renderer/viz/expressions/basic/variable.js
@@ -52,10 +52,6 @@ export default function variable (name) {
         }
     };
 
-    const isA = function (expression) {
-        return expression === Variable;
-    };
-
     const _getDependencies = () => {
         return [alias];
     };
@@ -80,9 +76,11 @@ export default function variable (name) {
                 case 'parent':
                 case 'notify':
                 case 'propertyName':
+                    return alias.property.name;
+                case 'name':
                     return name;
-                case 'isA':
-                    return isA;
+                case 'value':
+                    return obj[prop];
                 case 'blendTo':
                     return obj[prop];
                 case '_resolveAliases':

--- a/src/renderer/viz/expressions/basic/variable.js
+++ b/src/renderer/viz/expressions/basic/variable.js
@@ -78,7 +78,7 @@ export default function variable (name) {
                 case 'propertyName':
                     return alias.propertyName;
                 case 'name':
-                    return alias.property ? alias.property.name : name;
+                    return alias.name ? alias.name : name;
                 case 'blendTo':
                     return obj[prop];
                 case '_resolveAliases':

--- a/src/renderer/viz/expressions/basic/variable.js
+++ b/src/renderer/viz/expressions/basic/variable.js
@@ -58,19 +58,17 @@ export default function variable (name) {
 
     let aliaser = {
         set: (obj, prop, value) => {
-            if (alias && alias[prop]) {
+            if (prop === 'parent') {
+                obj[prop] = value;
+            } else if (prop === 'notify') {
+                obj[prop] = value;
+            } else if (alias && alias[prop]) {
                 alias[prop] = value;
-                return true;
+            } else {
+                return false;
             }
 
-            switch (prop) {
-                case 'parent':
-                case 'notify':
-                    obj[prop] = value;
-                    return true;
-                default:
-                    return false;
-            }
+            return true;
         },
 
         get: (obj, prop) => {
@@ -78,12 +76,10 @@ export default function variable (name) {
                 case 'parent':
                 case 'notify':
                 case 'propertyName':
-                    return alias.property ? alias.property.name : alias.propertyName;
+                    return alias.propertyName;
                 case 'name':
-                    return alias.property ? alias.property.name : alias.propertyName;
+                    return alias.property ? alias.property.name : name;
                 case 'blendTo':
-                    return obj[prop];
-                case 'aggType':
                     return obj[prop];
                 case '_resolveAliases':
                     return resolve;

--- a/src/renderer/viz/expressions/basic/variable.js
+++ b/src/renderer/viz/expressions/basic/variable.js
@@ -75,6 +75,8 @@ export default function variable (name) {
             switch (prop) {
                 case 'parent':
                 case 'notify':
+                case 'propertyName':
+                    return name;
                 case 'blendTo':
                     return obj[prop];
                 case '_resolveAliases':

--- a/src/renderer/viz/expressions/basic/variable.js
+++ b/src/renderer/viz/expressions/basic/variable.js
@@ -76,7 +76,7 @@ export default function variable (name) {
                 case 'parent':
                 case 'notify':
                 case 'propertyName':
-                    return alias.property.name;
+                    return alias.property ? alias.property.name : alias.propertyName;
                 case 'name':
                     return name;
                 case 'value':

--- a/src/renderer/viz/expressions/between.js
+++ b/src/renderer/viz/expressions/between.js
@@ -39,12 +39,14 @@ export default class Between extends BaseExpression {
         this.type = 'number';
         this.inlineMaker = inline => `((${inline.input} >= ${inline.lowerLimit} &&  ${inline.input} <= ${inline.upperLimit}) ? 1. : 0.)`;
     }
+
     eval (feature) {
         const input = this.input.eval(feature);
         const lower = this.lowerLimit.eval(feature);
         const upper = this.upperLimit.eval(feature);
         return (input >= lower && input <= upper) ? 1 : 0;
     }
+
     _bindMetadata (meta) {
         super._bindMetadata(meta);
 

--- a/src/renderer/viz/expressions/classification/Classifier.js
+++ b/src/renderer/viz/expressions/classification/Classifier.js
@@ -6,6 +6,7 @@ import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../e
 import Property from '../basic/property';
 import ClassifierGLSLHelper from './ClassifierGLSLHelper';
 import { Variable } from '../basic/variable';
+import ClusterCount from '../aggregation/cluster/ClusterCount';
 
 export const DEFAULT_HISTOGRAM_SIZE = 1000;
 
@@ -68,7 +69,6 @@ export default class Classifier extends BaseExpression {
     }
 
     _validateInputIsNumericProperty () {
-        checkInstance(this.expressionName, 'input', 0, [ Property, Variable ], this.input);
         checkType(this.expressionName, 'input', 0, 'number', this.input);
     }
 

--- a/src/renderer/viz/expressions/classification/Classifier.js
+++ b/src/renderer/viz/expressions/classification/Classifier.js
@@ -5,6 +5,7 @@ import { checkType, checkNumber, checkInstance } from '../utils';
 import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
 import Property from '../basic/property';
 import ClassifierGLSLHelper from './ClassifierGLSLHelper';
+import { Variable } from '../basic/variable';
 
 export const DEFAULT_HISTOGRAM_SIZE = 1000;
 
@@ -67,12 +68,16 @@ export default class Classifier extends BaseExpression {
     }
 
     _validateInputIsNumericProperty () {
-        checkInstance(this.expressionName, 'input', 0, Property, this.input);
+        checkInstance(this.expressionName, 'input', 0, [ Property, Variable ], this.input);
         checkType(this.expressionName, 'input', 0, 'number', this.input);
     }
 
     toString () {
         return `${this.expressionName}(${this.input.toString()}, ${this.numCategories})`;
+    }
+
+    get value () {
+        return this.breakpoints.map(br => br.expr);
     }
 
     eval (feature) {

--- a/src/renderer/viz/expressions/classification/Classifier.js
+++ b/src/renderer/viz/expressions/classification/Classifier.js
@@ -1,12 +1,9 @@
 import BaseExpression from '../base';
 import { number } from '../../expressions';
 
-import { checkType, checkNumber, checkInstance } from '../utils';
+import { checkType, checkNumber } from '../utils';
 import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
-import Property from '../basic/property';
 import ClassifierGLSLHelper from './ClassifierGLSLHelper';
-import { Variable } from '../basic/variable';
-import ClusterCount from '../aggregation/cluster/ClusterCount';
 
 export const DEFAULT_HISTOGRAM_SIZE = 1000;
 

--- a/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
@@ -39,7 +39,8 @@ export default class GlobalEqIntervals extends Classifier {
     }
 
     _updateBreakpointsWith (metadata) {
-        const { min, max } = metadata.stats(this.input.name);
+        const name = this.input.propertyName || this.input.name;
+        const { min, max } = metadata.stats(name);
         this.min = min;
         this.max = max;
 

--- a/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
@@ -45,7 +45,7 @@ export default class GlobalEqIntervals extends Classifier {
             throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalEqIntervals. Use ViewportEqIntervals instead`);
         }
 
-        const name = this.input.propertyName;
+        const name = this.input.name;
         const { min, max } = metadata.stats(name);
         this.min = min;
         this.max = max;

--- a/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
@@ -41,11 +41,11 @@ export default class GlobalEqIntervals extends Classifier {
     }
 
     _updateBreakpointsWith (metadata) {
-        if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
+        if (this.input.name === CLUSTER_FEATURE_COUNT) {
             throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalEqIntervals. Use ViewportEqIntervals instead`);
         }
 
-        const name = this.input.propertyName || this.input.name;
+        const name = this.input.name;
         const { min, max } = metadata.stats(name);
         this.min = min;
         this.max = max;

--- a/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
@@ -41,11 +41,11 @@ export default class GlobalEqIntervals extends Classifier {
     }
 
     _updateBreakpointsWith (metadata) {
-        if (this.input.name === CLUSTER_FEATURE_COUNT) {
+        if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
             throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalEqIntervals. Use ViewportEqIntervals instead`);
         }
 
-        const name = this.input.name;
+        const name = this.input.propertyName;
         const { min, max } = metadata.stats(name);
         this.min = min;
         this.max = max;

--- a/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
@@ -42,7 +42,7 @@ export default class GlobalEqIntervals extends Classifier {
 
     _updateBreakpointsWith (metadata) {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalEqIntervals. Use ViewportEqIntervals instead`);
+            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalEqIntervals. Consider using ViewportEqIntervals instead`);
         }
 
         const name = this.input.name;

--- a/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
@@ -1,5 +1,6 @@
 import Classifier from './Classifier';
 import { checkExactNumberOfArguments } from '../utils';
+import { CLUSTER_FEATURE_COUNT } from '../../../../constants/metadata';
 
 /**
  * Classify `input` by using the equal intervals method with `n` buckets.
@@ -39,7 +40,9 @@ export default class GlobalEqIntervals extends Classifier {
     }
 
     _updateBreakpointsWith (metadata) {
-        const name = this.input.propertyName || this.input.name;
+        const name = this.input.propertyName === CLUSTER_FEATURE_COUNT
+            ? 'cartodb_id'
+            : this.input.propertyName || this.input.name;
         const { min, max } = metadata.stats(name);
         this.min = min;
         this.max = max;

--- a/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
@@ -1,6 +1,7 @@
 import Classifier from './Classifier';
 import { checkExactNumberOfArguments } from '../utils';
 import { CLUSTER_FEATURE_COUNT } from '../../../../constants/metadata';
+import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
 
 /**
  * Classify `input` by using the equal intervals method with `n` buckets.
@@ -40,9 +41,11 @@ export default class GlobalEqIntervals extends Classifier {
     }
 
     _updateBreakpointsWith (metadata) {
-        const name = this.input.propertyName === CLUSTER_FEATURE_COUNT
-            ? 'cartodb_id'
-            : this.input.propertyName || this.input.name;
+        if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
+            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalEqIntervals. Use ViewportEqIntervals instead`);
+        }
+
+        const name = this.input.propertyName || this.input.name;
         const { min, max } = metadata.stats(name);
         this.min = min;
         this.max = max;

--- a/src/renderer/viz/expressions/classification/GlobalQuantiles.js
+++ b/src/renderer/viz/expressions/classification/GlobalQuantiles.js
@@ -1,5 +1,6 @@
 import Classifier from './Classifier';
 import { checkExactNumberOfArguments, checkType } from '../utils';
+import { CLUSTER_FEATURE_COUNT } from '../../../../constants/metadata';
 
 /**
  * Classify `input` by using the quantiles method with `n` buckets.
@@ -42,7 +43,9 @@ export default class GlobalQuantiles extends Classifier {
     _validateInputIsNumericProperty () { /* noop */ }
 
     _updateBreakpointsWith (metadata) {
-        const name = this.input.name || this.input.propertyName;
+        const name = this.input.propertyName === CLUSTER_FEATURE_COUNT
+            ? 'cartodb_id'
+            : this.input.propertyName || this.input.name;
         const copy = metadata.sample.map(s => s[name]);
         copy.sort((x, y) => x - y);
 

--- a/src/renderer/viz/expressions/classification/GlobalQuantiles.js
+++ b/src/renderer/viz/expressions/classification/GlobalQuantiles.js
@@ -42,7 +42,8 @@ export default class GlobalQuantiles extends Classifier {
     _validateInputIsNumericProperty () { /* noop */ }
 
     _updateBreakpointsWith (metadata) {
-        const copy = metadata.sample.map(s => s[this.input.name]);
+        const name = this.input.name || this.input.propertyName;
+        const copy = metadata.sample.map(s => s[name]);
         copy.sort((x, y) => x - y);
 
         this.breakpoints.map((breakpoint, index) => {

--- a/src/renderer/viz/expressions/classification/GlobalQuantiles.js
+++ b/src/renderer/viz/expressions/classification/GlobalQuantiles.js
@@ -45,7 +45,7 @@ export default class GlobalQuantiles extends Classifier {
 
     _updateBreakpointsWith (metadata) {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalQuantiles. Use ViewportQuantiles instead`);
+            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalQuantiles. Consider using ViewportQuantiles instead`);
         }
 
         const name = this.input.name;

--- a/src/renderer/viz/expressions/classification/GlobalQuantiles.js
+++ b/src/renderer/viz/expressions/classification/GlobalQuantiles.js
@@ -55,7 +55,7 @@ export default class GlobalQuantiles extends Classifier {
 
     _genBreakpoints () {
         const histogram = this._histogram.value;
-        if (histogram === undefined) { return; }
+        if (histogram === undefined || !histogram.length) { return; }
 
         const [min, max] = this._getMinMaxFrom(histogram);
 

--- a/src/renderer/viz/expressions/classification/GlobalQuantiles.js
+++ b/src/renderer/viz/expressions/classification/GlobalQuantiles.js
@@ -44,11 +44,11 @@ export default class GlobalQuantiles extends Classifier {
     _validateInputIsNumericProperty () { /* noop */ }
 
     _updateBreakpointsWith (metadata) {
-        if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
+        if (this.input.name === CLUSTER_FEATURE_COUNT) {
             throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalQuantiles. Use ViewportQuantiles instead`);
         }
 
-        const name = this.input.propertyName || this.input.name;
+        const name = this.input.name;
         const copy = metadata.sample.map(s => s[name]);
         copy.sort((x, y) => x - y);
 

--- a/src/renderer/viz/expressions/classification/GlobalQuantiles.js
+++ b/src/renderer/viz/expressions/classification/GlobalQuantiles.js
@@ -1,5 +1,6 @@
-import Classifier from './Classifier';
-import { checkExactNumberOfArguments } from '../utils';
+import Classifier, { DEFAULT_HISTOGRAM_SIZE } from './Classifier';
+import { checkMinArguments, checkMaxArguments } from '../utils';
+import { globalHistogram } from '../../expressions';
 
 /**
  * Classify `input` by using the quantiles method with `n` buckets.
@@ -27,24 +28,61 @@ import { checkExactNumberOfArguments } from '../utils';
  * @api
  */
 export default class GlobalQuantiles extends Classifier {
-    constructor (input, buckets) {
-        checkExactNumberOfArguments(arguments, 2, 'globalQuantiles');
-        super({ input, buckets });
+    constructor (input, buckets, histogramSize = DEFAULT_HISTOGRAM_SIZE) {
+        checkMinArguments(arguments, 2, 'globalQuantiles');
+        checkMaxArguments(arguments, 3, 'globalQuantiles');
+
+        super({ input, buckets, _histogramSize: histogramSize });
+    }
+
+    _histogramInitialization () {
+        const input = this.input;
+        const histogramSize = this._histogramSize.value;
+
+        this._histogram = globalHistogram(input, histogramSize);
+    }
+
+    _resolveAliases (aliases) {
+        super._resolveAliases(aliases);
+
+        this._histogramInitialization();
     }
 
     _bindMetadata (metadata) {
-        super._bindMetadata(metadata);
-
-        this._updateBreakpointsWith(metadata);
+        this._metadata = metadata;
+        this._genBreakpoints();
     }
 
-    _updateBreakpointsWith (metadata) {
-        const copy = metadata.sample.map(s => s[this.input.name]);
-        copy.sort((x, y) => x - y);
+    _genBreakpoints () {
+        const histogram = this._histogram.value;
+        if (histogram === undefined) { return; }
 
+        const [min, max] = this._getMinMaxFrom(histogram);
+
+        this._updateBreakpointsWith({ histogram, min, max });
+    }
+
+    _updateBreakpointsWith ({ histogram, min, max }) {
+        const histogramBuckets = histogram.length;
+
+        let i = 0;
+        const total = histogram[histogramBuckets - 1];
+        // TODO OPT: this could be faster with binary search
         this.breakpoints.map((breakpoint, index) => {
-            const p = (index + 1) / this.numCategories;
-            breakpoint.expr = copy[Math.floor(p * copy.length)];
+            for (i; i < histogramBuckets; i++) {
+                if (histogram[i] > (index + 1) / this.numCategories * total) {
+                    break;
+                }
+            }
+            const percentileValue = i / histogramBuckets * (max - min) + min;
+            breakpoint.expr = percentileValue;
         });
+    }
+
+    _getMinMaxFrom (histogram) {
+        const min = histogram[0].x[0];
+        const max = histogram[histogram.length - 1].x[1];
+
+        return [min, max];
     }
 }

--- a/src/renderer/viz/expressions/classification/GlobalQuantiles.js
+++ b/src/renderer/viz/expressions/classification/GlobalQuantiles.js
@@ -48,7 +48,7 @@ export default class GlobalQuantiles extends Classifier {
             throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalQuantiles. Use ViewportQuantiles instead`);
         }
 
-        const name = this.input.propertyName;
+        const name = this.input.name;
         const copy = metadata.sample.map(s => s[name]);
         copy.sort((x, y) => x - y);
 

--- a/src/renderer/viz/expressions/classification/GlobalQuantiles.js
+++ b/src/renderer/viz/expressions/classification/GlobalQuantiles.js
@@ -44,11 +44,11 @@ export default class GlobalQuantiles extends Classifier {
     _validateInputIsNumericProperty () { /* noop */ }
 
     _updateBreakpointsWith (metadata) {
-        if (this.input.name === CLUSTER_FEATURE_COUNT) {
+        if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
             throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalQuantiles. Use ViewportQuantiles instead`);
         }
 
-        const name = this.input.name;
+        const name = this.input.propertyName;
         const copy = metadata.sample.map(s => s[name]);
         copy.sort((x, y) => x - y);
 

--- a/src/renderer/viz/expressions/classification/GlobalQuantiles.js
+++ b/src/renderer/viz/expressions/classification/GlobalQuantiles.js
@@ -1,6 +1,7 @@
 import Classifier from './Classifier';
 import { checkExactNumberOfArguments, checkType } from '../utils';
 import { CLUSTER_FEATURE_COUNT } from '../../../../constants/metadata';
+import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
 
 /**
  * Classify `input` by using the quantiles method with `n` buckets.
@@ -43,9 +44,11 @@ export default class GlobalQuantiles extends Classifier {
     _validateInputIsNumericProperty () { /* noop */ }
 
     _updateBreakpointsWith (metadata) {
-        const name = this.input.propertyName === CLUSTER_FEATURE_COUNT
-            ? 'cartodb_id'
-            : this.input.propertyName || this.input.name;
+        if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
+            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalQuantiles. Use ViewportQuantiles instead`);
+        }
+
+        const name = this.input.propertyName || this.input.name;
         const copy = metadata.sample.map(s => s[name]);
         copy.sort((x, y) => x - y);
 

--- a/src/renderer/viz/expressions/classification/GlobalStandardDev.js
+++ b/src/renderer/viz/expressions/classification/GlobalStandardDev.js
@@ -4,6 +4,7 @@ import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../e
 import CartoRuntimeError, { CartoRuntimeTypes as runtimeErrors } from '../../../../errors/carto-runtime-error';
 
 import { average, standardDeviation } from '../stats';
+import { CLUSTER_FEATURE_COUNT } from '../../../../constants/metadata';
 
 /**
  * Classify `input` by using the Mean-Standard Deviation method with `n` buckets.
@@ -77,7 +78,9 @@ export default class GlobalStandardDev extends Classifier {
     }
 
     _updateBreakpointsWith (metadata) {
-        const name = this.input.propertyName || this.input.name;
+        const name = this.input.propertyName === CLUSTER_FEATURE_COUNT
+            ? 'cartodb_id'
+            : this.input.propertyName || this.input.name;
         const sample = metadata.sample.map(s => s[name]);
         const avg = average(sample);
         const standardDev = standardDeviation(sample);

--- a/src/renderer/viz/expressions/classification/GlobalStandardDev.js
+++ b/src/renderer/viz/expressions/classification/GlobalStandardDev.js
@@ -78,10 +78,10 @@ export default class GlobalStandardDev extends Classifier {
     }
 
     _updateBreakpointsWith (metadata) {
-        if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
+        if (this.input.name === CLUSTER_FEATURE_COUNT) {
             throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalStandardDev. Use ViewportStandardDev instead`);
         }
-        const name = this.input.propertyName || this.input.name;
+        const name = this.input.name;
         const sample = metadata.sample.map(s => s[name]);
         const avg = average(sample);
         const standardDev = standardDeviation(sample);

--- a/src/renderer/viz/expressions/classification/GlobalStandardDev.js
+++ b/src/renderer/viz/expressions/classification/GlobalStandardDev.js
@@ -81,7 +81,6 @@ export default class GlobalStandardDev extends Classifier {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
             throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalStandardDev. Use ViewportStandardDev instead`);
         }
-
         const name = this.input.propertyName || this.input.name;
         const sample = metadata.sample.map(s => s[name]);
         const avg = average(sample);

--- a/src/renderer/viz/expressions/classification/GlobalStandardDev.js
+++ b/src/renderer/viz/expressions/classification/GlobalStandardDev.js
@@ -79,7 +79,7 @@ export default class GlobalStandardDev extends Classifier {
 
     _updateBreakpointsWith (metadata) {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalStandardDev. Use ViewportStandardDev instead`);
+            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalStandardDev. Consider using ViewportStandardDev instead`);
         }
         const name = this.input.name;
         const sample = metadata.sample.map(s => s[name]);

--- a/src/renderer/viz/expressions/classification/GlobalStandardDev.js
+++ b/src/renderer/viz/expressions/classification/GlobalStandardDev.js
@@ -77,7 +77,8 @@ export default class GlobalStandardDev extends Classifier {
     }
 
     _updateBreakpointsWith (metadata) {
-        const sample = metadata.sample.map(s => s[this.input.name]);
+        const name = this.input.propertyName || this.input.name;
+        const sample = metadata.sample.map(s => s[name]);
         const avg = average(sample);
         const standardDev = standardDeviation(sample);
 

--- a/src/renderer/viz/expressions/classification/GlobalStandardDev.js
+++ b/src/renderer/viz/expressions/classification/GlobalStandardDev.js
@@ -78,9 +78,11 @@ export default class GlobalStandardDev extends Classifier {
     }
 
     _updateBreakpointsWith (metadata) {
-        const name = this.input.propertyName === CLUSTER_FEATURE_COUNT
-            ? 'cartodb_id'
-            : this.input.propertyName || this.input.name;
+        if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
+            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalStandardDev. Use ViewportStandardDev instead`);
+        }
+
+        const name = this.input.propertyName || this.input.name;
         const sample = metadata.sample.map(s => s[name]);
         const avg = average(sample);
         const standardDev = standardDeviation(sample);

--- a/src/renderer/viz/expressions/classification/GlobalStandardDev.js
+++ b/src/renderer/viz/expressions/classification/GlobalStandardDev.js
@@ -78,7 +78,7 @@ export default class GlobalStandardDev extends Classifier {
     }
 
     _updateBreakpointsWith (metadata) {
-        if (this.input.name === CLUSTER_FEATURE_COUNT) {
+        if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
             throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalStandardDev. Use ViewportStandardDev instead`);
         }
         const name = this.input.name;

--- a/src/renderer/viz/expressions/histogram/ViewportHistogram.js
+++ b/src/renderer/viz/expressions/histogram/ViewportHistogram.js
@@ -1,8 +1,8 @@
 import Histogram from './Histogram';
 import { checkMaxArguments, implicitCast } from '../utils';
-import { CLUSTER_FEATURE_COUNT } from '../../../schema';
 import { checkArray } from '../utils';
 import { DEFAULT_OPTIONS } from '../constants';
+import { CLUSTER_FEATURE_COUNT } from '../../../../constants/metadata';
 
 /**
  * Generates a histogram.

--- a/src/renderer/viz/expressions/linear.js
+++ b/src/renderer/viz/expressions/linear.js
@@ -134,15 +134,15 @@ export default class Linear extends BaseExpression {
                     inputIndex = 1; // end
                     break;
             }
-            const input = feature._dataframe.properties[this._metadata.decodedProperties(this.input.name)[inputIndex]][feature._index];
+            const input = feature._dataframe.properties[this._metadata.decodedProperties(this.input.propertyName)[inputIndex]][feature._index];
 
             return (input - this._internalMin) / (this._internalMax - this._internalMin);
         }
 
         const input = this.input.eval(feature);
         const metadata = this._metadata;
-        const codec = (metadata && this.input.name)
-            ? metadata.codec(this.input.name)
+        const codec = (metadata && this.input.propertyName)
+            ? metadata.codec(this.input.propertyName)
             : new IdentityCodec();
         const min = codec.externalToInternal(metadata, this.min.eval(feature));
         const max = codec.externalToInternal(metadata, this.max.eval(feature));
@@ -160,22 +160,22 @@ export default class Linear extends BaseExpression {
                 case 'unit':
                     // choose same side for all three:
                     inputIndex = 0; // start
-                    min = metadata.codec(this.input.name).externalToInternal(metadata, this.min.eval())[inputIndex];
-                    max = metadata.codec(this.input.name).externalToInternal(metadata, this.max.eval())[inputIndex];
+                    min = metadata.codec(this.input.propertyName).externalToInternal(metadata, this.min.eval())[inputIndex];
+                    max = metadata.codec(this.input.propertyName).externalToInternal(metadata, this.max.eval())[inputIndex];
                     // min in ms is castTimeRange(this.min.eval()).startValue;
                     // max in ms is castTimeRange(this.max.eval()).startValue;
                     break;
                 case 'start':
                     inputIndex = 0; // start
-                    min = metadata.codec(this.input.name).externalToInternal(metadata, this.min.eval())[0]; // start
-                    max = metadata.codec(this.input.name).externalToInternal(metadata, this.max.eval())[1]; // end
+                    min = metadata.codec(this.input.propertyName).externalToInternal(metadata, this.min.eval())[0]; // start
+                    max = metadata.codec(this.input.propertyName).externalToInternal(metadata, this.max.eval())[1]; // end
                     // min in ms is castTimeRange(this.min.eval()).startValue;
                     // max in ms is castTimeRange(this.max.eval()).endValue;
                     break;
                 case 'end':
                     inputIndex = 1; // end
-                    min = metadata.codec(this.input.name).externalToInternal(metadata, this.min.eval())[0]; // start
-                    max = metadata.codec(this.input.name).externalToInternal(metadata, this.max.eval())[1]; // end
+                    min = metadata.codec(this.input.propertyName).externalToInternal(metadata, this.min.eval())[0]; // start
+                    max = metadata.codec(this.input.propertyName).externalToInternal(metadata, this.max.eval())[1]; // end
                     // min in ms is castTimeRange(this.min.eval()).startValue;
                     // max in ms is castTimeRange(this.max.eval()).endValue;
                     break;
@@ -194,7 +194,7 @@ export default class Linear extends BaseExpression {
             // checkType('linear', 'max', 2, this.input.type, this.max);
             // but global aggregations are currently of type number even for dates
 
-            const codec = this.input.name && metadata.codec(this.input.name);
+            const codec = this.input.propertyName && metadata.codec(this.input.propertyName);
             if (!codec || codec.isIdentity()) {
                 // this permits using properties for the min/man expressions
                 this.inlineMaker = (inline) => `((${inline.input}-${inline.min})/(${inline.max}-${inline.min}))`;

--- a/src/renderer/viz/expressions/linear.js
+++ b/src/renderer/viz/expressions/linear.js
@@ -134,15 +134,15 @@ export default class Linear extends BaseExpression {
                     inputIndex = 1; // end
                     break;
             }
-            const input = feature._dataframe.properties[this._metadata.decodedProperties(this.input.propertyName)[inputIndex]][feature._index];
+            const input = feature._dataframe.properties[this._metadata.decodedProperties(this.input.name)[inputIndex]][feature._index];
 
             return (input - this._internalMin) / (this._internalMax - this._internalMin);
         }
 
         const input = this.input.eval(feature);
         const metadata = this._metadata;
-        const codec = (metadata && this.input.propertyName)
-            ? metadata.codec(this.input.propertyName)
+        const codec = (metadata && this.input.name)
+            ? metadata.codec(this.input.name)
             : new IdentityCodec();
         const min = codec.externalToInternal(metadata, this.min.eval(feature));
         const max = codec.externalToInternal(metadata, this.max.eval(feature));
@@ -160,22 +160,22 @@ export default class Linear extends BaseExpression {
                 case 'unit':
                     // choose same side for all three:
                     inputIndex = 0; // start
-                    min = metadata.codec(this.input.propertyName).externalToInternal(metadata, this.min.eval())[inputIndex];
-                    max = metadata.codec(this.input.propertyName).externalToInternal(metadata, this.max.eval())[inputIndex];
+                    min = metadata.codec(this.input.name).externalToInternal(metadata, this.min.eval())[inputIndex];
+                    max = metadata.codec(this.input.name).externalToInternal(metadata, this.max.eval())[inputIndex];
                     // min in ms is castTimeRange(this.min.eval()).startValue;
                     // max in ms is castTimeRange(this.max.eval()).startValue;
                     break;
                 case 'start':
                     inputIndex = 0; // start
-                    min = metadata.codec(this.input.propertyName).externalToInternal(metadata, this.min.eval())[0]; // start
-                    max = metadata.codec(this.input.propertyName).externalToInternal(metadata, this.max.eval())[1]; // end
+                    min = metadata.codec(this.input.name).externalToInternal(metadata, this.min.eval())[0]; // start
+                    max = metadata.codec(this.input.name).externalToInternal(metadata, this.max.eval())[1]; // end
                     // min in ms is castTimeRange(this.min.eval()).startValue;
                     // max in ms is castTimeRange(this.max.eval()).endValue;
                     break;
                 case 'end':
                     inputIndex = 1; // end
-                    min = metadata.codec(this.input.propertyName).externalToInternal(metadata, this.min.eval())[0]; // start
-                    max = metadata.codec(this.input.propertyName).externalToInternal(metadata, this.max.eval())[1]; // end
+                    min = metadata.codec(this.input.name).externalToInternal(metadata, this.min.eval())[0]; // start
+                    max = metadata.codec(this.input.name).externalToInternal(metadata, this.max.eval())[1]; // end
                     // min in ms is castTimeRange(this.min.eval()).startValue;
                     // max in ms is castTimeRange(this.max.eval()).endValue;
                     break;
@@ -194,7 +194,7 @@ export default class Linear extends BaseExpression {
             // checkType('linear', 'max', 2, this.input.type, this.max);
             // but global aggregations are currently of type number even for dates
 
-            const codec = this.input.propertyName && metadata.codec(this.input.propertyName);
+            const codec = this.input.name && metadata.codec(this.input.name);
             if (!codec || codec.isIdentity()) {
                 // this permits using properties for the min/man expressions
                 this.inlineMaker = (inline) => `((${inline.input}-${inline.min})/(${inline.max}-${inline.min}))`;

--- a/src/renderer/viz/expressions/top.js
+++ b/src/renderer/viz/expressions/top.js
@@ -45,7 +45,7 @@ export default class Top extends BaseExpression {
     }
 
     eval (feature) {
-        const metaColumn = this._metadata.properties[this.property.name];
+        const metaColumn = this._metadata.properties[this.property.propertyName];
         const orderedCategoryNames = [...metaColumn.categories].sort((a, b) =>
             b.frequency - a.frequency
         );
@@ -155,7 +155,7 @@ export default class Top extends BaseExpression {
 
     _preDraw (program, drawMetadata, gl) {
         const buckets = this.numBuckets;
-        const metaColumn = this._metadata.properties[this.property.name];
+        const metaColumn = this._metadata.properties[this.property.propertyName];
 
         const orderedCategoryNames = [...metaColumn.categories].sort((a, b) =>
             b.frequency - a.frequency
@@ -176,7 +176,7 @@ export default class Top extends BaseExpression {
     }
 
     getLegendData (options) {
-        const metaColumn = this._metadata.properties[this.property.name];
+        const metaColumn = this._metadata.properties[this.property.propertyName];
         const orderedCategoryNames = [...metaColumn.categories].sort((a, b) =>
             b.frequency - a.frequency
         );

--- a/src/renderer/viz/expressions/utils.js
+++ b/src/renderer/viz/expressions/utils.js
@@ -113,8 +113,11 @@ export function throwInvalidType (expressionName, parameterName, parameterIndex,
 }
 
 export function throwInvalidInstance (expressionName, parameterName, parameterIndex, expectedClass) {
+    const expectedClassNames = Array.isArray(expectedClass)
+        ? expectedClass.join(', ')
+        : expectedClass.name;
     throw new CartoValidationError(`${cvt.INCORRECT_TYPE} ${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-    expected type was instance of '${expectedClass.name}'`);
+    expected type was instance of '${expectedClassNames}'`);
 }
 
 export function throwInvalidNumber (expressionName, parameterName, parameterIndex, number) {
@@ -174,10 +177,19 @@ export function checkType (expressionName, parameterName, parameterIndex, expect
     }
 }
 
-export function checkInstance (expressionName, parameterName, parameterIndex, expectedClass, parameter) {
+export function checkInstance (expressionName, parameterName, parameterIndex, expectedExpression, parameter) {
     checkExpression(expressionName, parameterName, parameterIndex, parameter);
-    if (!(parameter.isA(expectedClass))) {
-        throwInvalidInstance(expressionName, parameterName, parameterIndex, expectedClass);
+
+    if (Array.isArray(expectedExpression)) {
+        const ok = expectedExpression.some(expression => {
+            return parameter.isA(expression);
+        });
+
+        if (!ok) {
+            throwInvalidInstance(expressionName, parameterName, parameterIndex, expectedExpression);
+        }
+    } else if (!(parameter.isA(expectedExpression))) {
+        throwInvalidInstance(expressionName, parameterName, parameterIndex, expectedExpression);
     }
 }
 

--- a/test/integration/user/test/viewportFeatures.test.js
+++ b/test/integration/user/test/viewportFeatures.test.js
@@ -1,7 +1,7 @@
 import carto from '../../../../src';
 import * as util from '../../util';
 import VIZ_PROPERTIES from '../../../../src/renderer/viz/utils/properties';
-import { CLUSTER_FEATURE_COUNT } from '../../../../src/renderer/schema';
+import { CLUSTER_FEATURE_COUNT } from '../../../../src/constants/metadata';
 
 const feature1 = {
     type: 'Feature',


### PR DESCRIPTION
Blocked by https://github.com/CartoDB/carto-vl/issues/1287
Related issue: https://github.com/CartoDB/carto-vl/issues/1275

This PR aims to solve several issues related with global expressions and clusterCount expression:

**Update**: the current problem is that, when using clusterCount() expression, we're not evaluating the expression in the feature properly and therefore we always get the same width in the examples.

## Linear globalMIN/MAX
- [x] Works with `clusterAVG`
  - [example](http://localhost:8080/examples/editor/index.html#eyJhIjoibWF4aGlfMjAxODA3MDJmMDcyIiwiYiI6IiIsImMiOiJtYW1hdGFha2VsbGEiLCJkIjoiaHR0cHM6Ly97dXNlcn0uY2FydG8uY29tIiwiZSI6IkBjYTogY2x1c3RlckFWRygkdmFsdWUpXG5cbndpZHRoOiByYW1wKGxpbmVhcihAY2EsZ2xvYmFsTUlOKEBjYSksZ2xvYmFsTUFYKEBjYSkpLFsxMCwzMF0pXG5jb2xvcjogcmFtcChsaW5lYXIoQGNhLGdsb2JhbE1JTihAY2EpLGdsb2JhbE1BWChAY2EpKSxwaW5reWwpXG5zdHJva2VXaWR0aDogMFxucmVzb2x1dGlvbjogMzIiLCJmIjp7ImxuZyI6LTk3LjE3NTI3MjA0NjI5MjE1LCJsYXQiOjQwLjAxNjUxODcyNTMwMzIzfSwiZyI6My4xMjM2NDUzMDA2NTM2ODgsImgiOiJQb3NpdHJvbiIsImkiOiJkYXRhc2V0In0=)
- ❌ Not working with `clusterCount` **not possible**
  - [example](http://localhost:8080/examples/editor/index.html#eyJhIjoibWF4aGlfMjAxODA3MDJmMDcyIiwiYiI6IiIsImMiOiJtYW1hdGFha2VsbGEiLCJkIjoiaHR0cHM6Ly97dXNlcn0uY2FydG8uY29tIiwiZSI6IkBjYzogY2x1c3RlckNvdW50KClcblxud2lkdGg6IHJhbXAobGluZWFyKEBjYyxnbG9iYWxNSU4oQGNjKSxnbG9iYWxNQVgoQGNjKSksWzEwLDMwXSlcbmNvbG9yOiByYW1wKGxpbmVhcihAY2MsZ2xvYmFsTUlOKEBjYyksZ2xvYmFsTUFYKEBjYykpLHBpbmt5bClcbnN0cm9rZVdpZHRoOiAwXG5yZXNvbHV0aW9uOiAzMiIsImYiOnsibG5nIjotOTcuMTc1MjcyMDQ2MjkyMTUsImxhdCI6NDAuMDE2NTE4NzI1MzAzMjN9LCJnIjozLjEyMzY0NTMwMDY1MzY4OCwiaCI6IlBvc2l0cm9uIiwiaSI6ImRhdGFzZXQifQ==)

## Global quantiles
- [x] works with `clusterAVG`
  - [example](http://localhost:8080/examples/editor/index.html#eyJhIjoibWF4aGlfMjAxODA3MDJmMDcyIiwiYiI6IiIsImMiOiJtYW1hdGFha2VsbGEiLCJkIjoiaHR0cHM6Ly97dXNlcn0uY2FydG8uY29tIiwiZSI6IkBjYTogY2x1c3RlckFWRygkdmFsdWUpXG5cbkBzaXplOiByYW1wKGdsb2JhbFF1YW50aWxlcyhAY2EsIDUpLCBbNSwzMF0pXG5AZmlsbDogcmFtcChnbG9iYWxRdWFudGlsZXMoQGNhLCA1KSwgcGlua3lsKVxuXG53aWR0aDogQHNpemVcbmNvbG9yOiBAZmlsbFxuc3Ryb2tlV2lkdGg6IDBcbnJlc29sdXRpb246IDMyIiwiZiI6eyJsbmciOi05Ny4wNTcwNzcyMjEwOTY1NiwibGF0Ijo0MC41MjEyOTk3ODU4NDU2ODR9LCJnIjozLjA2NjA5MzY1OTY5NjE2NjUsImgiOiJQb3NpdHJvbiIsImkiOiJkYXRhc2V0In0=)
- ❌ Doesn't look like `clusterCount()` is working there doesn't seem to be any bucketing happening in size or color - **not possible**
  - as seen [here](http://localhost:8080/examples/editor/index.html#eyJhIjoibWF4aGlfMjAxODA3MDJmMDcyIiwiYiI6IiIsImMiOiJtYW1hdGFha2VsbGEiLCJkIjoiaHR0cHM6Ly97dXNlcn0uY2FydG8uY29tIiwiZSI6IkBjYzogY2x1c3RlckNvdW50KClcblxuQHNpemU6IHJhbXAoZ2xvYmFsUXVhbnRpbGVzKEBjYywgNSksIFs1LDMwXSlcbkBmaWxsOiByYW1wKGdsb2JhbFF1YW50aWxlcyhAY2MsIDUpLCBwaW5reWwpXG5cbndpZHRoOiBAc2l6ZVxuY29sb3I6IEBmaWxsXG5zdHJva2VXaWR0aDogMFxucmVzb2x1dGlvbjogMzIiLCJmIjp7ImxuZyI6LTk3LjA1NzA3NzIyMTA5NjU2LCJsYXQiOjQwLjUyMTI5OTc4NTg0NTY4NH0sImciOjMuMDY2MDkzNjU5Njk2MTY2NSwiaCI6IlBvc2l0cm9uIiwiaSI6ImRhdGFzZXQifQ==) 
- [x] to double check that it wasn't the data, I did a quick test with viewport quantiles, and that seems to work. [Map](http://localhost:8080/examples/editor/index.html#eyJhIjoibWF4aGlfMjAxODA3MDJmMDcyIiwiYiI6IiIsImMiOiJtYW1hdGFha2VsbGEiLCJkIjoiaHR0cHM6Ly97dXNlcn0uY2FydG8uY29tIiwiZSI6IkBjYzogY2x1c3RlckNvdW50KClcblxuQHNpemU6IHJhbXAodmlld3BvcnRRdWFudGlsZXMoQGNjLCA1KSwgWzUsMzBdKVxuQGZpbGw6IHJhbXAodmlld3BvcnRRdWFudGlsZXMoQGNjLCA1KSwgcGlua3lsKVxuXG53aWR0aDogQHNpemVcbmNvbG9yOiBAZmlsbFxuc3Ryb2tlV2lkdGg6IDBcbnJlc29sdXRpb246IDMyIiwiZiI6eyJsbmciOi05Ny4wNTcwNzcyMjEwOTY1NiwibGF0Ijo0MC41MjEyOTk3ODU4NDU2ODR9LCJnIjozLjA2NjA5MzY1OTY5NjE2NjUsImgiOiJQb3NpdHJvbiIsImkiOiJkYXRhc2V0In0=)

## Global Equal Intervals

Doesn't seem to be working on count or avg
- [x] [clusterAVG map](http://localhost:8080/examples/editor/index.html#eyJhIjoibWF4aGlfMjAxODA3MDJmMDcyIiwiYiI6IiIsImMiOiJtYW1hdGFha2VsbGEiLCJkIjoiaHR0cHM6Ly97dXNlcn0uY2FydG8uY29tIiwiZSI6IkBjYTogY2x1c3RlckFWRygkdmFsdWUpXG5cbkBzaXplOiByYW1wKGdsb2JhbEVxSW50ZXJ2YWxzKEBjYSwgNSksIFs1LDMwXSlcbkBmaWxsOiByYW1wKGdsb2JhbEVxSW50ZXJ2YWxzKEBjYSwgNSksIHBpbmt5bClcblxud2lkdGg6IEBzaXplXG5jb2xvcjogQGZpbGxcbnN0cm9rZVdpZHRoOiAwXG5yZXNvbHV0aW9uOiAzMiIsImYiOnsibG5nIjotOTcuMDU3MDc3MjIxMDk2NTYsImxhdCI6NDAuNTIxMjk5Nzg1ODQ1Njg0fSwiZyI6My4wNjYwOTM2NTk2OTYxNjY1LCJoIjoiUG9zaXRyb24iLCJpIjoiZGF0YXNldCJ9)
- ❌[clusterCount map](http://localhost:8080/examples/editor/index.html#eyJhIjoibWF4aGlfMjAxODA3MDJmMDcyIiwiYiI6IiIsImMiOiJtYW1hdGFha2VsbGEiLCJkIjoiaHR0cHM6Ly97dXNlcn0uY2FydG8uY29tIiwiZSI6IkBjYzogY2x1c3RlckNvdW50KClcblxuQHNpemU6IHJhbXAoZ2xvYmFsRXFJbnRlcnZhbHMoQGNjLCA1KSwgWzUsMzBdKVxuQGZpbGw6IHJhbXAoZ2xvYmFsRXFJbnRlcnZhbHMoQGNjLCA1KSwgcGlua3lsKVxuXG53aWR0aDogQHNpemVcbmNvbG9yOiBAZmlsbFxuc3Ryb2tlV2lkdGg6IDBcbnJlc29sdXRpb246IDMyIiwiZiI6eyJsbmciOi05Ny4wNTcwNzcyMjEwOTY1NiwibGF0Ijo0MC41MjEyOTk3ODU4NDU2ODR9LCJnIjozLjA2NjA5MzY1OTY5NjE2NjUsImgiOiJQb3NpdHJvbiIsImkiOiJkYXRhc2V0In0=) **not possible**

## Standard Deviation

Doesn't seem to be working with
- ❌ [clusterCount](http://localhost:8080/examples/editor/index.html#eyJhIjoibWF4aGlfMjAxODA3MDJmMDcyIiwiYiI6IiIsImMiOiJtYW1hdGFha2VsbGEiLCJkIjoiaHR0cHM6Ly97dXNlcn0uY2FydG8uY29tIiwiZSI6IkBjYzogY2x1c3RlckNvdW50KClcblxuQHNpemU6IHJhbXAoZ2xvYmFsU3RhbmRhcmREZXYoQGNjLCA1KSwgWzUsMzBdKVxuQGNvbG9yOiByYW1wKGdsb2JhbFN0YW5kYXJkRGV2KEBjYywgNSksIHBpbmt5bClcblxud2lkdGg6IEBzaXplXG5jb2xvcjogQGNvbG9yXG5zdHJva2VXaWR0aDogMFxucmVzb2x1dGlvbjogMzIiLCJmIjp7ImxuZyI6LTk3LjA1NzA3NzIyMTA5NjU2LCJsYXQiOjQwLjUyMTI5OTc4NTg0NTY4NH0sImciOjMuMDY2MDkzNjU5Njk2MTY2NSwiaCI6IlBvc2l0cm9uIiwiaSI6ImRhdGFzZXQifQ==) **not possible**
- [x] [clusterAVG](http://localhost:8080/examples/editor/index.html#eyJhIjoibWF4aGlfMjAxODA3MDJmMDcyIiwiYiI6IiIsImMiOiJtYW1hdGFha2VsbGEiLCJkIjoiaHR0cHM6Ly97dXNlcn0uY2FydG8uY29tIiwiZSI6IkBjYTogY2x1c3RlckFWRygkdmFsdWUpXG5cbkBzaXplOiByYW1wKGdsb2JhbFN0YW5kYXJkRGV2KEBjYSwgNSksIFs1LDMwXSlcbkBjb2xvcjogcmFtcChnbG9iYWxTdGFuZGFyZERldihAY2EsIDUpLCBwaW5reWwpXG5cbndpZHRoOiBAc2l6ZVxuY29sb3I6IEBjb2xvclxuc3Ryb2tlV2lkdGg6IDBcbnJlc29sdXRpb246IDMyIiwiZiI6eyJsbmciOi05Ny4wNTcwNzcyMjEwOTY1NiwibGF0Ijo0MC41MjEyOTk3ODU4NDU2ODR9LCJnIjozLjA2NjA5MzY1OTY5NjE2NjUsImgiOiJQb3NpdHJvbiIsImkiOiJkYXRhc2V0In0=)

## Variables

* [x] [clusterMode](http://localhost:8080/examples/editor/index.html#eyJhIjoiZmlyZV9wZXJpbWV0ZXJzX2NvcHkiLCJiIjoiIiwiYyI6Im1hbWF0YWFrZWxsYSIsImQiOiJodHRwczovL3t1c2VyfS5jYXJ0by5jb20iLCJlIjoiQGNtOiAkY2F1c2VfZGVzY3JpcFxuY29sb3I6IHJhbXAoY2x1c3Rlck1vZGUoQGNtKSwgVml2aWQpIiwiZiI6eyJsbmciOi0xMjAuNjA5NTkxMTQ3NzE4MjIsImxhdCI6MzkuMTQxMTg0NzI1OTM2OTF9LCJnIjo1LjIyOTYzMDI2MTIxNTI1MywiaCI6IkRhcmtNYXR0ZXIiLCJpIjoiZGF0YXNldCJ9)

```js
@cat: $cause_descrip
@ramp: vivid
color: ramp(clusterMode(@cat),@ramp)
```