### PR TITLE
Fix `ramp` when evaluating a numeric property using `linear`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix regression in `toString` Viz method
 - Fix variables for aggregated values
 - Fix nesting `top` expression in histogram expressions
+- Fix `ramp` when evaluating a numeric property using `linear`
 
 ## [1.1.1] - 2019-01-16
 

--- a/src/renderer/viz/expressions/RampGeneric.js
+++ b/src/renderer/viz/expressions/RampGeneric.js
@@ -1,4 +1,4 @@
-import { checkType, mix, fract } from './utils';
+import { checkType, mix, fract, clamp } from './utils';
 
 import Property from './basic/property';
 import Linear from './linear';
@@ -61,9 +61,12 @@ export default class RampGeneric extends Base {
         const maxValues = paletteValues.length - 1;
         const min = Math.floor(input * maxValues);
         const max = Math.ceil(input * maxValues);
+
+        const clampMin = clamp(min, 0, maxValues);
+        const clampMax = clamp(max, 0, maxValues);
         const m = fract(input * maxValues);
 
-        return mix(paletteValues[min], paletteValues[max], m);
+        return mix(paletteValues[clampMin], paletteValues[clampMax], m);
     }
 
     getLegendData (options) {

--- a/test/unit/renderer/viz/expressions/ramp.test.js
+++ b/test/unit/renderer/viz/expressions/ramp.test.js
@@ -95,6 +95,44 @@ describe('src/renderer/viz/expressions/ramp', () => {
                 });
             });
         });
+
+        describe('when palettes are numbers', () => {
+            const METADATA = new Metadata({
+                properties: {
+                    price: { type: 'number', min: 1, max: 10 }
+                },
+                sample: [
+                    { price: 1 },
+                    { price: 2 },
+                    { price: 3 },
+                    { price: 4 },
+                    { price: 5 },
+                    { price: 6 },
+                    { price: 7 },
+                    { price: 8 },
+                    { price: 9 },
+                    { price: 10 }
+                ]
+            });
+            describe('and values are numeric', () => {
+                it('should get the correct values, when property is inside of mapping interval', () => {
+                    const r = ramp(linear(property('price'), 1, 10), [8, 32]);
+                    // const r = ramp(property('price'), [8, 32]); // same as previous
+                    r._bindMetadata(METADATA);
+
+                    expect(r.eval({ price: 1 })).toEqual(8);
+                    expect(r.eval({ price: 10 })).toEqual(32);
+                });
+
+                it('should get the correct (clamped) values, even when property is out of mapping interval', () => {
+                    const r = ramp(linear(property('price'), 1, 5), [8, 32]);
+                    r._bindMetadata(METADATA);
+
+                    expect(r.eval({ price: 0 })).toEqual(8);
+                    expect(r.eval({ price: 10 })).toEqual(32);
+                });
+            });
+        });
     });
 
     describe('.eval with buckets', () => {


### PR DESCRIPTION
### Fixes  #1270 

The problem arises when evaluating a feature inside a linear expression where the limits don't include the value of the feature. For example, using `width: ramp(linear($price, 0, 40), [8, 32])` and then trying to eval a feature with a price of 50.  

If the whole range of values is considered inside the linear, that  doesn't create a problem, such as when using: `width: ramp($price, [8, 32])` or the equivalent `width: ramp(linear($price, 8, 10005), [8, 32]) // with globalMin and globalMax`

The 'unexpected' value caused an incorrect evaluation in the ramp, such as if it were a 'color' not a 'number', thus causing the error