### PR TITLE
update Classification Variables example to percent + rounded attributes

### DIFF
--- a/examples/advanced/classification-variables.html
+++ b/examples/advanced/classification-variables.html
@@ -64,10 +64,10 @@
             <li>
               <label>1. Select the input field</label>
               <select id="valueSelector">
-                <option value="trump" selected>Trump</option>
-                <option value="clinton">Clinton</option>
-                <option value="pct_dem">Percent Democr.</option>
-                <option value="pct_higher_ed">Percent Higher Education</option>
+                <option value="pct_trump" selected>Percent Trump</option>
+                <option value="pct_clinton">Percent Clinton</option>
+                <option value="pct_dem_r">Percent Democrat</option>
+                <option value="pct_higher_edu">Percent Higher Education</option>
               </select>
             </li>
             <li>
@@ -241,7 +241,7 @@
     // Define layer
     const source = new carto.source.Dataset('higher_edu_by_county');
     let initialSettings = {
-      input: 'trump',
+      input: 'pct_trump',
       buckets: 3,
       palette: 'Burg',
       opacity: 0.8


### PR DESCRIPTION
@VictorVelarde @elenatorro 

Please merge if all is ok.

This is an update for this example:
https://carto.com/developers/carto-vl/examples/#example-interactive-classification

updates in this PR:
- [x] Just realized that we are mapping totals for the Trump and Clinton choropleth maps. To fix, I added some additional fields to the table with rounded percents and updated the map to use new `pct_trump` and `pct_clinton` columns
- [x] Since we have interactivity showing values, for nicer looking popup numbers, I rounded the `pct_dem` field to a new output `pct_dem_r`
- [x] Similarly, rounded the `pct_higher_ed` field to a new output `pct_higher_edu` and update the field in the example

I didn't overwrite existing fields in case any other example (on the dev center or not) was utilizing this table.