### PR TITLE
Revert path filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.2.0] - 2019-03-20
+## [1.2.2] - 2019-03-21
 
 ### Added
 - Allow the use of variables for all classifiers: `globalQuantiles`, `globalEqIntervals`, `globalStandardDev`, `viewportQuantiles`, `viewportEqIntervals` and `viewportStandardDev`

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "BSD-3-Clause",
   "files": [
     "src",
-    "dist/carto-vl*.*"
+    "dist"
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",


### PR DESCRIPTION
Context:
---

When publishing to `npm`, the `carto-vl.min.js` file was not updated to the registry. It seems to be a problem with `npm`, because, when running `npm pack`, the file is added correctly.

We've already sent this issue to npm support.

Meanwhile, we've decided to upload the `dist` file as we were doing in the past to avoid having this problem.