### PR TITLE
Fix  method and add regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Raise an error when the idProperty is not specified in the metadata and is not a number
 - Fix getting aggregation expression values passed to `viewportFeatures` expression
 - Fix WebGL incompatibility in Edge
+- Fix regression in `toString` Viz method
 
 ## [1.1.1] - 2019-01-16
 

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -468,16 +468,18 @@ export default class Viz {
         }
     }
 
-    _checkVizSpec (vizSpec) {
-        // Apply implicit cast to numeric style properties
-        vizSpec.width = implicitCast(vizSpec.width);
-        vizSpec.strokeWidth = implicitCast(vizSpec.strokeWidth);
-        vizSpec.symbolPlacement = implicitCast(vizSpec.symbolPlacement);
-        vizSpec.transform = implicitCast(vizSpec.transform);
-        vizSpec.symbol = implicitCast(vizSpec.symbol);
+    _applyImplitCastToNumericProperties (vizSpec) {
         vizSpec.filter = implicitCast(vizSpec.filter);
         vizSpec.resolution = implicitCast(vizSpec.resolution);
+        vizSpec.strokeWidth = implicitCast(vizSpec.strokeWidth);
+        vizSpec.symbol = implicitCast(vizSpec.symbol);
+        vizSpec.symbolPlacement = implicitCast(vizSpec.symbolPlacement);
+        vizSpec.transform = implicitCast(vizSpec.transform);
+        vizSpec.width = implicitCast(vizSpec.width);
+    }
 
+    _checkVizSpec (vizSpec) {
+        this._applyImplitCastToNumericProperties(vizSpec);
         this._checkResolution(vizSpec.resolution);
 
         SUPPORTED_VIZ_PROPERTIES.forEach((parameter) => {
@@ -515,14 +517,15 @@ export default class Viz {
 function checkVizPropertyTypes (viz) {
     const expectedTypePerProperty = {
         color: 'color',
-        strokeColor: 'color',
-        width: 'number',
-        strokeWidth: 'number',
-        order: 'orderer',
         filter: 'number',
+        order: 'orderer',
+        resolution: 'number',
+        strokeColor: 'color',
+        strokeWidth: 'number',
         symbol: 'image',
         symbolPlacement: 'placement',
-        transform: 'transformation'
+        transform: 'transformation',
+        width: 'number'
     };
 
     Object.keys(expectedTypePerProperty).forEach((property) => {

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -126,10 +126,7 @@ export default class Viz {
         Object.defineProperty(this, propertyName, {
             get: () => this['_' + propertyName],
             set: expr => {
-                if (propertyName !== 'resolution') {
-                    expr = implicitCast(expr);
-                }
-                this['_' + propertyName] = expr;
+                this['_' + propertyName] = implicitCast(expr);
                 this._changed().catch(this._ignoreChangeRejections);
             }
         });
@@ -458,10 +455,10 @@ export default class Viz {
 
         if (util.isNumber(resolutionValue)) {
             if (resolution <= MIN_RESOLUTION) {
-                throw new CartoValidationError(`${cvt.INCORRECT_VALUE} 'resolution' must be greater than ${MIN_RESOLUTION}.`);
+                throw new CartoValidationError(`${cvt.INCORRECT_VALUE} 'resolution' is ${resolution}, must be greater than ${MIN_RESOLUTION}.`);
             }
             if (resolution >= MAX_RESOLUTION) {
-                throw new CartoValidationError(`${cvt.INCORRECT_VALUE} 'resolution' must be less than ${MAX_RESOLUTION}.`);
+                throw new CartoValidationError(`${cvt.INCORRECT_VALUE} 'resolution' is ${resolution}, must be lower than ${MAX_RESOLUTION}.`);
             }
         } else {
             throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'resolution' property must be a number.`);

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -19,7 +19,7 @@ import svgs from './renderer/viz/defaultSVGs';
 import Placement from './renderer/viz/expressions/Placement';
 import Translate from './renderer/viz/expressions/transformation/Translate';
 import { GEOMETRY_TYPE } from './utils/geometry';
-import { MAX_RESOLUTION, MIN_RESOLUTION, SUPPORTED_VIZ_PROPERTIES } from './constants/viz';
+import { MAX_RESOLUTION, MIN_RESOLUTION, SUPPORTED_VIZ_PROPERTIES, STYLE_VIZ_PROPERTIES } from './constants/viz';
 
 const DEFAULT_COLOR_EXPRESSION = () => _markDefault(s.rgb(0, 0, 0));
 const DEFAULT_WIDTH_EXPRESSION = () => _markDefault(s.number(1));
@@ -165,6 +165,7 @@ export default class Viz {
     _getRootExpressions () {
         return this._rootExpressions;
     }
+
     _getRootStyleExpressions () {
         return this._rootStyleExpressions;
     }
@@ -199,29 +200,12 @@ export default class Viz {
     }
 
     _updateRootExpressionList () {
-        this._rootExpressions = [
-            this.color,
-            this.filter,
-            this.order,
-            this.strokeColor,
-            this.strokeWidth,
-            this.symbol,
-            this.symbolPlacement,
-            this.transform,
-            this.width,
-            ...Object.values(this.variables)
-        ];
-        this._rootStyleExpressions = [
-            this.color,
-            this.filter,
-            this.order,
-            this.strokeColor,
-            this.strokeWidth,
-            this.symbol,
-            this.symbolPlacement,
-            this.transform,
-            this.width
-        ];
+        const expressions = [...SUPPORTED_VIZ_PROPERTIES].map(expression => this[expression]);
+        const styleExpressions = [...STYLE_VIZ_PROPERTIES].map(expression => this[expression]);
+        const variables = [...Object.values(this.variables)];
+
+        this._rootExpressions = [...expressions, ...variables];
+        this._rootStyleExpressions = styleExpressions;
     }
 
     getMinimumNeededSchema () {

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -523,7 +523,6 @@ export default class Viz {
             order: ${this.order.toString()}
             symbol: ${this.symbol.toString()}
             symbolPlacement: ${this.symbolPlacement.toString()}
-            offset: ${this.offset.toString()}
             ${variables}`.replace(/ {4}/g, '');
     }
 }

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -47,7 +47,7 @@ export default class Windshaft {
     async getMetadata (viz) {
         const MNS = viz.getMinimumNeededSchema();
         this._checkAcceptableMNS(MNS);
-        const resolution = viz.resolution;
+        const resolution = viz.resolution.eval();
         const filtering = windshaftFiltering.getFiltering(viz, { exclusive: this._exclusive });
         this._forceIncludeCartodbId(MNS);
         if (this._needToInstantiate(MNS, resolution, filtering)) {

--- a/src/constants/viz.js
+++ b/src/constants/viz.js
@@ -11,5 +11,17 @@ export const SUPPORTED_VIZ_PROPERTIES = [
     'width'
 ];
 
+export const STYLE_VIZ_PROPERTIES = [
+    'color',
+    'filter',
+    'order',
+    'strokeColor',
+    'strokeWidth',
+    'symbol',
+    'symbolPlacement',
+    'transform',
+    'width'
+];
+
 export const MIN_RESOLUTION = 0;
 export const MAX_RESOLUTION = 256;

--- a/src/constants/viz.js
+++ b/src/constants/viz.js
@@ -1,0 +1,15 @@
+export const SUPPORTED_VIZ_PROPERTIES = [
+    'color',
+    'filter',
+    'order',
+    'resolution',
+    'strokeColor',
+    'strokeWidth',
+    'symbol',
+    'symbolPlacement',
+    'transform',
+    'width'
+];
+
+export const MIN_RESOLUTION = 0;
+export const MAX_RESOLUTION = 256;

--- a/src/interactivity/feature.js
+++ b/src/interactivity/feature.js
@@ -1,6 +1,6 @@
 import FeatureVizProperty from './featureVizProperty';
-import VIZ_PROPERTIES from '../renderer/viz/utils/properties';
 import CartoValidationError, { CartoValidationTypes as cvt } from '../errors/carto-validation-error';
+import { SUPPORTED_VIZ_PROPERTIES } from '../constants/viz';
 
 /**
  * @namespace Features
@@ -98,7 +98,7 @@ export default class Feature {
     }
 
     _defineVizProperties () {
-        VIZ_PROPERTIES.forEach((property) => {
+        SUPPORTED_VIZ_PROPERTIES.forEach((property) => {
             this[property] = this._buildFeatureVizProperty(property);
         });
     }
@@ -130,7 +130,7 @@ export default class Feature {
 
     blendTo (newVizProperties, duration = 500) {
         Object.keys(newVizProperties).forEach((property) => {
-            if (!(VIZ_PROPERTIES.includes(property))) {
+            if (!(SUPPORTED_VIZ_PROPERTIES.includes(property))) {
                 throw new CartoValidationError(`${cvt.INCORRECT_VALUE} Property '${property}' is not a valid viz property`);
             }
             const newValue = newVizProperties[property];
@@ -139,7 +139,7 @@ export default class Feature {
     }
 
     reset (duration = 500) {
-        VIZ_PROPERTIES.forEach((property) => {
+        SUPPORTED_VIZ_PROPERTIES.forEach((property) => {
             this[property].reset(duration);
         });
 

--- a/src/interactivity/feature.js
+++ b/src/interactivity/feature.js
@@ -71,13 +71,15 @@ import { SUPPORTED_VIZ_PROPERTIES } from '../constants/viz';
  * @typedef {Object} Feature
  * @property {number} id - Unique identification code
  * @property {FeatureVizProperty} color
- * @property {FeatureVizProperty} width
+ * @property {FeatureVizProperty} filter
+ * @property {FeatureVizProperty} order
+ * @property {FeatureVizProperty} resolution
  * @property {FeatureVizProperty} strokeColor
  * @property {FeatureVizProperty} strokeWidth
  * @property {FeatureVizProperty} symbol
  * @property {FeatureVizProperty} symbolPlacement
- * @property {FeatureVizProperty} filter
  * @property {FeatureVizProperty} transform
+ * @property {FeatureVizProperty} width
  * @property {FeatureVizProperty[]} variables - Declared variables in the viz object
  * @property {function} blendTo - Blend custom feature vizs by fading in `duration` milliseconds
  * @property {function} reset - Reset custom feature vizs by fading out `duration` milliseconds, where `duration` is the first parameter to reset

--- a/src/interactivity/lightweightFeature.js
+++ b/src/interactivity/lightweightFeature.js
@@ -1,6 +1,6 @@
-import VIZ_PROPERTIES from '../renderer/viz/utils/properties';
 import { generateBlenderFunction, generateResetFunction } from './blendUtils';
 import CartoValidationError, { CartoValidationTypes as cvt } from '../errors/carto-validation-error';
+import { SUPPORTED_VIZ_PROPERTIES } from '../constants/viz';
 
 /**
  * Generate a lightweight Feature-like class
@@ -41,7 +41,7 @@ function _defineIdProperty (targetObject, renderLayer) {
 }
 
 function _defineVizProperties (targetObject, renderLayer) {
-    VIZ_PROPERTIES.forEach(prop => {
+    SUPPORTED_VIZ_PROPERTIES.forEach(prop => {
         _createLightweightFeatureVizProperty(targetObject, renderLayer, prop);
     });
 }
@@ -113,7 +113,7 @@ function _defineRootBlendToMethod (targetObject) {
         get: function () {
             const blendTo = (newVizProperties, duration = 500) => {
                 Object.keys(newVizProperties).forEach((property) => {
-                    if (!(VIZ_PROPERTIES.includes(property))) {
+                    if (!(SUPPORTED_VIZ_PROPERTIES.includes(property))) {
                         throw new CartoValidationError(`${cvt.INCORRECT_VALUE} Property '${property}' is not a valid viz property`);
                     }
                     const newValue = newVizProperties[property];
@@ -129,7 +129,7 @@ function _defineRootResetMethod (targetObject) {
     Object.defineProperty(targetObject, 'reset', {
         get: function () {
             const reset = (duration = 500) => {
-                VIZ_PROPERTIES.forEach((property) => {
+                SUPPORTED_VIZ_PROPERTIES.forEach((property) => {
                     this[property].reset(duration);
                 });
 

--- a/src/interactivity/lightweightFeature.js
+++ b/src/interactivity/lightweightFeature.js
@@ -41,8 +41,8 @@ function _defineIdProperty (targetObject, renderLayer) {
 }
 
 function _defineVizProperties (targetObject, renderLayer) {
-    SUPPORTED_VIZ_PROPERTIES.forEach(prop => {
-        _createLightweightFeatureVizProperty(targetObject, renderLayer, prop);
+    SUPPORTED_VIZ_PROPERTIES.forEach(property => {
+        _createLightweightFeatureVizProperty(targetObject, renderLayer, property);
     });
 }
 
@@ -132,7 +132,6 @@ function _defineRootResetMethod (targetObject) {
                 SUPPORTED_VIZ_PROPERTIES.forEach((property) => {
                     this[property].reset(duration);
                 });
-
                 for (let key in this.variables) {
                     this.variables[key].reset(duration);
                 }

--- a/src/renderer/viz/expressions/ordering.js
+++ b/src/renderer/viz/expressions/ordering.js
@@ -37,6 +37,11 @@ export class Asc extends BaseExpression {
         super({ by });
         this.type = 'orderer';
     }
+
+    eval () {
+        return 'asc';
+    }
+
     _bindMetadata (metadata) {
         super._bindMetadata(metadata);
         checkInstance('asc', 'by', 0, Width, this.by);
@@ -79,6 +84,11 @@ export class Desc extends BaseExpression {
         super({ by });
         this.type = 'orderer';
     }
+
+    eval () {
+        return 'desc';
+    }
+
     _bindMetadata (metadata) {
         super._bindMetadata(metadata);
         checkInstance('desc', 'by', 0, Width, this.by);
@@ -112,6 +122,10 @@ export class NoOrder extends BaseExpression {
 
         super({});
         this.type = 'orderer';
+    }
+
+    eval () {
+        return 'noOrder';
     }
 }
 

--- a/src/renderer/viz/expressions/viewportFeatures.js
+++ b/src/renderer/viz/expressions/viewportFeatures.js
@@ -93,6 +93,7 @@ export default class ViewportFeatures extends BaseExpression {
             const propertyNames = this._requiredProperties.map((p) => {
                 return { property: p.propertyName, variable: p._variableName };
             });
+
             this._FeatureProxy = genLightweightFeatureClass(propertyNames, renderLayer);
         }
         this.expr = [];

--- a/src/renderer/viz/utils/properties.js
+++ b/src/renderer/viz/utils/properties.js
@@ -1,2 +1,0 @@
-const VIZ_PROPERTIES = ['color', 'width', 'strokeColor', 'strokeWidth', 'symbol', 'symbolPlacement', 'filter', 'transform'];
-export default VIZ_PROPERTIES;

--- a/test/integration/user/test/viewportFeatures.test.js
+++ b/test/integration/user/test/viewportFeatures.test.js
@@ -1,7 +1,7 @@
 import carto from '../../../../src';
 import * as util from '../../util';
-import VIZ_PROPERTIES from '../../../../src/renderer/viz/utils/properties';
 import { CLUSTER_FEATURE_COUNT } from '../../../../src/renderer/schema';
+import { SUPPORTED_VIZ_PROPERTIES } from '../../../../src/constants/viz';
 
 const feature1 = {
     type: 'Feature',
@@ -198,7 +198,7 @@ describe('viewportFeatures', () => {
 
             // 2. and featureVizProperties / variables are available
             featureList.forEach(feature => {
-                VIZ_PROPERTIES.forEach(propertyName => {
+                SUPPORTED_VIZ_PROPERTIES.forEach(propertyName => {
                     expect(feature[propertyName]).toBeTruthy();
                 });
                 expect(feature['variables']).toBeTruthy();

--- a/test/unit/viz.test.js
+++ b/test/unit/viz.test.js
@@ -99,7 +99,7 @@ describe('api/viz', () => {
                 };
                 expect(function () {
                     new Viz(vizSpec);
-                }).toThrowError(CartoValidationError, cvt.INCORRECT_VALUE + ' \'resolution\' must be greater than 0.');
+                }).toThrowError(CartoValidationError, cvt.INCORRECT_VALUE + ' \'resolution\' is 0, must be greater than 0.');
             });
 
             it('should throw an error when resolution is too big', () => {
@@ -108,7 +108,7 @@ describe('api/viz', () => {
                 };
                 expect(function () {
                     new Viz(vizSpec);
-                }).toThrowError(CartoValidationError, cvt.INCORRECT_VALUE + ' \'resolution\' must be less than 256.');
+                }).toThrowError(CartoValidationError, cvt.INCORRECT_VALUE + ' \'resolution\' is 10000, must be lower than 256.');
             });
 
             it('should throw an error when color is not a valid expression', () => {
@@ -231,8 +231,8 @@ describe('api/viz', () => {
                 done();
                 return Promise.resolve(null);
             });
-            viz.resolution = 8;
-            expect(viz.resolution).toEqual(8);
+            viz.resolution = s.number(8);
+            expect(viz.resolution.eval()).toEqual(8);
         });
     });
 

--- a/test/unit/viz.test.js
+++ b/test/unit/viz.test.js
@@ -374,4 +374,34 @@ describe('api/viz', () => {
             `)).toThrowError('Viz contains a circular dependency');
         });
     });
+
+    describe('toString', () => {
+        it('should be able to get the stringified viz', () => {
+            const vizString = `
+                @input: $wind_speed
+                @buckets: 5
+                @palette: reverse(sunset)
+                color: ramp(globalQuantiles(@input, @buckets), @palette)
+                width: 10
+                strokeColor: ramp($wind_speed, Prism)
+            `;
+
+            const viz = new Viz(vizString);
+            const actual = viz.toString().replace(/\s/g, '');
+            const expected = `
+                color: ramp(globalQuantiles($wind_speed,5), reverse(Sunset))
+                strokeColor: ramp($wind_speed,Prism)
+                width:10 
+                strokeWidth: 0
+                filter:1
+                order:noOrder()
+                symbol:svg()
+                symbolPlacement:placement(0,1)
+                @input:$wind_speed,
+                @buckets:5,
+                @palette:reverse(Sunset)
+            `.replace(/\s/g, '');
+            expect(expected).toEqual(actual);
+        });
+    });
 });


### PR DESCRIPTION
This PR:

- fixes `viz.toString` method
- uses a common constant for the supported viz properties
- uses resolution property as a _number expression_