### PR TITLE
Add types to errors

### DIFF
--- a/docs/guides/06-aggregation-and-data-summaries.md
+++ b/docs/guides/06-aggregation-and-data-summaries.md
@@ -275,7 +275,7 @@ width: sqrt(clusterSum($pop_max) / 5000) + 5
 
 In the previous expression, the aggregated population in the cluster is used to determine the circle size (helped with some maths to manually adjust values to pixels).
 
-But if you just replace that property in the current `viz` configuration, you'll get a `CartoValidationError: [Incorrect value]: Incompatible combination of cluster aggregation usages`, because you are mixing aggregated and unaggregated usages of the same property *pop_max*. So it is better if you just simplify the viz.
+But if you just replace that property in the current `viz` configuration, you'll get a `CartoValidationError: [Incorrect value] Incompatible combination of cluster aggregation usages`, because you are mixing aggregated and unaggregated usages of the same property *pop_max*. So it is better if you just simplify the viz.
 
 Change your `viz` code to this:
 ```js

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -4,7 +4,7 @@ import Viz from './Viz';
 import SourceBase from './sources/Base';
 import Renderer from './renderer/Renderer';
 import RenderLayer from './renderer/RenderLayer';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../src/errors/carto-validation-error';
 import CartoRuntimeError from '../src/errors/carto-runtime-error';
 
 import { cubic } from './renderer/viz/expressions';
@@ -558,34 +558,34 @@ export default class Layer {
 
     _checkId (id) {
         if (id === undefined) {
-            throw new CartoValidationError('\'id\'', cvt.MISSING_REQUIRED);
+            throw new CartoValidationError('\'id\'', CartoValidationTypes.MISSING_REQUIRED);
         }
         if (!util.isString(id)) {
-            throw new CartoValidationError('\'id\' property must be a string.', cvt.INCORRECT_TYPE);
+            throw new CartoValidationError('\'id\' property must be a string.', CartoValidationTypes.INCORRECT_TYPE);
         }
         if (id === '') {
-            throw new CartoValidationError('\'id\' property must be not empty.', cvt.INCORRECT_VALUE);
+            throw new CartoValidationError('\'id\' property must be not empty.', CartoValidationTypes.INCORRECT_VALUE);
         }
     }
 
     _checkSource (source) {
         if (source === undefined) {
-            throw new CartoValidationError('\'source\'', cvt.MISSING_REQUIRED);
+            throw new CartoValidationError('\'source\'', CartoValidationTypes.MISSING_REQUIRED);
         }
         if (!(source instanceof SourceBase)) {
-            throw new CartoValidationError('The given object is not a valid \'source\'. See "carto.source".', cvt.INCORRECT_TYPE);
+            throw new CartoValidationError('The given object is not a valid \'source\'. See "carto.source".', CartoValidationTypes.INCORRECT_TYPE);
         }
     }
 
     _checkViz (viz) {
         if (util.isUndefined(viz)) {
-            throw new CartoValidationError('\'viz\'', cvt.MISSING_REQUIRED);
+            throw new CartoValidationError('\'viz\'', CartoValidationTypes.MISSING_REQUIRED);
         }
 
         if (!(viz instanceof Viz)) {
             throw new CartoValidationError(
                 'The given object is not a valid \'viz\'. See "carto.Viz".',
-                cvt.INCORRECT_TYPE
+                CartoValidationTypes.INCORRECT_TYPE
             );
         }
 
@@ -593,7 +593,7 @@ export default class Layer {
             // Not the required 1 on 1 relationship between layer & viz
             throw new CartoValidationError(
                 'The given Viz object is already bound to another layer. Vizs cannot be shared between different layers.',
-                cvt.INCORRECT_VALUE
+                CartoValidationTypes.INCORRECT_VALUE
             );
         }
     }

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -75,6 +75,8 @@ export default class Layer {
         this._initialViz = viz;
         this._renderWaiters = [];
         this._cameraMatrix = mat4.identity([]);
+
+        this.updateLayer = this.update(source, viz);
     }
 
     /**
@@ -95,16 +97,6 @@ export default class Layer {
         this._visible = visible;
         if (visible !== initial) {
             this._fire('updated', 'visibility change');
-        }
-    }
-
-    async init () {
-        if (this._initialSource && this._initialViz) {
-            try {
-                this._sourcePromise = await this.update(this._initialSource, this._initialViz);
-            } catch (err) {
-                throw err;
-            }
         }
     }
 
@@ -169,11 +161,11 @@ export default class Layer {
      */
     async addTo (map, beforeLayerID) {
         // Manage errors, whether they are an Evented Error or a common Error
-        try {
-            await this.init();
-        } catch (err) {
-            throw err;
-        }
+        // try {
+        //     await this.init();
+        // } catch (err) {
+        //     throw err;
+        // }
 
         try {
             map.once('error', (data) => {
@@ -376,7 +368,7 @@ export default class Layer {
      */
     async blendToViz (viz, ms = 400, interpolator = cubic) {
         this._checkViz(viz);
-        await this._sourcePromise;
+        await this.updateLayer;
 
         // It doesn't make sense to blendTo if a new request is required
         if (this._viz && !this._source.requiresNewMetadata(viz)) {

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -4,7 +4,7 @@ import Viz from './Viz';
 import SourceBase from './sources/Base';
 import Renderer from './renderer/Renderer';
 import RenderLayer from './renderer/RenderLayer';
-import CartoValidationError, { CartoValidationTypes } from '../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../src/errors/carto-validation-error';
 import CartoRuntimeError from '../src/errors/carto-runtime-error';
 
 import { cubic } from './renderer/viz/expressions';
@@ -558,34 +558,34 @@ export default class Layer {
 
     _checkId (id) {
         if (id === undefined) {
-            throw new CartoValidationError('\'id\'', CartoValidationTypes.MISSING_REQUIRED);
+            throw new CartoValidationError('\'id\'', CartoValidationErrorTypes.MISSING_REQUIRED);
         }
         if (!util.isString(id)) {
-            throw new CartoValidationError('\'id\' property must be a string.', CartoValidationTypes.INCORRECT_TYPE);
+            throw new CartoValidationError('\'id\' property must be a string.', CartoValidationErrorTypes.INCORRECT_TYPE);
         }
         if (id === '') {
-            throw new CartoValidationError('\'id\' property must be not empty.', CartoValidationTypes.INCORRECT_VALUE);
+            throw new CartoValidationError('\'id\' property must be not empty.', CartoValidationErrorTypes.INCORRECT_VALUE);
         }
     }
 
     _checkSource (source) {
         if (source === undefined) {
-            throw new CartoValidationError('\'source\'', CartoValidationTypes.MISSING_REQUIRED);
+            throw new CartoValidationError('\'source\'', CartoValidationErrorTypes.MISSING_REQUIRED);
         }
         if (!(source instanceof SourceBase)) {
-            throw new CartoValidationError('The given object is not a valid \'source\'. See "carto.source".', CartoValidationTypes.INCORRECT_TYPE);
+            throw new CartoValidationError('The given object is not a valid \'source\'. See "carto.source".', CartoValidationErrorTypes.INCORRECT_TYPE);
         }
     }
 
     _checkViz (viz) {
         if (util.isUndefined(viz)) {
-            throw new CartoValidationError('\'viz\'', CartoValidationTypes.MISSING_REQUIRED);
+            throw new CartoValidationError('\'viz\'', CartoValidationErrorTypes.MISSING_REQUIRED);
         }
 
         if (!(viz instanceof Viz)) {
             throw new CartoValidationError(
                 'The given object is not a valid \'viz\'. See "carto.Viz".',
-                CartoValidationTypes.INCORRECT_TYPE
+                CartoValidationErrorTypes.INCORRECT_TYPE
             );
         }
 
@@ -593,7 +593,7 @@ export default class Layer {
             // Not the required 1 on 1 relationship between layer & viz
             throw new CartoValidationError(
                 'The given Viz object is already bound to another layer. Vizs cannot be shared between different layers.',
-                CartoValidationTypes.INCORRECT_VALUE
+                CartoValidationErrorTypes.INCORRECT_VALUE
             );
         }
     }

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -558,35 +558,35 @@ export default class Layer {
 
     _checkId (id) {
         if (id === undefined) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, `'id'`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, '\'id\'');
         }
         if (!util.isString(id)) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, `'id' property must be a string.`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'id\' property must be a string.');
         }
         if (id === '') {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, `'id' property must be not empty.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, '\'id\' property must be not empty.');
         }
     }
 
     _checkSource (source) {
         if (source === undefined) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, `'source'`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, '\'source\'');
         }
         if (!(source instanceof SourceBase)) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, `The given object is not a valid 'source'. See "carto.source".`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, 'The given object is not a valid \'source\'. See "carto.source".');
         }
     }
 
     _checkViz (viz) {
         if (util.isUndefined(viz)) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, `'viz'`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, '\'viz\'');
         }
         if (!(viz instanceof Viz)) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, `The given object is not a valid 'viz'. See "carto.Viz".`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, 'The given object is not a valid \'viz\'. See "carto.Viz".');
         }
         if (viz._boundLayer && viz._boundLayer !== this) {
             // Not the required 1 on 1 relationship between layer & viz
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, `The given Viz object is already bound to another layer. Vizs cannot be shared between different layers.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, 'The given Viz object is already bound to another layer. Vizs cannot be shared between different layers.');
         }
     }
 

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -558,35 +558,43 @@ export default class Layer {
 
     _checkId (id) {
         if (id === undefined) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, '\'id\'');
+            throw new CartoValidationError('\'id\'', cvt.MISSING_REQUIRED);
         }
         if (!util.isString(id)) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'id\' property must be a string.');
+            throw new CartoValidationError('\'id\' property must be a string.', cvt.INCORRECT_TYPE);
         }
         if (id === '') {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, '\'id\' property must be not empty.');
+            throw new CartoValidationError('\'id\' property must be not empty.', cvt.INCORRECT_VALUE);
         }
     }
 
     _checkSource (source) {
         if (source === undefined) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, '\'source\'');
+            throw new CartoValidationError('\'source\'', cvt.MISSING_REQUIRED);
         }
         if (!(source instanceof SourceBase)) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, 'The given object is not a valid \'source\'. See "carto.source".');
+            throw new CartoValidationError('The given object is not a valid \'source\'. See "carto.source".', cvt.INCORRECT_TYPE);
         }
     }
 
     _checkViz (viz) {
         if (util.isUndefined(viz)) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, '\'viz\'');
+            throw new CartoValidationError('\'viz\'', cvt.MISSING_REQUIRED);
         }
+
         if (!(viz instanceof Viz)) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, 'The given object is not a valid \'viz\'. See "carto.Viz".');
+            throw new CartoValidationError(
+                'The given object is not a valid \'viz\'. See "carto.Viz".',
+                cvt.INCORRECT_TYPE
+            );
         }
+
         if (viz._boundLayer && viz._boundLayer !== this) {
             // Not the required 1 on 1 relationship between layer & viz
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, 'The given Viz object is already bound to another layer. Vizs cannot be shared between different layers.');
+            throw new CartoValidationError(
+                'The given Viz object is already bound to another layer. Vizs cannot be shared between different layers.',
+                cvt.INCORRECT_VALUE
+            );
         }
     }
 

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -76,7 +76,7 @@ export default class Layer {
         this._renderWaiters = [];
         this._cameraMatrix = mat4.identity([]);
 
-        this.updateLayer = this.update(source, viz);
+        this._updateLayer = this.update(source, viz);
     }
 
     /**
@@ -368,7 +368,7 @@ export default class Layer {
      */
     async blendToViz (viz, ms = 400, interpolator = cubic) {
         this._checkViz(viz);
-        await this.updateLayer;
+        await this._updateLayer;
 
         // It doesn't make sense to blendTo if a new request is required
         if (this._viz && !this._source.requiresNewMetadata(viz)) {

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -558,35 +558,35 @@ export default class Layer {
 
     _checkId (id) {
         if (id === undefined) {
-            throw new CartoValidationError(`${cvt.MISSING_REQUIRED} 'id'`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, `'id'`);
         }
         if (!util.isString(id)) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'id' property must be a string.`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, `'id' property must be a string.`);
         }
         if (id === '') {
-            throw new CartoValidationError(`${cvt.INCORRECT_VALUE} 'id' property must be not empty.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, `'id' property must be not empty.`);
         }
     }
 
     _checkSource (source) {
         if (source === undefined) {
-            throw new CartoValidationError(`${cvt.MISSING_REQUIRED} 'source'`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, `'source'`);
         }
         if (!(source instanceof SourceBase)) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} The given object is not a valid 'source'. See "carto.source".`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, `The given object is not a valid 'source'. See "carto.source".`);
         }
     }
 
     _checkViz (viz) {
         if (util.isUndefined(viz)) {
-            throw new CartoValidationError(`${cvt.MISSING_REQUIRED} 'viz'`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, `'viz'`);
         }
         if (!(viz instanceof Viz)) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} The given object is not a valid 'viz'. See "carto.Viz".`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, `The given object is not a valid 'viz'. See "carto.Viz".`);
         }
         if (viz._boundLayer && viz._boundLayer !== this) {
             // Not the required 1 on 1 relationship between layer & viz
-            throw new CartoValidationError(`${cvt.INCORRECT_VALUE} The given Viz object is already bound to another layer. Vizs cannot be shared between different layers.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, `The given Viz object is already bound to another layer. Vizs cannot be shared between different layers.`);
         }
     }
 

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -6,7 +6,7 @@ import BaseExpression from './renderer/viz/expressions/base';
 import { implicitCast, noOverrideColor } from './renderer/viz/expressions/utils';
 import { parseVizDefinition } from './renderer/viz/parser';
 import util from './utils/util';
-import CartoValidationError, { CartoValidationTypes } from '../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../src/errors/carto-validation-error';
 import CartoRuntimeError from '../src/errors/carto-runtime-error';
 import pointVertexShaderGLSL from './renderer/shaders/geometry/point/pointVertexShader.glsl';
 import pointFragmentShaderGLSL from './renderer/shaders/geometry/point/pointFragmentShader.glsl';
@@ -392,7 +392,7 @@ export default class Viz {
         }
         throw new CartoValidationError(
             'viz \'definition\' should be a vizSpec object or a valid viz string.',
-            CartoValidationTypes.INCORRECT_VALUE
+            CartoValidationErrorTypes.INCORRECT_VALUE
         );
     }
 
@@ -446,20 +446,20 @@ export default class Viz {
             if (resolution <= MIN_RESOLUTION) {
                 throw new CartoValidationError(
                     `'resolution' is ${resolution}, must be greater than ${MIN_RESOLUTION}.`,
-                    CartoValidationTypes.INCORRECT_VALUE
+                    CartoValidationErrorTypes.INCORRECT_VALUE
                 );
             }
 
             if (resolution >= MAX_RESOLUTION) {
                 throw new CartoValidationError(
                     `'resolution' is ${resolution}, must be lower than ${MAX_RESOLUTION}.`,
-                    CartoValidationTypes.INCORRECT_VALUE
+                    CartoValidationErrorTypes.INCORRECT_VALUE
                 );
             }
         } else {
             throw new CartoValidationError(
                 '\'resolution\' property must be a number.',
-                CartoValidationTypes.INCORRECT_TYPE
+                CartoValidationErrorTypes.INCORRECT_TYPE
             );
         }
     }
@@ -482,7 +482,7 @@ export default class Viz {
             if (!(vizSpec[parameter] instanceof BaseExpression)) {
                 throw new CartoValidationError(
                     `'${parameter}' parameter is not a valid viz Expresion.`,
-                    CartoValidationTypes.INCORRECT_TYPE);
+                    CartoValidationErrorTypes.INCORRECT_TYPE);
             }
         });
 
@@ -532,7 +532,7 @@ function checkVizPropertyTypes (viz) {
         if (currentType !== expected) {
             throw new CartoValidationError(
                 `Viz property '${property}': must be of type '${expected}' but it was of type '${currentType}'`,
-                CartoValidationTypes.INCORRECT_TYPE
+                CartoValidationErrorTypes.INCORRECT_TYPE
             );
         }
     });

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -390,7 +390,10 @@ export default class Viz {
         if (util.isString(definition)) {
             return this._setDefaults(parseVizDefinition(definition));
         }
-        throw new CartoValidationError(cvt.INCORRECT_VALUE, 'viz \'definition\' should be a vizSpec object or a valid viz string.');
+        throw new CartoValidationError(
+            'viz \'definition\' should be a vizSpec object or a valid viz string.',
+            cvt.INCORRECT_VALUE
+        );
     }
 
     /**
@@ -441,13 +444,23 @@ export default class Viz {
 
         if (util.isNumber(resolutionValue)) {
             if (resolution <= MIN_RESOLUTION) {
-                throw new CartoValidationError(cvt.INCORRECT_VALUE, `'resolution' is ${resolution}, must be greater than ${MIN_RESOLUTION}.`);
+                throw new CartoValidationError(
+                    `'resolution' is ${resolution}, must be greater than ${MIN_RESOLUTION}.`,
+                    cvt.INCORRECT_VALUE
+                );
             }
+
             if (resolution >= MAX_RESOLUTION) {
-                throw new CartoValidationError(cvt.INCORRECT_VALUE, `'resolution' is ${resolution}, must be lower than ${MAX_RESOLUTION}.`);
+                throw new CartoValidationError(
+                    `'resolution' is ${resolution}, must be lower than ${MAX_RESOLUTION}.`,
+                    cvt.INCORRECT_VALUE
+                );
             }
         } else {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'resolution\' property must be a number.');
+            throw new CartoValidationError(
+                '\'resolution\' property must be a number.',
+                cvt.INCORRECT_TYPE
+            );
         }
     }
 
@@ -467,7 +480,9 @@ export default class Viz {
 
         SUPPORTED_VIZ_PROPERTIES.forEach((parameter) => {
             if (!(vizSpec[parameter] instanceof BaseExpression)) {
-                throw new CartoValidationError(cvt.INCORRECT_TYPE, `'${parameter}' parameter is not a valid viz Expresion.`);
+                throw new CartoValidationError(
+                    `'${parameter}' parameter is not a valid viz Expresion.`,
+                    cvt.INCORRECT_TYPE);
             }
         });
 
@@ -516,7 +531,8 @@ function checkVizPropertyTypes (viz) {
         const expected = expectedTypePerProperty[property];
         if (currentType !== expected) {
             throw new CartoValidationError(
-                cvt.INCORRECT_TYPE, `Viz property '${property}': must be of type '${expected}' but it was of type '${currentType}'`
+                `Viz property '${property}': must be of type '${expected}' but it was of type '${currentType}'`,
+                cvt.INCORRECT_TYPE
             );
         }
     });

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -390,7 +390,7 @@ export default class Viz {
         if (util.isString(definition)) {
             return this._setDefaults(parseVizDefinition(definition));
         }
-        throw new CartoValidationError(cvt.INCORRECT_VALUE, `viz 'definition' should be a vizSpec object or a valid viz string.`);
+        throw new CartoValidationError(cvt.INCORRECT_VALUE, 'viz \'definition\' should be a vizSpec object or a valid viz string.');
     }
 
     /**
@@ -447,7 +447,7 @@ export default class Viz {
                 throw new CartoValidationError(cvt.INCORRECT_VALUE, `'resolution' is ${resolution}, must be lower than ${MAX_RESOLUTION}.`);
             }
         } else {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, `'resolution' property must be a number.`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'resolution\' property must be a number.');
         }
     }
 

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -390,7 +390,7 @@ export default class Viz {
         if (util.isString(definition)) {
             return this._setDefaults(parseVizDefinition(definition));
         }
-        throw new CartoValidationError(`${cvt.INCORRECT_VALUE} viz 'definition' should be a vizSpec object or a valid viz string.`);
+        throw new CartoValidationError(cvt.INCORRECT_VALUE, `viz 'definition' should be a vizSpec object or a valid viz string.`);
     }
 
     /**
@@ -441,13 +441,13 @@ export default class Viz {
 
         if (util.isNumber(resolutionValue)) {
             if (resolution <= MIN_RESOLUTION) {
-                throw new CartoValidationError(`${cvt.INCORRECT_VALUE} 'resolution' is ${resolution}, must be greater than ${MIN_RESOLUTION}.`);
+                throw new CartoValidationError(cvt.INCORRECT_VALUE, `'resolution' is ${resolution}, must be greater than ${MIN_RESOLUTION}.`);
             }
             if (resolution >= MAX_RESOLUTION) {
-                throw new CartoValidationError(`${cvt.INCORRECT_VALUE} 'resolution' is ${resolution}, must be lower than ${MAX_RESOLUTION}.`);
+                throw new CartoValidationError(cvt.INCORRECT_VALUE, `'resolution' is ${resolution}, must be lower than ${MAX_RESOLUTION}.`);
             }
         } else {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'resolution' property must be a number.`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, `'resolution' property must be a number.`);
         }
     }
 
@@ -467,7 +467,7 @@ export default class Viz {
 
         SUPPORTED_VIZ_PROPERTIES.forEach((parameter) => {
             if (!(vizSpec[parameter] instanceof BaseExpression)) {
-                throw new CartoValidationError(`${cvt.INCORRECT_TYPE} '${parameter}' parameter is not a valid viz Expresion.`);
+                throw new CartoValidationError(cvt.INCORRECT_TYPE, `'${parameter}' parameter is not a valid viz Expresion.`);
             }
         });
 
@@ -516,7 +516,7 @@ function checkVizPropertyTypes (viz) {
         const expected = expectedTypePerProperty[property];
         if (currentType !== expected) {
             throw new CartoValidationError(
-                `${cvt.INCORRECT_TYPE} Viz property '${property}': must be of type '${expected}' but it was of type '${currentType}'`
+                cvt.INCORRECT_TYPE, `Viz property '${property}': must be of type '${expected}' but it was of type '${currentType}'`
             );
         }
     });

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -6,7 +6,7 @@ import BaseExpression from './renderer/viz/expressions/base';
 import { implicitCast, noOverrideColor } from './renderer/viz/expressions/utils';
 import { parseVizDefinition } from './renderer/viz/parser';
 import util from './utils/util';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../src/errors/carto-validation-error';
 import CartoRuntimeError from '../src/errors/carto-runtime-error';
 import pointVertexShaderGLSL from './renderer/shaders/geometry/point/pointVertexShader.glsl';
 import pointFragmentShaderGLSL from './renderer/shaders/geometry/point/pointFragmentShader.glsl';
@@ -392,7 +392,7 @@ export default class Viz {
         }
         throw new CartoValidationError(
             'viz \'definition\' should be a vizSpec object or a valid viz string.',
-            cvt.INCORRECT_VALUE
+            CartoValidationTypes.INCORRECT_VALUE
         );
     }
 
@@ -446,20 +446,20 @@ export default class Viz {
             if (resolution <= MIN_RESOLUTION) {
                 throw new CartoValidationError(
                     `'resolution' is ${resolution}, must be greater than ${MIN_RESOLUTION}.`,
-                    cvt.INCORRECT_VALUE
+                    CartoValidationTypes.INCORRECT_VALUE
                 );
             }
 
             if (resolution >= MAX_RESOLUTION) {
                 throw new CartoValidationError(
                     `'resolution' is ${resolution}, must be lower than ${MAX_RESOLUTION}.`,
-                    cvt.INCORRECT_VALUE
+                    CartoValidationTypes.INCORRECT_VALUE
                 );
             }
         } else {
             throw new CartoValidationError(
                 '\'resolution\' property must be a number.',
-                cvt.INCORRECT_TYPE
+                CartoValidationTypes.INCORRECT_TYPE
             );
         }
     }
@@ -482,7 +482,7 @@ export default class Viz {
             if (!(vizSpec[parameter] instanceof BaseExpression)) {
                 throw new CartoValidationError(
                     `'${parameter}' parameter is not a valid viz Expresion.`,
-                    cvt.INCORRECT_TYPE);
+                    CartoValidationTypes.INCORRECT_TYPE);
             }
         });
 
@@ -532,7 +532,7 @@ function checkVizPropertyTypes (viz) {
         if (currentType !== expected) {
             throw new CartoValidationError(
                 `Viz property '${property}': must be of type '${expected}' but it was of type '${currentType}'`,
-                cvt.INCORRECT_TYPE
+                CartoValidationTypes.INCORRECT_TYPE
             );
         }
     });

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -79,7 +79,7 @@ export default class Windshaft {
             const aggregatedUsage = usages.some(x => x.type === aggregationTypes.AGGREGATED);
             const unAggregatedUsage = usages.some(x => x.type === aggregationTypes.UNAGGREGATED);
             if (aggregatedUsage && unAggregatedUsage) {
-                throw new CartoValidationError(`${cvt.INCORRECT_VALUE} Incompatible combination of cluster aggregation usages (${
+                throw new CartoValidationError(cvt.INCORRECT_VALUE, `Incompatible combination of cluster aggregation usages (${
                     JSON.stringify(usages.filter(x => x.type !== 'aggregated'))
                 }) with unaggregated usage for property '${propertyName}'`);
             }
@@ -205,7 +205,7 @@ export default class Windshaft {
     _checkLayerMeta (MNS) {
         if (!this._isAggregated()) {
             if (this._requiresAggregation(MNS)) {
-                throw new CartoMapsAPIError(`${cmt.NOT_SUPPORTED} Aggregation not supported for this dataset`);
+                throw new CartoMapsAPIError(cmt.NOT_SUPPORTED, `Aggregation not supported for this dataset`);
             }
         }
     }
@@ -324,11 +324,11 @@ export default class Windshaft {
         if (!response.ok) {
             if (response.status === 401) {
                 throw new CartoMapsAPIError(
-                    `${cmt.SECURITY} Unauthorized access to Maps API: invalid combination of user('${this._source._username}') and apiKey('${this._source._apiKey}')`
+                    cmt.SECURITY, `Unauthorized access to Maps API: invalid combination of user('${this._source._username}') and apiKey('${this._source._apiKey}')`
                 );
             } else if (response.status === 403) {
                 throw new CartoMapsAPIError(
-                    `${cmt.SECURITY} Unauthorized access to dataset: the provided apiKey('${this._source._apiKey}') doesn't provide access to the requested data`
+                    cmt.SECURITY, `Unauthorized access to dataset: the provided apiKey('${this._source._apiKey}') doesn't provide access to the requested data`
                 );
             }
             throw new CartoMapsAPIError(`SQL errors: ${JSON.stringify(layergroup.errors)}`);
@@ -369,7 +369,7 @@ export default class Windshaft {
                 const dimType = adaptColumnType(dimensionStats.type);
                 const { column, ...params } = dimension;
                 if (properties[column].dimension) {
-                    throw new CartoMapsAPIError(`${cmt.NOT_SUPPORTED} Multiple dimensions based on same column '${column}'.`);
+                    throw new CartoMapsAPIError(cmt.NOT_SUPPORTED, `Multiple dimensions based on same column '${column}'.`);
                 }
                 properties[column].dimension = {
                     propertyName: dimName,
@@ -423,7 +423,7 @@ function adaptGeometryType (type) {
         case 'ST_LineString':
             return GEOMETRY_TYPE.LINE;
         default:
-            throw new CartoMapsAPIError(`${cmt.NOT_SUPPORTED} Unimplemented geometry type '${type}'.`);
+            throw new CartoMapsAPIError(cmt.NOT_SUPPORTED, `Unimplemented geometry type '${type}'.`);
     }
 }
 

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -79,9 +79,11 @@ export default class Windshaft {
             const aggregatedUsage = usages.some(x => x.type === aggregationTypes.AGGREGATED);
             const unAggregatedUsage = usages.some(x => x.type === aggregationTypes.UNAGGREGATED);
             if (aggregatedUsage && unAggregatedUsage) {
-                throw new CartoValidationError(cvt.INCORRECT_VALUE, `Incompatible combination of cluster aggregation usages (${
-                    JSON.stringify(usages.filter(x => x.type !== 'aggregated'))
-                }) with unaggregated usage for property '${propertyName}'`);
+                const aggregationUssages = JSON.stringify(usages.filter(x => x.type !== 'aggregated'));
+                throw new CartoValidationError(
+                    `Incompatible combination of cluster aggregation usages (${aggregationUssages}) with unaggregated usage for property '${propertyName}'`,
+                    cvt.INCORRECT_VALUE
+                );
             }
         });
     }
@@ -205,7 +207,7 @@ export default class Windshaft {
     _checkLayerMeta (MNS) {
         if (!this._isAggregated()) {
             if (this._requiresAggregation(MNS)) {
-                throw new CartoMapsAPIError(cmt.NOT_SUPPORTED, 'Aggregation not supported for this dataset');
+                throw new CartoMapsAPIError('Aggregation not supported for this dataset', cmt.NOT_SUPPORTED);
             }
         }
     }
@@ -324,11 +326,13 @@ export default class Windshaft {
         if (!response.ok) {
             if (response.status === 401) {
                 throw new CartoMapsAPIError(
-                    cmt.SECURITY, `Unauthorized access to Maps API: invalid combination of user('${this._source._username}') and apiKey('${this._source._apiKey}')`
+                    `Unauthorized access to Maps API: invalid combination of user('${this._source._username}') and apiKey('${this._source._apiKey}')`,
+                    cmt.SECURITY
                 );
             } else if (response.status === 403) {
                 throw new CartoMapsAPIError(
-                    cmt.SECURITY, `Unauthorized access to dataset: the provided apiKey('${this._source._apiKey}') doesn't provide access to the requested data`
+                    `Unauthorized access to dataset: the provided apiKey('${this._source._apiKey}') doesn't provide access to the requested data`,
+                    cmt.SECURITY
                 );
             }
             throw new CartoMapsAPIError(`SQL errors: ${JSON.stringify(layergroup.errors)}`);
@@ -369,7 +373,7 @@ export default class Windshaft {
                 const dimType = adaptColumnType(dimensionStats.type);
                 const { column, ...params } = dimension;
                 if (properties[column].dimension) {
-                    throw new CartoMapsAPIError(cmt.NOT_SUPPORTED, `Multiple dimensions based on same column '${column}'.`);
+                    throw new CartoMapsAPIError(`Multiple dimensions based on same column '${column}'.`, cmt.NOT_SUPPORTED);
                 }
                 properties[column].dimension = {
                     propertyName: dimName,
@@ -423,7 +427,7 @@ function adaptGeometryType (type) {
         case 'ST_LineString':
             return GEOMETRY_TYPE.LINE;
         default:
-            throw new CartoMapsAPIError(cmt.NOT_SUPPORTED, `Unimplemented geometry type '${type}'.`);
+            throw new CartoMapsAPIError(`Unimplemented geometry type '${type}'.`, cmt.NOT_SUPPORTED);
     }
 }
 

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -335,7 +335,7 @@ export default class Windshaft {
                     CartoMapsAPIErrorTypes.SECURITY
                 );
             }
-            throw new CartoMapsAPIError(`SQL errors: ${JSON.stringify(layergroup.errors)}`);
+            throw new CartoMapsAPIError(`${JSON.stringify(layergroup.errors)}`, CartoMapsAPIErrorTypes.SQL);
         }
         return {
             urlTemplates: layergroup.metadata.tilejson.vector.tiles,

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -7,7 +7,6 @@ import CartoValidationError, { CartoValidationErrorTypes } from '../errors/carto
 import CartoMapsAPIError, { CartoMapsAPIErrorTypes } from '../errors/carto-maps-api-error';
 import { GEOMETRY_TYPE } from '../utils/geometry';
 import { CLUSTER_FEATURE_COUNT, aggregationTypes } from '../constants/metadata';
-import { decode } from 'punycode';
 
 const SAMPLE_ROWS = 1000;
 const MIN_FILTERING = 2000000;

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -4,7 +4,7 @@ import Metadata from './WindshaftMetadata';
 import schema from '../renderer/schema';
 import * as windshaftFiltering from './windshaft-filtering';
 import CartoValidationError, { CartoValidationErrorTypes } from '../errors/carto-validation-error';
-import CartoMapsAPIError, { CartoValidationErrorTypes } from '../errors/carto-maps-api-error';
+import CartoMapsAPIError, { CartoMapsAPIErrorTypes } from '../errors/carto-maps-api-error';
 import { GEOMETRY_TYPE } from '../utils/geometry';
 import { CLUSTER_FEATURE_COUNT, aggregationTypes } from '../constants/metadata';
 
@@ -207,7 +207,7 @@ export default class Windshaft {
     _checkLayerMeta (MNS) {
         if (!this._isAggregated()) {
             if (this._requiresAggregation(MNS)) {
-                throw new CartoMapsAPIError('Aggregation not supported for this dataset', CartoValidationErrorTypes.NOT_SUPPORTED);
+                throw new CartoMapsAPIError('Aggregation not supported for this dataset', CartoMapsAPIErrorTypes.NOT_SUPPORTED);
             }
         }
     }
@@ -327,12 +327,12 @@ export default class Windshaft {
             if (response.status === 401) {
                 throw new CartoMapsAPIError(
                     `Unauthorized access to Maps API: invalid combination of user('${this._source._username}') and apiKey('${this._source._apiKey}')`,
-                    CartoValidationErrorTypes.SECURITY
+                    CartoMapsAPIErrorTypes.SECURITY
                 );
             } else if (response.status === 403) {
                 throw new CartoMapsAPIError(
                     `Unauthorized access to dataset: the provided apiKey('${this._source._apiKey}') doesn't provide access to the requested data`,
-                    CartoValidationErrorTypes.SECURITY
+                    CartoMapsAPIErrorTypes.SECURITY
                 );
             }
             throw new CartoMapsAPIError(`SQL errors: ${JSON.stringify(layergroup.errors)}`);
@@ -373,7 +373,7 @@ export default class Windshaft {
                 const dimType = adaptColumnType(dimensionStats.type);
                 const { column, ...params } = dimension;
                 if (properties[column].dimension) {
-                    throw new CartoMapsAPIError(`Multiple dimensions based on same column '${column}'.`, CartoValidationErrorTypes.NOT_SUPPORTED);
+                    throw new CartoMapsAPIError(`Multiple dimensions based on same column '${column}'.`, CartoMapsAPIErrorTypes.NOT_SUPPORTED);
                 }
                 properties[column].dimension = {
                     propertyName: dimName,
@@ -427,7 +427,7 @@ function adaptGeometryType (type) {
         case 'ST_LineString':
             return GEOMETRY_TYPE.LINE;
         default:
-            throw new CartoMapsAPIError(`Unimplemented geometry type '${type}'.`, CartoValidationErrorTypes.NOT_SUPPORTED);
+            throw new CartoMapsAPIError(`Unimplemented geometry type '${type}'.`, CartoMapsAPIErrorTypes.NOT_SUPPORTED);
     }
 }
 

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -3,8 +3,8 @@ import MVT from '../sources/MVT';
 import Metadata from './WindshaftMetadata';
 import schema from '../renderer/schema';
 import * as windshaftFiltering from './windshaft-filtering';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../errors/carto-validation-error';
-import CartoMapsAPIError, { CartoMapsAPITypes as cmt } from '../errors/carto-maps-api-error';
+import CartoValidationError, { CartoValidationTypes } from '../errors/carto-validation-error';
+import CartoMapsAPIError, { CartoMapsAPITypes } from '../errors/carto-maps-api-error';
 import { GEOMETRY_TYPE } from '../utils/geometry';
 import { CLUSTER_FEATURE_COUNT, aggregationTypes } from '../constants/metadata';
 
@@ -82,7 +82,7 @@ export default class Windshaft {
                 const aggregationUssages = JSON.stringify(usages.filter(x => x.type !== 'aggregated'));
                 throw new CartoValidationError(
                     `Incompatible combination of cluster aggregation usages (${aggregationUssages}) with unaggregated usage for property '${propertyName}'`,
-                    cvt.INCORRECT_VALUE
+                    CartoValidationTypes.INCORRECT_VALUE
                 );
             }
         });
@@ -207,7 +207,7 @@ export default class Windshaft {
     _checkLayerMeta (MNS) {
         if (!this._isAggregated()) {
             if (this._requiresAggregation(MNS)) {
-                throw new CartoMapsAPIError('Aggregation not supported for this dataset', cmt.NOT_SUPPORTED);
+                throw new CartoMapsAPIError('Aggregation not supported for this dataset', CartoMapsAPITypes.NOT_SUPPORTED);
             }
         }
     }
@@ -327,12 +327,12 @@ export default class Windshaft {
             if (response.status === 401) {
                 throw new CartoMapsAPIError(
                     `Unauthorized access to Maps API: invalid combination of user('${this._source._username}') and apiKey('${this._source._apiKey}')`,
-                    cmt.SECURITY
+                    CartoMapsAPITypes.SECURITY
                 );
             } else if (response.status === 403) {
                 throw new CartoMapsAPIError(
                     `Unauthorized access to dataset: the provided apiKey('${this._source._apiKey}') doesn't provide access to the requested data`,
-                    cmt.SECURITY
+                    CartoMapsAPITypes.SECURITY
                 );
             }
             throw new CartoMapsAPIError(`SQL errors: ${JSON.stringify(layergroup.errors)}`);
@@ -373,7 +373,7 @@ export default class Windshaft {
                 const dimType = adaptColumnType(dimensionStats.type);
                 const { column, ...params } = dimension;
                 if (properties[column].dimension) {
-                    throw new CartoMapsAPIError(`Multiple dimensions based on same column '${column}'.`, cmt.NOT_SUPPORTED);
+                    throw new CartoMapsAPIError(`Multiple dimensions based on same column '${column}'.`, CartoMapsAPITypes.NOT_SUPPORTED);
                 }
                 properties[column].dimension = {
                     propertyName: dimName,
@@ -427,7 +427,7 @@ function adaptGeometryType (type) {
         case 'ST_LineString':
             return GEOMETRY_TYPE.LINE;
         default:
-            throw new CartoMapsAPIError(`Unimplemented geometry type '${type}'.`, cmt.NOT_SUPPORTED);
+            throw new CartoMapsAPIError(`Unimplemented geometry type '${type}'.`, CartoMapsAPITypes.NOT_SUPPORTED);
     }
 }
 

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -7,6 +7,7 @@ import CartoValidationError, { CartoValidationErrorTypes } from '../errors/carto
 import CartoMapsAPIError, { CartoMapsAPIErrorTypes } from '../errors/carto-maps-api-error';
 import { GEOMETRY_TYPE } from '../utils/geometry';
 import { CLUSTER_FEATURE_COUNT, aggregationTypes } from '../constants/metadata';
+import { decode } from 'punycode';
 
 const SAMPLE_ROWS = 1000;
 const MIN_FILTERING = 2000000;
@@ -335,8 +336,10 @@ export default class Windshaft {
                     CartoMapsAPIErrorTypes.SECURITY
                 );
             }
+
             throw new CartoMapsAPIError(`${JSON.stringify(layergroup.errors)}`, CartoMapsAPIErrorTypes.SQL);
         }
+
         return {
             urlTemplates: layergroup.metadata.tilejson.vector.tiles,
             metadata: overrideMetadata || this._adaptMetadata(layergroup.metadata.layers[0].meta, agg, MNS)

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -3,8 +3,8 @@ import MVT from '../sources/MVT';
 import Metadata from './WindshaftMetadata';
 import schema from '../renderer/schema';
 import * as windshaftFiltering from './windshaft-filtering';
-import CartoValidationError, { CartoValidationTypes } from '../errors/carto-validation-error';
-import CartoMapsAPIError, { CartoMapsAPITypes } from '../errors/carto-maps-api-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../errors/carto-validation-error';
+import CartoMapsAPIError, { CartoValidationErrorTypes } from '../errors/carto-maps-api-error';
 import { GEOMETRY_TYPE } from '../utils/geometry';
 import { CLUSTER_FEATURE_COUNT, aggregationTypes } from '../constants/metadata';
 
@@ -82,7 +82,7 @@ export default class Windshaft {
                 const aggregationUssages = JSON.stringify(usages.filter(x => x.type !== 'aggregated'));
                 throw new CartoValidationError(
                     `Incompatible combination of cluster aggregation usages (${aggregationUssages}) with unaggregated usage for property '${propertyName}'`,
-                    CartoValidationTypes.INCORRECT_VALUE
+                    CartoValidationErrorTypes.INCORRECT_VALUE
                 );
             }
         });
@@ -207,7 +207,7 @@ export default class Windshaft {
     _checkLayerMeta (MNS) {
         if (!this._isAggregated()) {
             if (this._requiresAggregation(MNS)) {
-                throw new CartoMapsAPIError('Aggregation not supported for this dataset', CartoMapsAPITypes.NOT_SUPPORTED);
+                throw new CartoMapsAPIError('Aggregation not supported for this dataset', CartoValidationErrorTypes.NOT_SUPPORTED);
             }
         }
     }
@@ -327,12 +327,12 @@ export default class Windshaft {
             if (response.status === 401) {
                 throw new CartoMapsAPIError(
                     `Unauthorized access to Maps API: invalid combination of user('${this._source._username}') and apiKey('${this._source._apiKey}')`,
-                    CartoMapsAPITypes.SECURITY
+                    CartoValidationErrorTypes.SECURITY
                 );
             } else if (response.status === 403) {
                 throw new CartoMapsAPIError(
                     `Unauthorized access to dataset: the provided apiKey('${this._source._apiKey}') doesn't provide access to the requested data`,
-                    CartoMapsAPITypes.SECURITY
+                    CartoValidationErrorTypes.SECURITY
                 );
             }
             throw new CartoMapsAPIError(`SQL errors: ${JSON.stringify(layergroup.errors)}`);
@@ -373,7 +373,7 @@ export default class Windshaft {
                 const dimType = adaptColumnType(dimensionStats.type);
                 const { column, ...params } = dimension;
                 if (properties[column].dimension) {
-                    throw new CartoMapsAPIError(`Multiple dimensions based on same column '${column}'.`, CartoMapsAPITypes.NOT_SUPPORTED);
+                    throw new CartoMapsAPIError(`Multiple dimensions based on same column '${column}'.`, CartoValidationErrorTypes.NOT_SUPPORTED);
                 }
                 properties[column].dimension = {
                     propertyName: dimName,
@@ -427,7 +427,7 @@ function adaptGeometryType (type) {
         case 'ST_LineString':
             return GEOMETRY_TYPE.LINE;
         default:
-            throw new CartoMapsAPIError(`Unimplemented geometry type '${type}'.`, CartoMapsAPITypes.NOT_SUPPORTED);
+            throw new CartoMapsAPIError(`Unimplemented geometry type '${type}'.`, CartoValidationErrorTypes.NOT_SUPPORTED);
     }
 }
 

--- a/src/client/windshaft.js
+++ b/src/client/windshaft.js
@@ -205,7 +205,7 @@ export default class Windshaft {
     _checkLayerMeta (MNS) {
         if (!this._isAggregated()) {
             if (this._requiresAggregation(MNS)) {
-                throw new CartoMapsAPIError(cmt.NOT_SUPPORTED, `Aggregation not supported for this dataset`);
+                throw new CartoMapsAPIError(cmt.NOT_SUPPORTED, 'Aggregation not supported for this dataset');
             }
         }
     }

--- a/src/codecs/index.js
+++ b/src/codecs/index.js
@@ -1,7 +1,7 @@
 import NumberCodec from './Number';
 import CategoryCodec from './Category';
 import DateCodec from './Date';
-import CartoRuntimeError, { CartoRuntimeTypes as runtimeErrors } from '../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../errors/carto-runtime-error';
 
 export default function codecFactory (metadata, type, propertyName) {
     switch (type) {
@@ -13,7 +13,7 @@ export default function codecFactory (metadata, type, propertyName) {
             return new DateCodec(metadata, propertyName);
         default:
             throw new CartoRuntimeError(
-                `${runtimeErrors.NOT_SUPPORTED} Feature property value of type '${type}' cannot be decoded.`
+                crt.NOT_SUPPORTED, `Feature property value of type '${type}' cannot be decoded.`
             );
     }
 }

--- a/src/codecs/index.js
+++ b/src/codecs/index.js
@@ -1,7 +1,7 @@
 import NumberCodec from './Number';
 import CategoryCodec from './Category';
 import DateCodec from './Date';
-import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeTypes } from '../errors/carto-runtime-error';
 
 export default function codecFactory (metadata, type, propertyName) {
     switch (type) {
@@ -14,7 +14,7 @@ export default function codecFactory (metadata, type, propertyName) {
         default:
             throw new CartoRuntimeError(
                 `Feature property value of type '${type}' cannot be decoded.`,
-                crt.NOT_SUPPORTED
+                CartoRuntimeTypes.NOT_SUPPORTED
             );
     }
 }

--- a/src/codecs/index.js
+++ b/src/codecs/index.js
@@ -1,7 +1,7 @@
 import NumberCodec from './Number';
 import CategoryCodec from './Category';
 import DateCodec from './Date';
-import CartoRuntimeError, { CartoRuntimeTypes } from '../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeErrorTypes } from '../errors/carto-runtime-error';
 
 export default function codecFactory (metadata, type, propertyName) {
     switch (type) {
@@ -14,7 +14,7 @@ export default function codecFactory (metadata, type, propertyName) {
         default:
             throw new CartoRuntimeError(
                 `Feature property value of type '${type}' cannot be decoded.`,
-                CartoRuntimeTypes.NOT_SUPPORTED
+                CartoRuntimeErrorTypes.NOT_SUPPORTED
             );
     }
 }

--- a/src/codecs/index.js
+++ b/src/codecs/index.js
@@ -13,7 +13,8 @@ export default function codecFactory (metadata, type, propertyName) {
             return new DateCodec(metadata, propertyName);
         default:
             throw new CartoRuntimeError(
-                crt.NOT_SUPPORTED, `Feature property value of type '${type}' cannot be decoded.`
+                `Feature property value of type '${type}' cannot be decoded.`,
+                crt.NOT_SUPPORTED
             );
     }
 }

--- a/src/codecs/mvt/Category.js
+++ b/src/codecs/mvt/Category.js
@@ -1,5 +1,5 @@
 import CategoryCodec from '../Category';
-import CartoRuntimeError, { CartoRuntimeTypes } from '../../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeErrorTypes } from '../../errors/carto-runtime-error';
 
 export default class MVTCategoryCodec extends CategoryCodec {
     sourceToInternal (metadata, propertyValue) {
@@ -11,7 +11,7 @@ export default class MVTCategoryCodec extends CategoryCodec {
             // For more general solutions we'd need to provide the source property name as an argument to this method.
             throw new CartoRuntimeError(
                 `MVT decoding error. Metadata property '${this._baseName}' is of type 'category' but the MVT tile contained a feature property of type '${propertyValueType}': '${propertyValue}'`,
-                CartoRuntimeTypes.MVT
+                CartoRuntimeErrorTypes.MVT
             );
         }
         return super.sourceToInternal(metadata, propertyValue);

--- a/src/codecs/mvt/Category.js
+++ b/src/codecs/mvt/Category.js
@@ -9,7 +9,10 @@ export default class MVTCategoryCodec extends CategoryCodec {
             // but for the generic MVT sources we don't support multiple source properties per base property (e.g. aggregations)
             // so it would suffice to keep the property name in the Codec class.
             // For more general solutions we'd need to provide the source property name as an argument to this method.
-            throw new CartoRuntimeError(crt.MVT, `MVT decoding error. Metadata property '${this._baseName}' is of type 'category' but the MVT tile contained a feature property of type '${propertyValueType}': '${propertyValue}'`);
+            throw new CartoRuntimeError(
+                `MVT decoding error. Metadata property '${this._baseName}' is of type 'category' but the MVT tile contained a feature property of type '${propertyValueType}': '${propertyValue}'`,
+                crt.MVT
+            );
         }
         return super.sourceToInternal(metadata, propertyValue);
     }

--- a/src/codecs/mvt/Category.js
+++ b/src/codecs/mvt/Category.js
@@ -1,5 +1,5 @@
 import CategoryCodec from '../Category';
-import CartoRuntimeError, { CartoRuntimeTypes as runtimeErrors } from '../../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../../errors/carto-runtime-error';
 
 export default class MVTCategoryCodec extends CategoryCodec {
     sourceToInternal (metadata, propertyValue) {
@@ -9,7 +9,7 @@ export default class MVTCategoryCodec extends CategoryCodec {
             // but for the generic MVT sources we don't support multiple source properties per base property (e.g. aggregations)
             // so it would suffice to keep the property name in the Codec class.
             // For more general solutions we'd need to provide the source property name as an argument to this method.
-            throw new CartoRuntimeError(`${runtimeErrors.MVT} MVT decoding error. Metadata property '${this._baseName}' is of type 'category' but the MVT tile contained a feature property of type '${propertyValueType}': '${propertyValue}'`);
+            throw new CartoRuntimeError(crt.MVT, `MVT decoding error. Metadata property '${this._baseName}' is of type 'category' but the MVT tile contained a feature property of type '${propertyValueType}': '${propertyValue}'`);
         }
         return super.sourceToInternal(metadata, propertyValue);
     }

--- a/src/codecs/mvt/Category.js
+++ b/src/codecs/mvt/Category.js
@@ -1,5 +1,5 @@
 import CategoryCodec from '../Category';
-import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeTypes } from '../../errors/carto-runtime-error';
 
 export default class MVTCategoryCodec extends CategoryCodec {
     sourceToInternal (metadata, propertyValue) {
@@ -11,7 +11,7 @@ export default class MVTCategoryCodec extends CategoryCodec {
             // For more general solutions we'd need to provide the source property name as an argument to this method.
             throw new CartoRuntimeError(
                 `MVT decoding error. Metadata property '${this._baseName}' is of type 'category' but the MVT tile contained a feature property of type '${propertyValueType}': '${propertyValue}'`,
-                crt.MVT
+                CartoRuntimeTypes.MVT
             );
         }
         return super.sourceToInternal(metadata, propertyValue);

--- a/src/codecs/mvt/Number.js
+++ b/src/codecs/mvt/Number.js
@@ -1,5 +1,5 @@
 import NumberCodec from '../Number';
-import CartoRuntimeError, { CartoRuntimeTypes } from '../../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeErrorTypes } from '../../errors/carto-runtime-error';
 
 export default class MVTNumberCodec extends NumberCodec {
     sourceToInternal (metadata, propertyValue) {
@@ -7,7 +7,7 @@ export default class MVTNumberCodec extends NumberCodec {
         if (propertyValue !== null && propertyValueType !== 'undefined' && propertyValueType !== 'number') {
             throw new CartoRuntimeError(
                 `MVT decoding error. Metadata property '${this._baseName}' is of type 'number' but the MVT tile contained a feature property of type '${propertyValueType}': '${propertyValue}'`,
-                CartoRuntimeTypes.MVT
+                CartoRuntimeErrorTypes.MVT
             );
         }
         return super.sourceToInternal(metadata, propertyValue);

--- a/src/codecs/mvt/Number.js
+++ b/src/codecs/mvt/Number.js
@@ -1,5 +1,5 @@
 import NumberCodec from '../Number';
-import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeTypes } from '../../errors/carto-runtime-error';
 
 export default class MVTNumberCodec extends NumberCodec {
     sourceToInternal (metadata, propertyValue) {
@@ -7,7 +7,7 @@ export default class MVTNumberCodec extends NumberCodec {
         if (propertyValue !== null && propertyValueType !== 'undefined' && propertyValueType !== 'number') {
             throw new CartoRuntimeError(
                 `MVT decoding error. Metadata property '${this._baseName}' is of type 'number' but the MVT tile contained a feature property of type '${propertyValueType}': '${propertyValue}'`,
-                crt.MVT
+                CartoRuntimeTypes.MVT
             );
         }
         return super.sourceToInternal(metadata, propertyValue);

--- a/src/codecs/mvt/Number.js
+++ b/src/codecs/mvt/Number.js
@@ -1,11 +1,11 @@
 import NumberCodec from '../Number';
-import CartoRuntimeError, { CartoRuntimeTypes as runtimeErrors } from '../../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../../errors/carto-runtime-error';
 
 export default class MVTNumberCodec extends NumberCodec {
     sourceToInternal (metadata, propertyValue) {
         const propertyValueType = typeof propertyValue;
         if (propertyValue !== null && propertyValueType !== 'undefined' && propertyValueType !== 'number') {
-            throw new CartoRuntimeError(`${runtimeErrors.MVT} MVT decoding error. Metadata property '${this._baseName}' is of type 'number' but the MVT tile contained a feature property of type '${propertyValueType}': '${propertyValue}'`);
+            throw new CartoRuntimeError(crt.MVT, `MVT decoding error. Metadata property '${this._baseName}' is of type 'number' but the MVT tile contained a feature property of type '${propertyValueType}': '${propertyValue}'`);
         }
         return super.sourceToInternal(metadata, propertyValue);
     }

--- a/src/codecs/mvt/Number.js
+++ b/src/codecs/mvt/Number.js
@@ -5,7 +5,10 @@ export default class MVTNumberCodec extends NumberCodec {
     sourceToInternal (metadata, propertyValue) {
         const propertyValueType = typeof propertyValue;
         if (propertyValue !== null && propertyValueType !== 'undefined' && propertyValueType !== 'number') {
-            throw new CartoRuntimeError(crt.MVT, `MVT decoding error. Metadata property '${this._baseName}' is of type 'number' but the MVT tile contained a feature property of type '${propertyValueType}': '${propertyValue}'`);
+            throw new CartoRuntimeError(
+                `MVT decoding error. Metadata property '${this._baseName}' is of type 'number' but the MVT tile contained a feature property of type '${propertyValueType}': '${propertyValue}'`,
+                crt.MVT
+            );
         }
         return super.sourceToInternal(metadata, propertyValue);
     }

--- a/src/codecs/mvt/index.js
+++ b/src/codecs/mvt/index.js
@@ -1,6 +1,6 @@
 import NumberCodec from './Number';
 import CategoryCodec from './Category';
-import CartoRuntimeError, { CartoRuntimeTypes as runtimeErrors } from '../../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../../errors/carto-runtime-error';
 
 export default function MVTCodecFactory (metadata, type, propertyName) {
     switch (type) {
@@ -10,7 +10,7 @@ export default function MVTCodecFactory (metadata, type, propertyName) {
             return new CategoryCodec(metadata, propertyName);
         default:
             throw new CartoRuntimeError(
-                `${runtimeErrors.MVT} MVT decoding error. Feature property value of type '${type}' cannot be decoded.`
+                crt.MVT, `MVT decoding error. Feature property value of type '${type}' cannot be decoded.`
             );
     }
 }

--- a/src/codecs/mvt/index.js
+++ b/src/codecs/mvt/index.js
@@ -1,6 +1,6 @@
 import NumberCodec from './Number';
 import CategoryCodec from './Category';
-import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeTypes } from '../../errors/carto-runtime-error';
 
 export default function MVTCodecFactory (metadata, type, propertyName) {
     switch (type) {
@@ -11,7 +11,7 @@ export default function MVTCodecFactory (metadata, type, propertyName) {
         default:
             throw new CartoRuntimeError(
                 `MVT decoding error. Feature property value of type '${type}' cannot be decoded.`,
-                crt.MVT
+                CartoRuntimeTypes.MVT
             );
     }
 }

--- a/src/codecs/mvt/index.js
+++ b/src/codecs/mvt/index.js
@@ -1,6 +1,6 @@
 import NumberCodec from './Number';
 import CategoryCodec from './Category';
-import CartoRuntimeError, { CartoRuntimeTypes } from '../../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeErrorTypes } from '../../errors/carto-runtime-error';
 
 export default function MVTCodecFactory (metadata, type, propertyName) {
     switch (type) {
@@ -11,7 +11,7 @@ export default function MVTCodecFactory (metadata, type, propertyName) {
         default:
             throw new CartoRuntimeError(
                 `MVT decoding error. Feature property value of type '${type}' cannot be decoded.`,
-                CartoRuntimeTypes.MVT
+                CartoRuntimeErrorTypes.MVT
             );
     }
 }

--- a/src/codecs/mvt/index.js
+++ b/src/codecs/mvt/index.js
@@ -10,7 +10,8 @@ export default function MVTCodecFactory (metadata, type, propertyName) {
             return new CategoryCodec(metadata, propertyName);
         default:
             throw new CartoRuntimeError(
-                crt.MVT, `MVT decoding error. Feature property value of type '${type}' cannot be decoded.`
+                `MVT decoding error. Feature property value of type '${type}' cannot be decoded.`,
+                crt.MVT
             );
     }
 }

--- a/src/codecs/windshaft/index.js
+++ b/src/codecs/windshaft/index.js
@@ -2,7 +2,7 @@ import NumberCodec from '../Number';
 import CategoryCodec from '../Category';
 import WindshaftDateCodec from './WindshaftDate';
 import TimeRangeCodec from './TimeRange';
-import CartoMapsAPIError, { CartoValidationErrorTypes } from '../../errors/carto-maps-api-error';
+import CartoMapsAPIError, { CartoMapsAPIErrorTypes } from '../../errors/carto-maps-api-error';
 
 export default function windshaftCodecFactory (metadata, type, propertyName) {
     switch (type) {
@@ -17,6 +17,6 @@ export default function windshaftCodecFactory (metadata, type, propertyName) {
         default:
             throw new CartoMapsAPIError(
                 `Windshaft MVT decoding error. Feature property value of type '${type}' cannot be decoded.`,
-                CartoValidationErrorTypes.NOT_SUPPORTED);
+                CartoMapsAPIErrorTypes.NOT_SUPPORTED);
     }
 }

--- a/src/codecs/windshaft/index.js
+++ b/src/codecs/windshaft/index.js
@@ -16,7 +16,7 @@ export default function windshaftCodecFactory (metadata, type, propertyName) {
             return new TimeRangeCodec(metadata, propertyName);
         default:
             throw new CartoMapsAPIError(
-                cmt.NOT_SUPPORTED, `Windshaft MVT decoding error. Feature property value of type '${type}' cannot be decoded.`
-            );
+                `Windshaft MVT decoding error. Feature property value of type '${type}' cannot be decoded.`,
+                cmt.NOT_SUPPORTED);
     }
 }

--- a/src/codecs/windshaft/index.js
+++ b/src/codecs/windshaft/index.js
@@ -2,7 +2,7 @@ import NumberCodec from '../Number';
 import CategoryCodec from '../Category';
 import WindshaftDateCodec from './WindshaftDate';
 import TimeRangeCodec from './TimeRange';
-import CartoMapsAPIError, { CartoMapsAPITypes as cmt } from '../../errors/carto-maps-api-error';
+import CartoMapsAPIError, { CartoMapsAPITypes } from '../../errors/carto-maps-api-error';
 
 export default function windshaftCodecFactory (metadata, type, propertyName) {
     switch (type) {
@@ -17,6 +17,6 @@ export default function windshaftCodecFactory (metadata, type, propertyName) {
         default:
             throw new CartoMapsAPIError(
                 `Windshaft MVT decoding error. Feature property value of type '${type}' cannot be decoded.`,
-                cmt.NOT_SUPPORTED);
+                CartoMapsAPITypes.NOT_SUPPORTED);
     }
 }

--- a/src/codecs/windshaft/index.js
+++ b/src/codecs/windshaft/index.js
@@ -2,7 +2,7 @@ import NumberCodec from '../Number';
 import CategoryCodec from '../Category';
 import WindshaftDateCodec from './WindshaftDate';
 import TimeRangeCodec from './TimeRange';
-import CartoMapsAPIError, { CartoMapsAPITypes } from '../../errors/carto-maps-api-error';
+import CartoMapsAPIError, { CartoValidationErrorTypes } from '../../errors/carto-maps-api-error';
 
 export default function windshaftCodecFactory (metadata, type, propertyName) {
     switch (type) {
@@ -17,6 +17,6 @@ export default function windshaftCodecFactory (metadata, type, propertyName) {
         default:
             throw new CartoMapsAPIError(
                 `Windshaft MVT decoding error. Feature property value of type '${type}' cannot be decoded.`,
-                CartoMapsAPITypes.NOT_SUPPORTED);
+                CartoValidationErrorTypes.NOT_SUPPORTED);
     }
 }

--- a/src/codecs/windshaft/index.js
+++ b/src/codecs/windshaft/index.js
@@ -16,7 +16,7 @@ export default function windshaftCodecFactory (metadata, type, propertyName) {
             return new TimeRangeCodec(metadata, propertyName);
         default:
             throw new CartoMapsAPIError(
-                `${cmt.NOT_SUPPORTED} Windshaft MVT decoding error. Feature property value of type '${type}' cannot be decoded.`
+                cmt.NOT_SUPPORTED, `Windshaft MVT decoding error. Feature property value of type '${type}' cannot be decoded.`
             );
     }
 }

--- a/src/errors/carto-error.js
+++ b/src/errors/carto-error.js
@@ -10,6 +10,12 @@
  * @event CartoError
  * @api
  */
+
+/**
+ * @namespace CartoErrors
+ * @api
+ *
+*/
 export default class CartoError extends Error {
     /**
      * Build a cartoError from a generic error.

--- a/src/errors/carto-error.js
+++ b/src/errors/carto-error.js
@@ -22,7 +22,7 @@ export default class CartoError extends Error {
         }
         super(error.message);
         this.name = 'CartoError';
-        this.type = '[Error]:'
+        this.type = '[Error]:';
         this.originalError = error;
     }
 }

--- a/src/errors/carto-error.js
+++ b/src/errors/carto-error.js
@@ -22,6 +22,7 @@ export default class CartoError extends Error {
         }
         super(error.message);
         this.name = 'CartoError';
+        this.type = '[Error]:'
         this.originalError = error;
     }
 }

--- a/src/errors/carto-error.js
+++ b/src/errors/carto-error.js
@@ -4,6 +4,7 @@
  * @typedef {Object} CartoError
  * @property {String} message - A short error description
  * @property {String} name - The name of the error "CartoError"
+ * @property {String} type - The type of the error "CartoError"
  * @property {Object} originalError - An object containing the internal/original error
  *
  * @event CartoError

--- a/src/errors/carto-error.js
+++ b/src/errors/carto-error.js
@@ -17,12 +17,21 @@ export default class CartoError extends Error {
      * @return {CartoError} A well formed object representing the error.
      */
     constructor (error) {
-        if (!(error && error.message)) {
+        if (!error) {
             throw Error('Invalid CartoError, a message is mandatory');
         }
-        super(error.message);
+
+        if (!error.message) {
+            throw Error('Invalid CartoError, a message is mandatory');
+        }
+
+        if (!error.type) {
+            throw Error('Invalid CartoError, a type is mandatory');
+        }
+
+        super(`${error.type} ${error.message}`);
         this.name = 'CartoError';
-        this.type = '[Error]:';
+        this.type = error.type;
         this.originalError = error;
     }
 }

--- a/src/errors/carto-maps-api-error.js
+++ b/src/errors/carto-maps-api-error.js
@@ -18,13 +18,13 @@ import CartoError from './carto-error';
 */
 
 export default class CartoMapsAPIError extends CartoError {
-    constructor (message, type = CartoMapsAPITypes.DEFAULT) {
+    constructor (message, type = CartoValidationErrorTypes.DEFAULT) {
         super({ message, type });
         this.name = 'CartoMapsAPIError';
     }
 }
 
-export const CartoMapsAPITypes = {
+export const CartoValidationErrorTypes = {
     DEFAULT: '[Error]',
     NOT_SUPPORTED: '[Not supported]',
     SECURITY: '[Security]'

--- a/src/errors/carto-maps-api-error.js
+++ b/src/errors/carto-maps-api-error.js
@@ -13,7 +13,7 @@ export default class CartoMapsAPIError extends CartoError {
 }
 
 export const CartoMapsAPITypes = {
-    DEFAULT: '[Error]:',
-    NOT_SUPPORTED: '[Not supported]:',
-    SECURITY: '[Security]:'
+    DEFAULT: '[Error]',
+    NOT_SUPPORTED: '[Not supported]',
+    SECURITY: '[Security]'
 };

--- a/src/errors/carto-maps-api-error.js
+++ b/src/errors/carto-maps-api-error.js
@@ -26,6 +26,7 @@ export default class CartoMapsAPIError extends CartoError {
 
 export const CartoMapsAPIErrorTypes = {
     DEFAULT: '[Error]',
+    SQL: '[SQL]',
     NOT_SUPPORTED: '[Not supported]',
     SECURITY: '[Security]'
 };

--- a/src/errors/carto-maps-api-error.js
+++ b/src/errors/carto-maps-api-error.js
@@ -5,6 +5,18 @@ import CartoError from './carto-error';
  *
  * @return {CartoError} A well formed object representing the error.
  */
+
+/**
+ * CartoMapsAPIError types:
+ * - [Error]
+ * - [Not supported]
+ * - [Security]
+ *
+ * @name CartoMapsAPIError
+ * @memberof CartoError
+ * @api
+*/
+
 export default class CartoMapsAPIError extends CartoError {
     constructor (message, type = CartoMapsAPITypes.DEFAULT) {
         super({ message, type });

--- a/src/errors/carto-maps-api-error.js
+++ b/src/errors/carto-maps-api-error.js
@@ -6,7 +6,7 @@ import CartoError from './carto-error';
  * @return {CartoError} A well formed object representing the error.
  */
 export default class CartoMapsAPIError extends CartoError {
-    constructor (type=CartoMapsAPITypes.DEFAULT, message) {
+    constructor (type = CartoMapsAPITypes.DEFAULT, message) {
         super({ message });
         this.name = 'CartoMapsAPIError';
         this.type = type;

--- a/src/errors/carto-maps-api-error.js
+++ b/src/errors/carto-maps-api-error.js
@@ -18,13 +18,13 @@ import CartoError from './carto-error';
 */
 
 export default class CartoMapsAPIError extends CartoError {
-    constructor (message, type = CartoValidationErrorTypes.DEFAULT) {
+    constructor (message, type = CartoMapsAPIErrorTypes.DEFAULT) {
         super({ message, type });
         this.name = 'CartoMapsAPIError';
     }
 }
 
-export const CartoValidationErrorTypes = {
+export const CartoMapsAPIErrorTypes = {
     DEFAULT: '[Error]',
     NOT_SUPPORTED: '[Not supported]',
     SECURITY: '[Security]'

--- a/src/errors/carto-maps-api-error.js
+++ b/src/errors/carto-maps-api-error.js
@@ -6,13 +6,15 @@ import CartoError from './carto-error';
  * @return {CartoError} A well formed object representing the error.
  */
 export default class CartoMapsAPIError extends CartoError {
-    constructor (message) {
-        super({ message: message });
+    constructor (type=CartoMapsAPITypes.DEFAULT, message) {
+        super({ message });
         this.name = 'CartoMapsAPIError';
+        this.type = type;
     }
 }
 
 export const CartoMapsAPITypes = {
+    DEFAULT: '[Error]:',
     NOT_SUPPORTED: '[Not supported]:',
     SECURITY: '[Security]:'
 };

--- a/src/errors/carto-maps-api-error.js
+++ b/src/errors/carto-maps-api-error.js
@@ -6,10 +6,9 @@ import CartoError from './carto-error';
  * @return {CartoError} A well formed object representing the error.
  */
 export default class CartoMapsAPIError extends CartoError {
-    constructor (type = CartoMapsAPITypes.DEFAULT, message) {
-        super({ message });
+    constructor (message, type = CartoMapsAPITypes.DEFAULT) {
+        super({ message, type });
         this.name = 'CartoMapsAPIError';
-        this.type = type;
     }
 }
 

--- a/src/errors/carto-parsing-error.js
+++ b/src/errors/carto-parsing-error.js
@@ -7,8 +7,8 @@ import CartoError from './carto-error';
  */
 export default class CartoParsingError extends CartoError {
     constructor (message) {
-        super({ message });
+        const type = '[Error]:';
+        super({ message, type });
         this.name = 'CartoParsingError';
-        this.type = '[Error]:';
     }
 }

--- a/src/errors/carto-parsing-error.js
+++ b/src/errors/carto-parsing-error.js
@@ -5,6 +5,16 @@ import CartoError from './carto-error';
  *
  * @return {CartoError} A well formed object representing the error.
  */
+
+/**
+ * CartoParsingError types:
+ * - [Error]
+ *
+ * @name CartoParsingError
+ * @memberof CartoError
+ * @api
+*/
+
 export default class CartoParsingError extends CartoError {
     constructor (message) {
         const type = '[Error]';

--- a/src/errors/carto-parsing-error.js
+++ b/src/errors/carto-parsing-error.js
@@ -7,7 +7,8 @@ import CartoError from './carto-error';
  */
 export default class CartoParsingError extends CartoError {
     constructor (message) {
-        super({ message: message });
+        super({ message });
         this.name = 'CartoParsingError';
+        this.type = '[Error]:';
     }
 }

--- a/src/errors/carto-parsing-error.js
+++ b/src/errors/carto-parsing-error.js
@@ -7,7 +7,7 @@ import CartoError from './carto-error';
  */
 export default class CartoParsingError extends CartoError {
     constructor (message) {
-        const type = '[Error]:';
+        const type = '[Error]';
         super({ message, type });
         this.name = 'CartoParsingError';
     }

--- a/src/errors/carto-runtime-error.js
+++ b/src/errors/carto-runtime-error.js
@@ -5,6 +5,18 @@ import CartoError from './carto-error';
  *
  * @return {CartoError} A well formed object representing the error.
  */
+
+/**
+ * CartoRuntimeError types:
+ * - [Error]
+ * - [Not supported]
+ * - [WebGL]
+ * - [MVT]
+ *
+ * @name CartoRuntimeError
+ * @memberof CartoError
+ * @api
+*/
 export default class CartoRuntimeError extends CartoError {
     constructor (message, type = CartoRuntimeTypes.DEFAULT) {
         super({ message, type });

--- a/src/errors/carto-runtime-error.js
+++ b/src/errors/carto-runtime-error.js
@@ -13,8 +13,8 @@ export default class CartoRuntimeError extends CartoError {
 }
 
 export const CartoRuntimeTypes = {
-    DEFAULT: '[Error]:',
-    NOT_SUPPORTED: '[Not supported]:',
-    WEB_GL: '[WebGL]:',
-    MVT: '[MVT]:'
+    DEFAULT: '[Error]',
+    NOT_SUPPORTED: '[Not supported]',
+    WEB_GL: '[WebGL]',
+    MVT: '[MVT]'
 };

--- a/src/errors/carto-runtime-error.js
+++ b/src/errors/carto-runtime-error.js
@@ -6,10 +6,9 @@ import CartoError from './carto-error';
  * @return {CartoError} A well formed object representing the error.
  */
 export default class CartoRuntimeError extends CartoError {
-    constructor (type = CartoRuntimeTypes.DEFAULT, message) {
-        super({ message });
+    constructor (message, type = CartoRuntimeTypes.DEFAULT) {
+        super({ message, type });
         this.name = 'CartoRuntimeError';
-        this.type = type;
     }
 }
 

--- a/src/errors/carto-runtime-error.js
+++ b/src/errors/carto-runtime-error.js
@@ -6,13 +6,15 @@ import CartoError from './carto-error';
  * @return {CartoError} A well formed object representing the error.
  */
 export default class CartoRuntimeError extends CartoError {
-    constructor (message) {
-        super({ message: message });
+    constructor (types=CartoRuntimeTypes.DEFAULT, message) {
+        super({ message });
         this.name = 'CartoRuntimeError';
+        this.type = type;
     }
 }
 
 export const CartoRuntimeTypes = {
+    DEFAULT: '[Error]:',
     NOT_SUPPORTED: '[Not supported]:',
     WEB_GL: '[WebGL]:',
     MVT: '[MVT]:'

--- a/src/errors/carto-runtime-error.js
+++ b/src/errors/carto-runtime-error.js
@@ -6,7 +6,7 @@ import CartoError from './carto-error';
  * @return {CartoError} A well formed object representing the error.
  */
 export default class CartoRuntimeError extends CartoError {
-    constructor (types=CartoRuntimeTypes.DEFAULT, message) {
+    constructor (type = CartoRuntimeTypes.DEFAULT, message) {
         super({ message });
         this.name = 'CartoRuntimeError';
         this.type = type;

--- a/src/errors/carto-runtime-error.js
+++ b/src/errors/carto-runtime-error.js
@@ -18,13 +18,13 @@ import CartoError from './carto-error';
  * @api
 */
 export default class CartoRuntimeError extends CartoError {
-    constructor (message, type = CartoRuntimeTypes.DEFAULT) {
+    constructor (message, type = CartoRuntimeErrorTypes.DEFAULT) {
         super({ message, type });
         this.name = 'CartoRuntimeError';
     }
 }
 
-export const CartoRuntimeTypes = {
+export const CartoRuntimeErrorTypes = {
     DEFAULT: '[Error]',
     NOT_SUPPORTED: '[Not supported]',
     WEB_GL: '[WebGL]',

--- a/src/errors/carto-validation-error.js
+++ b/src/errors/carto-validation-error.js
@@ -21,13 +21,13 @@ import CartoError from './carto-error';
  * @api
 */
 export default class CartoValidationError extends CartoError {
-    constructor (message, type = CartoValidationTypes.DEFAULT) {
+    constructor (message, type = CartoValidationErrorTypes.DEFAULT) {
         super({ message, type });
         this.name = 'CartoValidationError';
     }
 }
 
-export const CartoValidationTypes = {
+export const CartoValidationErrorTypes = {
     DEFAULT: '[Error]',
     MISSING_REQUIRED: '[Missing required property]',
     INCORRECT_TYPE: '[Property with an incorrect type]',

--- a/src/errors/carto-validation-error.js
+++ b/src/errors/carto-validation-error.js
@@ -5,6 +5,21 @@ import CartoError from './carto-error';
  *
  * @return {CartoError} A well formed object representing the error.
  */
+
+/**
+ * CartoValidationError types:
+ * - [Error]
+ * - [Missing required property]
+ * - [Property with an incorrect type]
+ * - [Incorrect value]
+ * - [Too many arguments]
+ * - [Not enough arguments]
+ * - [Wrong number of arguments]
+ *
+ * @name CartoValidationError
+ * @memberof CartoError
+ * @api
+*/
 export default class CartoValidationError extends CartoError {
     constructor (message, type = CartoValidationTypes.DEFAULT) {
         super({ message, type });

--- a/src/errors/carto-validation-error.js
+++ b/src/errors/carto-validation-error.js
@@ -6,7 +6,7 @@ import CartoError from './carto-error';
  * @return {CartoError} A well formed object representing the error.
  */
 export default class CartoValidationError extends CartoError {
-    constructor (type=CartoValidationTypes.DEFAULT, message) {
+    constructor (type = CartoValidationTypes.DEFAULT, message) {
         super({ message });
         this.name = 'CartoValidationError';
         this.type = type;

--- a/src/errors/carto-validation-error.js
+++ b/src/errors/carto-validation-error.js
@@ -6,13 +6,15 @@ import CartoError from './carto-error';
  * @return {CartoError} A well formed object representing the error.
  */
 export default class CartoValidationError extends CartoError {
-    constructor (message) {
-        super({ message: message });
+    constructor (type=CartoValidationTypes.DEFAULT, message) {
+        super({ message });
         this.name = 'CartoValidationError';
+        this.type = type;
     }
 }
 
 export const CartoValidationTypes = {
+    DEFAULT: '[Error:]',
     MISSING_REQUIRED: '[Missing required property]:',
     INCORRECT_TYPE: '[Property with an incorrect type]:',
     INCORRECT_VALUE: '[Incorrect value]:',

--- a/src/errors/carto-validation-error.js
+++ b/src/errors/carto-validation-error.js
@@ -6,15 +6,14 @@ import CartoError from './carto-error';
  * @return {CartoError} A well formed object representing the error.
  */
 export default class CartoValidationError extends CartoError {
-    constructor (type = CartoValidationTypes.DEFAULT, message) {
-        super({ message });
+    constructor (message, type = CartoValidationTypes.DEFAULT) {
+        super({ message, type });
         this.name = 'CartoValidationError';
-        this.type = type;
     }
 }
 
 export const CartoValidationTypes = {
-    DEFAULT: '[Error:]',
+    DEFAULT: '[Error]:',
     MISSING_REQUIRED: '[Missing required property]:',
     INCORRECT_TYPE: '[Property with an incorrect type]:',
     INCORRECT_VALUE: '[Incorrect value]:',

--- a/src/errors/carto-validation-error.js
+++ b/src/errors/carto-validation-error.js
@@ -13,11 +13,11 @@ export default class CartoValidationError extends CartoError {
 }
 
 export const CartoValidationTypes = {
-    DEFAULT: '[Error]:',
-    MISSING_REQUIRED: '[Missing required property]:',
-    INCORRECT_TYPE: '[Property with an incorrect type]:',
-    INCORRECT_VALUE: '[Incorrect value]:',
-    TOO_MANY_ARGS: '[Too many arguments]:',
-    NOT_ENOUGH_ARGS: '[Not enough arguments]:',
-    WRONG_NUMBER_ARGS: '[Wrong number of arguments]:'
+    DEFAULT: '[Error]',
+    MISSING_REQUIRED: '[Missing required property]',
+    INCORRECT_TYPE: '[Property with an incorrect type]',
+    INCORRECT_VALUE: '[Incorrect value]',
+    TOO_MANY_ARGS: '[Too many arguments]',
+    NOT_ENOUGH_ARGS: '[Not enough arguments]',
+    WRONG_NUMBER_ARGS: '[Wrong number of arguments]'
 };

--- a/src/interactivity/Interactivity.js
+++ b/src/interactivity/Interactivity.js
@@ -1,6 +1,6 @@
 import mitt from 'mitt';
 import Layer from '../Layer';
-import CartoValidationError, { CartoValidationTypes } from '../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../errors/carto-validation-error';
 
 const EVENTS = [
     'featureClick',
@@ -303,21 +303,21 @@ function preCheckLayerList (layerList) {
     if (!Array.isArray(layerList)) {
         throw new CartoValidationError(
             'Invalid layer list, parameter must be an array of "carto.Layer" objects.',
-            CartoValidationTypes.INCORRECT_TYPE
+            CartoValidationErrorTypes.INCORRECT_TYPE
         );
     }
 
     if (!layerList.length) {
         throw new CartoValidationError(
             'Invalid argument, layer list must not be empty.',
-            CartoValidationTypes.INCORRECT_VALUE
+            CartoValidationErrorTypes.INCORRECT_VALUE
         );
     }
 
     if (!layerList.every(layer => layer instanceof Layer)) {
         throw new CartoValidationError(
             'Invalid layer, layer must be an instance of "carto.Layer".',
-            CartoValidationTypes.INCORRECT_TYPE
+            CartoValidationErrorTypes.INCORRECT_TYPE
         );
     }
 }
@@ -326,7 +326,7 @@ function postCheckLayerList (layerList) {
     if (!layerList.every(layer => layer.map === layerList[0].map)) {
         throw new CartoValidationError(
             'Invalid argument, all layers must belong to the same map.',
-            CartoValidationTypes.INCORRECT_VALUE
+            CartoValidationErrorTypes.INCORRECT_VALUE
         );
     }
 }
@@ -335,7 +335,7 @@ function checkEvent (eventName) {
     if (!EVENTS.includes(eventName)) {
         throw new CartoValidationError(
             `Unrecognized event: '${eventName}'. Available events: ${EVENTS.join(', ')}.`,
-            CartoValidationTypes.INCORRECT_VALUE
+            CartoValidationErrorTypes.INCORRECT_VALUE
         );
     }
 }

--- a/src/interactivity/Interactivity.js
+++ b/src/interactivity/Interactivity.js
@@ -301,24 +301,41 @@ export default class Interactivity {
 
 function preCheckLayerList (layerList) {
     if (!Array.isArray(layerList)) {
-        throw new CartoValidationError(cvt.INCORRECT_TYPE, 'Invalid layer list, parameter must be an array of "carto.Layer" objects.');
+        throw new CartoValidationError(
+            'Invalid layer list, parameter must be an array of "carto.Layer" objects.',
+            cvt.INCORRECT_TYPE
+        );
     }
+
     if (!layerList.length) {
-        throw new CartoValidationError(cvt.INCORRECT_VALUE, 'Invalid argument, layer list must not be empty.');
+        throw new CartoValidationError(
+            'Invalid argument, layer list must not be empty.',
+            cvt.INCORRECT_VALUE
+        );
     }
+
     if (!layerList.every(layer => layer instanceof Layer)) {
-        throw new CartoValidationError(cvt.INCORRECT_TYPE, 'Invalid layer, layer must be an instance of "carto.Layer".');
+        throw new CartoValidationError(
+            'Invalid layer, layer must be an instance of "carto.Layer".',
+            cvt.INCORRECT_TYPE
+        );
     }
 }
 
 function postCheckLayerList (layerList) {
     if (!layerList.every(layer => layer.map === layerList[0].map)) {
-        throw new CartoValidationError(cvt.INCORRECT_VALUE, 'Invalid argument, all layers must belong to the same map.');
+        throw new CartoValidationError(
+            'Invalid argument, all layers must belong to the same map.',
+            cvt.INCORRECT_VALUE
+        );
     }
 }
 
 function checkEvent (eventName) {
     if (!EVENTS.includes(eventName)) {
-        throw new CartoValidationError(cvt.INCORRECT_VALUE, `Unrecognized event: '${eventName}'. Available events: ${EVENTS.join(', ')}.`);
+        throw new CartoValidationError(
+            `Unrecognized event: '${eventName}'. Available events: ${EVENTS.join(', ')}.`,
+            cvt.INCORRECT_VALUE
+        );
     }
 }

--- a/src/interactivity/Interactivity.js
+++ b/src/interactivity/Interactivity.js
@@ -301,19 +301,19 @@ export default class Interactivity {
 
 function preCheckLayerList (layerList) {
     if (!Array.isArray(layerList)) {
-        throw new CartoValidationError(cvt.INCORRECT_TYPE, `Invalid layer list, parameter must be an array of "carto.Layer" objects.`);
+        throw new CartoValidationError(cvt.INCORRECT_TYPE, 'Invalid layer list, parameter must be an array of "carto.Layer" objects.');
     }
     if (!layerList.length) {
-        throw new CartoValidationError(cvt.INCORRECT_VALUE, `Invalid argument, layer list must not be empty.`);
+        throw new CartoValidationError(cvt.INCORRECT_VALUE, 'Invalid argument, layer list must not be empty.');
     }
     if (!layerList.every(layer => layer instanceof Layer)) {
-        throw new CartoValidationError(cvt.INCORRECT_TYPE, `Invalid layer, layer must be an instance of "carto.Layer".`);
+        throw new CartoValidationError(cvt.INCORRECT_TYPE, 'Invalid layer, layer must be an instance of "carto.Layer".');
     }
 }
 
 function postCheckLayerList (layerList) {
     if (!layerList.every(layer => layer.map === layerList[0].map)) {
-        throw new CartoValidationError(cvt.INCORRECT_VALUE, `Invalid argument, all layers must belong to the same map.`);
+        throw new CartoValidationError(cvt.INCORRECT_VALUE, 'Invalid argument, all layers must belong to the same map.');
     }
 }
 

--- a/src/interactivity/Interactivity.js
+++ b/src/interactivity/Interactivity.js
@@ -301,24 +301,24 @@ export default class Interactivity {
 
 function preCheckLayerList (layerList) {
     if (!Array.isArray(layerList)) {
-        throw new CartoValidationError(`${cvt.INCORRECT_TYPE} Invalid layer list, parameter must be an array of "carto.Layer" objects.`);
+        throw new CartoValidationError(cvt.INCORRECT_TYPE, `Invalid layer list, parameter must be an array of "carto.Layer" objects.`);
     }
     if (!layerList.length) {
-        throw new CartoValidationError(`${cvt.INCORRECT_VALUE} Invalid argument, layer list must not be empty.`);
+        throw new CartoValidationError(cvt.INCORRECT_VALUE, `Invalid argument, layer list must not be empty.`);
     }
     if (!layerList.every(layer => layer instanceof Layer)) {
-        throw new CartoValidationError(`${cvt.INCORRECT_TYPE} Invalid layer, layer must be an instance of "carto.Layer".`);
+        throw new CartoValidationError(cvt.INCORRECT_TYPE, `Invalid layer, layer must be an instance of "carto.Layer".`);
     }
 }
 
 function postCheckLayerList (layerList) {
     if (!layerList.every(layer => layer.map === layerList[0].map)) {
-        throw new CartoValidationError(`${cvt.INCORRECT_VALUE} Invalid argument, all layers must belong to the same map.`);
+        throw new CartoValidationError(cvt.INCORRECT_VALUE, `Invalid argument, all layers must belong to the same map.`);
     }
 }
 
 function checkEvent (eventName) {
     if (!EVENTS.includes(eventName)) {
-        throw new CartoValidationError(`${cvt.INCORRECT_VALUE} Unrecognized event: '${eventName}'. Available events: ${EVENTS.join(', ')}.`);
+        throw new CartoValidationError(cvt.INCORRECT_VALUE, `Unrecognized event: '${eventName}'. Available events: ${EVENTS.join(', ')}.`);
     }
 }

--- a/src/interactivity/Interactivity.js
+++ b/src/interactivity/Interactivity.js
@@ -1,6 +1,6 @@
 import mitt from 'mitt';
 import Layer from '../Layer';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../errors/carto-validation-error';
 
 const EVENTS = [
     'featureClick',
@@ -303,21 +303,21 @@ function preCheckLayerList (layerList) {
     if (!Array.isArray(layerList)) {
         throw new CartoValidationError(
             'Invalid layer list, parameter must be an array of "carto.Layer" objects.',
-            cvt.INCORRECT_TYPE
+            CartoValidationTypes.INCORRECT_TYPE
         );
     }
 
     if (!layerList.length) {
         throw new CartoValidationError(
             'Invalid argument, layer list must not be empty.',
-            cvt.INCORRECT_VALUE
+            CartoValidationTypes.INCORRECT_VALUE
         );
     }
 
     if (!layerList.every(layer => layer instanceof Layer)) {
         throw new CartoValidationError(
             'Invalid layer, layer must be an instance of "carto.Layer".',
-            cvt.INCORRECT_TYPE
+            CartoValidationTypes.INCORRECT_TYPE
         );
     }
 }
@@ -326,7 +326,7 @@ function postCheckLayerList (layerList) {
     if (!layerList.every(layer => layer.map === layerList[0].map)) {
         throw new CartoValidationError(
             'Invalid argument, all layers must belong to the same map.',
-            cvt.INCORRECT_VALUE
+            CartoValidationTypes.INCORRECT_VALUE
         );
     }
 }
@@ -335,7 +335,7 @@ function checkEvent (eventName) {
     if (!EVENTS.includes(eventName)) {
         throw new CartoValidationError(
             `Unrecognized event: '${eventName}'. Available events: ${EVENTS.join(', ')}.`,
-            cvt.INCORRECT_VALUE
+            CartoValidationTypes.INCORRECT_VALUE
         );
     }
 }

--- a/src/interactivity/feature.js
+++ b/src/interactivity/feature.js
@@ -133,7 +133,10 @@ export default class Feature {
     blendTo (newVizProperties, duration = 500) {
         Object.keys(newVizProperties).forEach((property) => {
             if (!(SUPPORTED_VIZ_PROPERTIES.includes(property))) {
-                throw new CartoValidationError(cvt.INCORRECT_VALUE, `Property '${property}' is not a valid viz property`);
+                throw new CartoValidationError(
+                    `Property '${property}' is not a valid viz property`,
+                    cvt.INCORRECT_VALUE
+                );
             }
             const newValue = newVizProperties[property];
             this[property].blendTo(newValue, duration);

--- a/src/interactivity/feature.js
+++ b/src/interactivity/feature.js
@@ -1,5 +1,5 @@
 import FeatureVizProperty from './featureVizProperty';
-import CartoValidationError, { CartoValidationTypes } from '../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../errors/carto-validation-error';
 import { SUPPORTED_VIZ_PROPERTIES } from '../constants/viz';
 
 /**
@@ -135,7 +135,7 @@ export default class Feature {
             if (!(SUPPORTED_VIZ_PROPERTIES.includes(property))) {
                 throw new CartoValidationError(
                     `Property '${property}' is not a valid viz property`,
-                    CartoValidationTypes.INCORRECT_VALUE
+                    CartoValidationErrorTypes.INCORRECT_VALUE
                 );
             }
             const newValue = newVizProperties[property];

--- a/src/interactivity/feature.js
+++ b/src/interactivity/feature.js
@@ -133,7 +133,7 @@ export default class Feature {
     blendTo (newVizProperties, duration = 500) {
         Object.keys(newVizProperties).forEach((property) => {
             if (!(SUPPORTED_VIZ_PROPERTIES.includes(property))) {
-                throw new CartoValidationError(`${cvt.INCORRECT_VALUE} Property '${property}' is not a valid viz property`);
+                throw new CartoValidationError(cvt.INCORRECT_VALUE, `Property '${property}' is not a valid viz property`);
             }
             const newValue = newVizProperties[property];
             this[property].blendTo(newValue, duration);

--- a/src/interactivity/feature.js
+++ b/src/interactivity/feature.js
@@ -1,5 +1,5 @@
 import FeatureVizProperty from './featureVizProperty';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../errors/carto-validation-error';
 import { SUPPORTED_VIZ_PROPERTIES } from '../constants/viz';
 
 /**
@@ -135,7 +135,7 @@ export default class Feature {
             if (!(SUPPORTED_VIZ_PROPERTIES.includes(property))) {
                 throw new CartoValidationError(
                     `Property '${property}' is not a valid viz property`,
-                    cvt.INCORRECT_VALUE
+                    CartoValidationTypes.INCORRECT_VALUE
                 );
             }
             const newValue = newVizProperties[property];

--- a/src/interactivity/lightweightFeature.js
+++ b/src/interactivity/lightweightFeature.js
@@ -1,5 +1,5 @@
 import { generateBlenderFunction, generateResetFunction } from './blendUtils';
-import CartoValidationError, { CartoValidationTypes } from '../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../errors/carto-validation-error';
 import { SUPPORTED_VIZ_PROPERTIES } from '../constants/viz';
 
 /**
@@ -116,7 +116,7 @@ function _defineRootBlendToMethod (targetObject) {
                     if (!(SUPPORTED_VIZ_PROPERTIES.includes(property))) {
                         throw new CartoValidationError(
                             `Property '${property}' is not a valid viz property`,
-                            CartoValidationTypes.INCORRECT_VALUE
+                            CartoValidationErrorTypes.INCORRECT_VALUE
                         );
                     }
                     const newValue = newVizProperties[property];

--- a/src/interactivity/lightweightFeature.js
+++ b/src/interactivity/lightweightFeature.js
@@ -114,7 +114,7 @@ function _defineRootBlendToMethod (targetObject) {
             const blendTo = (newVizProperties, duration = 500) => {
                 Object.keys(newVizProperties).forEach((property) => {
                     if (!(SUPPORTED_VIZ_PROPERTIES.includes(property))) {
-                        throw new CartoValidationError(`${cvt.INCORRECT_VALUE} Property '${property}' is not a valid viz property`);
+                        throw new CartoValidationError(cvt.INCORRECT_VALUE, `Property '${property}' is not a valid viz property`);
                     }
                     const newValue = newVizProperties[property];
                     this[property].blendTo(newValue, duration);

--- a/src/interactivity/lightweightFeature.js
+++ b/src/interactivity/lightweightFeature.js
@@ -1,5 +1,5 @@
 import { generateBlenderFunction, generateResetFunction } from './blendUtils';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../errors/carto-validation-error';
 import { SUPPORTED_VIZ_PROPERTIES } from '../constants/viz';
 
 /**
@@ -116,7 +116,7 @@ function _defineRootBlendToMethod (targetObject) {
                     if (!(SUPPORTED_VIZ_PROPERTIES.includes(property))) {
                         throw new CartoValidationError(
                             `Property '${property}' is not a valid viz property`,
-                            cvt.INCORRECT_VALUE
+                            CartoValidationTypes.INCORRECT_VALUE
                         );
                     }
                     const newValue = newVizProperties[property];

--- a/src/interactivity/lightweightFeature.js
+++ b/src/interactivity/lightweightFeature.js
@@ -114,7 +114,10 @@ function _defineRootBlendToMethod (targetObject) {
             const blendTo = (newVizProperties, duration = 500) => {
                 Object.keys(newVizProperties).forEach((property) => {
                     if (!(SUPPORTED_VIZ_PROPERTIES.includes(property))) {
-                        throw new CartoValidationError(cvt.INCORRECT_VALUE, `Property '${property}' is not a valid viz property`);
+                        throw new CartoValidationError(
+                            `Property '${property}' is not a valid viz property`,
+                            cvt.INCORRECT_VALUE
+                        );
                     }
                     const newValue = newVizProperties[property];
                     this[property].blendTo(newValue, duration);

--- a/src/renderer/RenderLayer.js
+++ b/src/renderer/RenderLayer.js
@@ -1,5 +1,5 @@
 import Feature from '../interactivity/feature';
-import CartoValidationError, { CartoValidationTypes } from '../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../errors/carto-validation-error';
 import { GEOMETRY_TYPE } from '../utils/geometry';
 import { getCompoundFeature } from '../interactivity/commonFeature';
 
@@ -57,7 +57,7 @@ export default class RenderLayer {
         if (this.type !== dataframe.type) {
             throw new CartoValidationError(
                 'Layer dataframes must always be of the same type',
-                CartoValidationTypes.INCORRECT_TYPE
+                CartoValidationErrorTypes.INCORRECT_TYPE
             );
         }
     }

--- a/src/renderer/RenderLayer.js
+++ b/src/renderer/RenderLayer.js
@@ -55,7 +55,7 @@ export default class RenderLayer {
 
     _checkDataframeType (dataframe) {
         if (this.type !== dataframe.type) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} Layer dataframes must always be of the same type`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, `Layer dataframes must always be of the same type`);
         }
     }
 

--- a/src/renderer/RenderLayer.js
+++ b/src/renderer/RenderLayer.js
@@ -1,5 +1,5 @@
 import Feature from '../interactivity/feature';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../errors/carto-validation-error';
 import { GEOMETRY_TYPE } from '../utils/geometry';
 import { getCompoundFeature } from '../interactivity/commonFeature';
 
@@ -57,7 +57,7 @@ export default class RenderLayer {
         if (this.type !== dataframe.type) {
             throw new CartoValidationError(
                 'Layer dataframes must always be of the same type',
-                cvt.INCORRECT_TYPE
+                CartoValidationTypes.INCORRECT_TYPE
             );
         }
     }

--- a/src/renderer/RenderLayer.js
+++ b/src/renderer/RenderLayer.js
@@ -55,7 +55,7 @@ export default class RenderLayer {
 
     _checkDataframeType (dataframe) {
         if (this.type !== dataframe.type) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, `Layer dataframes must always be of the same type`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, 'Layer dataframes must always be of the same type');
         }
     }
 

--- a/src/renderer/RenderLayer.js
+++ b/src/renderer/RenderLayer.js
@@ -55,7 +55,10 @@ export default class RenderLayer {
 
     _checkDataframeType (dataframe) {
         if (this.type !== dataframe.type) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, 'Layer dataframes must always be of the same type');
+            throw new CartoValidationError(
+                'Layer dataframes must always be of the same type',
+                cvt.INCORRECT_TYPE
+            );
         }
     }
 

--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -437,13 +437,13 @@ export function unsupportedBrowserReasons (canvas, gl, early = false) {
         gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
     }
     if (!gl) {
-        reasons.push(new CartoRuntimeError(crt.WEB_GL, `WebGL 1 is unsupported`));
+        reasons.push(new CartoRuntimeError(crt.WEB_GL, 'WebGL 1 is unsupported'));
         return reasons;
     }
 
     const OESTextureFloat = gl.getExtension('OES_texture_float');
     if (!OESTextureFloat) {
-        reasons.push(new CartoRuntimeError(crt.WEB_GL, `WebGL extension 'OES_texture_float' is unsupported`));
+        reasons.push(new CartoRuntimeError(crt.WEB_GL, 'WebGL extension \'OES_texture_float\' is unsupported'));
         if (early) {
             return reasons;
         }

--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -1,6 +1,6 @@
 import shaders from './shaders';
 import { Asc, Desc } from './viz/expressions';
-import CartoRuntimeError, { CartoRuntimeTypes } from '../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeErrorTypes } from '../errors/carto-runtime-error';
 import { mat4 } from 'gl-matrix';
 import { RESOLUTION_ZOOMLEVEL_ZERO } from '../constants/layer';
 import { parseVizExpression } from './viz/parser';
@@ -437,13 +437,13 @@ export function unsupportedBrowserReasons (canvas, gl, early = false) {
         gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
     }
     if (!gl) {
-        reasons.push(new CartoRuntimeError('WebGL 1 is unsupported', CartoRuntimeTypes.WEB_GL));
+        reasons.push(new CartoRuntimeError('WebGL 1 is unsupported', CartoRuntimeErrorTypes.WEB_GL));
         return reasons;
     }
 
     const OESTextureFloat = gl.getExtension('OES_texture_float');
     if (!OESTextureFloat) {
-        reasons.push(new CartoRuntimeError('WebGL extension \'OES_texture_float\' is unsupported', CartoRuntimeTypes.WEB_GL));
+        reasons.push(new CartoRuntimeError('WebGL extension \'OES_texture_float\' is unsupported', CartoRuntimeErrorTypes.WEB_GL));
         if (early) {
             return reasons;
         }
@@ -454,7 +454,7 @@ export function unsupportedBrowserReasons (canvas, gl, early = false) {
         reasons.push(
             new CartoRuntimeError(
                 `WebGL parameter 'gl.MAX_RENDERBUFFER_SIZE' is below the requirement: ${supportedRTT} < ${RTT_WIDTH}`,
-                CartoRuntimeTypes.WEB_GL
+                CartoRuntimeErrorTypes.WEB_GL
             )
         );
     }

--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -437,13 +437,13 @@ export function unsupportedBrowserReasons (canvas, gl, early = false) {
         gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
     }
     if (!gl) {
-        reasons.push(new CartoRuntimeError(crt.WEB_GL, 'WebGL 1 is unsupported'));
+        reasons.push(new CartoRuntimeError('WebGL 1 is unsupported', crt.WEB_GL));
         return reasons;
     }
 
     const OESTextureFloat = gl.getExtension('OES_texture_float');
     if (!OESTextureFloat) {
-        reasons.push(new CartoRuntimeError(crt.WEB_GL, 'WebGL extension \'OES_texture_float\' is unsupported'));
+        reasons.push(new CartoRuntimeError('WebGL extension \'OES_texture_float\' is unsupported', crt.WEB_GL));
         if (early) {
             return reasons;
         }
@@ -451,7 +451,12 @@ export function unsupportedBrowserReasons (canvas, gl, early = false) {
 
     const supportedRTT = gl.getParameter(gl.MAX_RENDERBUFFER_SIZE);
     if (supportedRTT < RTT_WIDTH) {
-        reasons.push(new CartoRuntimeError(crt.WEB_GL, `WebGL parameter 'gl.MAX_RENDERBUFFER_SIZE' is below the requirement: ${supportedRTT} < ${RTT_WIDTH}`));
+        reasons.push(
+            new CartoRuntimeError(
+                `WebGL parameter 'gl.MAX_RENDERBUFFER_SIZE' is below the requirement: ${supportedRTT} < ${RTT_WIDTH}`,
+                crt.WEB_GL
+            )
+        );
     }
 
     return reasons;

--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -1,6 +1,6 @@
 import shaders from './shaders';
 import { Asc, Desc } from './viz/expressions';
-import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeTypes } from '../errors/carto-runtime-error';
 import { mat4 } from 'gl-matrix';
 import { RESOLUTION_ZOOMLEVEL_ZERO } from '../constants/layer';
 import { parseVizExpression } from './viz/parser';
@@ -437,13 +437,13 @@ export function unsupportedBrowserReasons (canvas, gl, early = false) {
         gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
     }
     if (!gl) {
-        reasons.push(new CartoRuntimeError('WebGL 1 is unsupported', crt.WEB_GL));
+        reasons.push(new CartoRuntimeError('WebGL 1 is unsupported', CartoRuntimeTypes.WEB_GL));
         return reasons;
     }
 
     const OESTextureFloat = gl.getExtension('OES_texture_float');
     if (!OESTextureFloat) {
-        reasons.push(new CartoRuntimeError('WebGL extension \'OES_texture_float\' is unsupported', crt.WEB_GL));
+        reasons.push(new CartoRuntimeError('WebGL extension \'OES_texture_float\' is unsupported', CartoRuntimeTypes.WEB_GL));
         if (early) {
             return reasons;
         }
@@ -454,7 +454,7 @@ export function unsupportedBrowserReasons (canvas, gl, early = false) {
         reasons.push(
             new CartoRuntimeError(
                 `WebGL parameter 'gl.MAX_RENDERBUFFER_SIZE' is below the requirement: ${supportedRTT} < ${RTT_WIDTH}`,
-                crt.WEB_GL
+                CartoRuntimeTypes.WEB_GL
             )
         );
     }

--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -1,6 +1,6 @@
 import shaders from './shaders';
 import { Asc, Desc } from './viz/expressions';
-import CartoRuntimeError, { CartoRuntimeTypes as runtimeErrors } from '../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../errors/carto-runtime-error';
 import { mat4 } from 'gl-matrix';
 import { RESOLUTION_ZOOMLEVEL_ZERO } from '../constants/layer';
 import { parseVizExpression } from './viz/parser';
@@ -437,13 +437,13 @@ export function unsupportedBrowserReasons (canvas, gl, early = false) {
         gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
     }
     if (!gl) {
-        reasons.push(new CartoRuntimeError(`${runtimeErrors.WEB_GL} WebGL 1 is unsupported`));
+        reasons.push(new CartoRuntimeError(crt.WEB_GL, `WebGL 1 is unsupported`));
         return reasons;
     }
 
     const OESTextureFloat = gl.getExtension('OES_texture_float');
     if (!OESTextureFloat) {
-        reasons.push(new CartoRuntimeError(`${runtimeErrors.WEB_GL} WebGL extension 'OES_texture_float' is unsupported`));
+        reasons.push(new CartoRuntimeError(crt.WEB_GL, `WebGL extension 'OES_texture_float' is unsupported`));
         if (early) {
             return reasons;
         }
@@ -451,7 +451,7 @@ export function unsupportedBrowserReasons (canvas, gl, early = false) {
 
     const supportedRTT = gl.getParameter(gl.MAX_RENDERBUFFER_SIZE);
     if (supportedRTT < RTT_WIDTH) {
-        reasons.push(new CartoRuntimeError(`${runtimeErrors.WEB_GL} WebGL parameter 'gl.MAX_RENDERBUFFER_SIZE' is below the requirement: ${supportedRTT} < ${RTT_WIDTH}`));
+        reasons.push(new CartoRuntimeError(crt.WEB_GL, `WebGL parameter 'gl.MAX_RENDERBUFFER_SIZE' is below the requirement: ${supportedRTT} < ${RTT_WIDTH}`));
     }
 
     return reasons;

--- a/src/renderer/decoder/index.js
+++ b/src/renderer/decoder/index.js
@@ -1,7 +1,7 @@
 import { decodePoint } from './pointDecoder';
 import { decodeLine } from './lineDecoder';
 import { decodePolygon } from './polygonDecoder';
-import CartoRuntimeError, { CartoRuntimeTypes as runtimeErrors } from '../../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../../errors/carto-runtime-error';
 import { GEOMETRY_TYPE } from '../../utils/geometry';
 
 export function decodeGeom (geomType, geom) {
@@ -13,6 +13,6 @@ export function decodeGeom (geomType, geom) {
         case GEOMETRY_TYPE.POLYGON:
             return decodePolygon(geom);
         default:
-            throw new CartoRuntimeError(`${runtimeErrors.NOT_SUPPORTED} Unimplemented geometry type: '${geomType}'.`);
+            throw new CartoRuntimeError(crt.NOT_SUPPORTED, `Unimplemented geometry type: '${geomType}'.`);
     }
 }

--- a/src/renderer/decoder/index.js
+++ b/src/renderer/decoder/index.js
@@ -1,7 +1,7 @@
 import { decodePoint } from './pointDecoder';
 import { decodeLine } from './lineDecoder';
 import { decodePolygon } from './polygonDecoder';
-import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeTypes } from '../../errors/carto-runtime-error';
 import { GEOMETRY_TYPE } from '../../utils/geometry';
 
 export function decodeGeom (geomType, geom) {
@@ -15,7 +15,7 @@ export function decodeGeom (geomType, geom) {
         default:
             throw new CartoRuntimeError(
                 `Unimplemented geometry type: '${geomType}'.`,
-                crt.NOT_SUPPORTED
+                CartoRuntimeTypes.NOT_SUPPORTED
             );
     }
 }

--- a/src/renderer/decoder/index.js
+++ b/src/renderer/decoder/index.js
@@ -13,6 +13,9 @@ export function decodeGeom (geomType, geom) {
         case GEOMETRY_TYPE.POLYGON:
             return decodePolygon(geom);
         default:
-            throw new CartoRuntimeError(crt.NOT_SUPPORTED, `Unimplemented geometry type: '${geomType}'.`);
+            throw new CartoRuntimeError(
+                `Unimplemented geometry type: '${geomType}'.`,
+                crt.NOT_SUPPORTED
+            );
     }
 }

--- a/src/renderer/decoder/index.js
+++ b/src/renderer/decoder/index.js
@@ -1,7 +1,7 @@
 import { decodePoint } from './pointDecoder';
 import { decodeLine } from './lineDecoder';
 import { decodePolygon } from './polygonDecoder';
-import CartoRuntimeError, { CartoRuntimeTypes } from '../../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeErrorTypes } from '../../errors/carto-runtime-error';
 import { GEOMETRY_TYPE } from '../../utils/geometry';
 
 export function decodeGeom (geomType, geom) {
@@ -15,7 +15,7 @@ export function decodeGeom (geomType, geom) {
         default:
             throw new CartoRuntimeError(
                 `Unimplemented geometry type: '${geomType}'.`,
-                CartoRuntimeTypes.NOT_SUPPORTED
+                CartoRuntimeErrorTypes.NOT_SUPPORTED
             );
     }
 }

--- a/src/renderer/shaders/shaderCompiler.js
+++ b/src/renderer/shaders/shaderCompiler.js
@@ -4,6 +4,7 @@ class IDGenerator {
     constructor () {
         this._ids = new Map();
     }
+
     getID (expression) {
         if (this._ids.has(expression)) {
             return this._ids.get(expression);

--- a/src/renderer/shaders/utils.js
+++ b/src/renderer/shaders/utils.js
@@ -1,5 +1,5 @@
 import Cache from './Cache';
-import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeTypes } from '../../errors/carto-runtime-error';
 
 let programID = 1;
 const shaderCache = new Cache();
@@ -33,7 +33,7 @@ export function compileProgram (gl, glslvertexShader, glslfragmentShader) {
     gl.deleteShader(fragmentShader);
 
     if (!gl.getProgramParameter(shader.program, gl.LINK_STATUS)) {
-        throw new CartoRuntimeError(`Unable to link the shader program: ${gl.getProgramInfoLog(shader.program)}.`, crt.WEB_GL);
+        throw new CartoRuntimeError(`Unable to link the shader program: ${gl.getProgramInfoLog(shader.program)}.`, CartoRuntimeTypes.WEB_GL);
     }
 
     shader.programID = programID++;
@@ -54,7 +54,7 @@ function _compileShader (gl, sourceCode, type) {
     if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
         const log = gl.getShaderInfoLog(shader);
         gl.deleteShader(shader);
-        throw new CartoRuntimeError(`An error occurred compiling the shaders: ${log}\nSource:\n${sourceCode}`, crt.WEB_GL);
+        throw new CartoRuntimeError(`An error occurred compiling the shaders: ${log}\nSource:\n${sourceCode}`, CartoRuntimeTypes.WEB_GL);
     }
 
     shaderCache.set(gl, sourceCode, shader);

--- a/src/renderer/shaders/utils.js
+++ b/src/renderer/shaders/utils.js
@@ -1,5 +1,5 @@
 import Cache from './Cache';
-import CartoRuntimeError, { CartoRuntimeTypes as runtimeErrors } from '../../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../../errors/carto-runtime-error';
 
 let programID = 1;
 const shaderCache = new Cache();
@@ -33,7 +33,7 @@ export function compileProgram (gl, glslvertexShader, glslfragmentShader) {
     gl.deleteShader(fragmentShader);
 
     if (!gl.getProgramParameter(shader.program, gl.LINK_STATUS)) {
-        throw new CartoRuntimeError(`${runtimeErrors.WEB_GL} Unable to link the shader program: ${gl.getProgramInfoLog(shader.program)}.`);
+        throw new CartoRuntimeError(crt.WEB_GL, `Unable to link the shader program: ${gl.getProgramInfoLog(shader.program)}.`);
     }
 
     shader.programID = programID++;
@@ -54,7 +54,7 @@ function _compileShader (gl, sourceCode, type) {
     if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
         const log = gl.getShaderInfoLog(shader);
         gl.deleteShader(shader);
-        throw new CartoRuntimeError(`${runtimeErrors.WEB_GL} An error occurred compiling the shaders: ${log}\nSource:\n${sourceCode}`);
+        throw new CartoRuntimeError(crt.WEB_GL, `An error occurred compiling the shaders: ${log}\nSource:\n${sourceCode}`);
     }
 
     shaderCache.set(gl, sourceCode, shader);

--- a/src/renderer/shaders/utils.js
+++ b/src/renderer/shaders/utils.js
@@ -33,7 +33,7 @@ export function compileProgram (gl, glslvertexShader, glslfragmentShader) {
     gl.deleteShader(fragmentShader);
 
     if (!gl.getProgramParameter(shader.program, gl.LINK_STATUS)) {
-        throw new CartoRuntimeError(crt.WEB_GL, `Unable to link the shader program: ${gl.getProgramInfoLog(shader.program)}.`);
+        throw new CartoRuntimeError(`Unable to link the shader program: ${gl.getProgramInfoLog(shader.program)}.`, crt.WEB_GL);
     }
 
     shader.programID = programID++;
@@ -54,7 +54,7 @@ function _compileShader (gl, sourceCode, type) {
     if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
         const log = gl.getShaderInfoLog(shader);
         gl.deleteShader(shader);
-        throw new CartoRuntimeError(crt.WEB_GL, `An error occurred compiling the shaders: ${log}\nSource:\n${sourceCode}`);
+        throw new CartoRuntimeError(`An error occurred compiling the shaders: ${log}\nSource:\n${sourceCode}`, crt.WEB_GL);
     }
 
     shaderCache.set(gl, sourceCode, shader);

--- a/src/renderer/shaders/utils.js
+++ b/src/renderer/shaders/utils.js
@@ -1,5 +1,5 @@
 import Cache from './Cache';
-import CartoRuntimeError, { CartoRuntimeTypes } from '../../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeErrorTypes } from '../../errors/carto-runtime-error';
 
 let programID = 1;
 const shaderCache = new Cache();
@@ -33,7 +33,7 @@ export function compileProgram (gl, glslvertexShader, glslfragmentShader) {
     gl.deleteShader(fragmentShader);
 
     if (!gl.getProgramParameter(shader.program, gl.LINK_STATUS)) {
-        throw new CartoRuntimeError(`Unable to link the shader program: ${gl.getProgramInfoLog(shader.program)}.`, CartoRuntimeTypes.WEB_GL);
+        throw new CartoRuntimeError(`Unable to link the shader program: ${gl.getProgramInfoLog(shader.program)}.`, CartoRuntimeErrorTypes.WEB_GL);
     }
 
     shader.programID = programID++;
@@ -54,7 +54,7 @@ function _compileShader (gl, sourceCode, type) {
     if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
         const log = gl.getShaderInfoLog(shader);
         gl.deleteShader(shader);
-        throw new CartoRuntimeError(`An error occurred compiling the shaders: ${log}\nSource:\n${sourceCode}`, CartoRuntimeTypes.WEB_GL);
+        throw new CartoRuntimeError(`An error occurred compiling the shaders: ${log}\nSource:\n${sourceCode}`, CartoRuntimeErrorTypes.WEB_GL);
     }
 
     shaderCache.set(gl, sourceCode, shader);

--- a/src/renderer/viz/expressions/Zoomrange.js
+++ b/src/renderer/viz/expressions/Zoomrange.js
@@ -1,6 +1,6 @@
 import BaseExpression from './base';
 import { pow, blend, linear, zoom } from '../expressions';
-import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../errors/carto-validation-error';
 import { implicitCast, checkType, checkExpression } from './utils';
 
 /**
@@ -40,7 +40,7 @@ export default class Zoomrange extends BaseExpression {
         this.zoomBreakpointList._bindMetadata(metadata);
         checkType('zoomrange', 'zoomBreakpointList', 0, 'number-list', this.zoomBreakpointList);
         if (this.zoomBreakpointList.elems.length < 2) {
-            throw new CartoValidationError('zoomrange() function must receive a list with at least two elements.', CartoValidationTypes.INCORRECT_VALUE);
+            throw new CartoValidationError('zoomrange() function must receive a list with at least two elements.', CartoValidationErrorTypes.INCORRECT_VALUE);
         }
 
         const breakpointListCopy = [...this.zoomBreakpointList.elems];

--- a/src/renderer/viz/expressions/Zoomrange.js
+++ b/src/renderer/viz/expressions/Zoomrange.js
@@ -40,7 +40,7 @@ export default class Zoomrange extends BaseExpression {
         this.zoomBreakpointList._bindMetadata(metadata);
         checkType('zoomrange', 'zoomBreakpointList', 0, 'number-list', this.zoomBreakpointList);
         if (this.zoomBreakpointList.elems.length < 2) {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, 'zoomrange() function must receive a list with at least two elements.');
+            throw new CartoValidationError('zoomrange() function must receive a list with at least two elements.', cvt.INCORRECT_VALUE);
         }
 
         const breakpointListCopy = [...this.zoomBreakpointList.elems];

--- a/src/renderer/viz/expressions/Zoomrange.js
+++ b/src/renderer/viz/expressions/Zoomrange.js
@@ -1,6 +1,6 @@
 import BaseExpression from './base';
 import { pow, blend, linear, zoom } from '../expressions';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
 import { implicitCast, checkType, checkExpression } from './utils';
 
 /**
@@ -40,7 +40,7 @@ export default class Zoomrange extends BaseExpression {
         this.zoomBreakpointList._bindMetadata(metadata);
         checkType('zoomrange', 'zoomBreakpointList', 0, 'number-list', this.zoomBreakpointList);
         if (this.zoomBreakpointList.elems.length < 2) {
-            throw new CartoValidationError('zoomrange() function must receive a list with at least two elements.', cvt.INCORRECT_VALUE);
+            throw new CartoValidationError('zoomrange() function must receive a list with at least two elements.', CartoValidationTypes.INCORRECT_VALUE);
         }
 
         const breakpointListCopy = [...this.zoomBreakpointList.elems];

--- a/src/renderer/viz/expressions/Zoomrange.js
+++ b/src/renderer/viz/expressions/Zoomrange.js
@@ -40,7 +40,7 @@ export default class Zoomrange extends BaseExpression {
         this.zoomBreakpointList._bindMetadata(metadata);
         checkType('zoomrange', 'zoomBreakpointList', 0, 'number-list', this.zoomBreakpointList);
         if (this.zoomBreakpointList.elems.length < 2) {
-            throw new CartoValidationError(`${cvt.INCORRECT_VALUE} zoomrange() function must receive a list with at least two elements.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, `zoomrange() function must receive a list with at least two elements.`);
         }
 
         const breakpointListCopy = [...this.zoomBreakpointList.elems];

--- a/src/renderer/viz/expressions/Zoomrange.js
+++ b/src/renderer/viz/expressions/Zoomrange.js
@@ -40,7 +40,7 @@ export default class Zoomrange extends BaseExpression {
         this.zoomBreakpointList._bindMetadata(metadata);
         checkType('zoomrange', 'zoomBreakpointList', 0, 'number-list', this.zoomBreakpointList);
         if (this.zoomBreakpointList.elems.length < 2) {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, `zoomrange() function must receive a list with at least two elements.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, 'zoomrange() function must receive a list with at least two elements.');
         }
 
         const breakpointListCopy = [...this.zoomBreakpointList.elems];

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
@@ -1,7 +1,7 @@
 import BaseExpression from '../../base';
 import { number } from '../../../expressions';
 import { implicitCast } from '../../utils';
-import CartoValidationError, { CartoValidationTypes } from '../../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../../errors/carto-validation-error';
 import { CLUSTER_FEATURE_COUNT } from '../../../../../constants/metadata';
 
 /**
@@ -99,7 +99,7 @@ export default class GlobalAggregation extends BaseExpression {
             }
         } else {
             if (propertyName === CLUSTER_FEATURE_COUNT) {
-                throw new CartoValidationError(CartoValidationTypes.INCORRECT_TYPE, `'clusterCount' can not be used in ${this.expressionName}.`);
+                throw new CartoValidationError(CartoValidationErrorTypes.INCORRECT_TYPE, `'clusterCount' can not be used in ${this.expressionName}.`);
             }
             const stats = metadata.stats(propertyName);
             value = stats && stats[this._name];
@@ -108,7 +108,7 @@ export default class GlobalAggregation extends BaseExpression {
         if (value === undefined) {
             throw new CartoValidationError(
                 `Metadata ${this._name} for property ${propertyName} is not defined`,
-                CartoValidationTypes.MISSING_REQUIRED
+                CartoValidationErrorTypes.MISSING_REQUIRED
             );
         }
 

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
@@ -106,7 +106,10 @@ export default class GlobalAggregation extends BaseExpression {
         }
 
         if (value === undefined) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, `Metadata ${this._name} for property ${propertyName} is not defined`);
+            throw new CartoValidationError(
+                `Metadata ${this._name} for property ${propertyName} is not defined`,
+                cvt.MISSING_REQUIRED
+            );
         }
 
         return value;

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
@@ -1,7 +1,7 @@
 import BaseExpression from '../../base';
 import { number } from '../../../expressions';
 import { implicitCast } from '../../utils';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../../errors/carto-validation-error';
 import { CLUSTER_FEATURE_COUNT } from '../../../../../constants/metadata';
 
 /**
@@ -99,7 +99,7 @@ export default class GlobalAggregation extends BaseExpression {
             }
         } else {
             if (propertyName === CLUSTER_FEATURE_COUNT) {
-                throw new CartoValidationError(cvt.INCORRECT_TYPE, `'clusterCount' can not be used in ${this.expressionName}.`);
+                throw new CartoValidationError(CartoValidationTypes.INCORRECT_TYPE, `'clusterCount' can not be used in ${this.expressionName}.`);
             }
             const stats = metadata.stats(propertyName);
             value = stats && stats[this._name];
@@ -108,7 +108,7 @@ export default class GlobalAggregation extends BaseExpression {
         if (value === undefined) {
             throw new CartoValidationError(
                 `Metadata ${this._name} for property ${propertyName} is not defined`,
-                cvt.MISSING_REQUIRED
+                CartoValidationTypes.MISSING_REQUIRED
             );
         }
 

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAggregation.js
@@ -99,14 +99,14 @@ export default class GlobalAggregation extends BaseExpression {
             }
         } else {
             if (propertyName === CLUSTER_FEATURE_COUNT) {
-                throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in ${this.expressionName}.`);
+                throw new CartoValidationError(cvt.INCORRECT_TYPE, `'clusterCount' can not be used in ${this.expressionName}.`);
             }
             const stats = metadata.stats(propertyName);
             value = stats && stats[this._name];
         }
 
         if (value === undefined) {
-            throw new CartoValidationError(`${cvt.MISSING_REQUIRED} Metadata ${this._name} for property ${propertyName} is not defined`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, `Metadata ${this._name} for property ${propertyName} is not defined`);
         }
 
         return value;

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAvg.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAvg.js
@@ -42,7 +42,10 @@ export default class GlobalAvg extends GlobalAggregation {
                 // but we'll allow it
                 baseStats = 'avg';
             } else {
-                throw new CartoValidationError(cvt.INCORRECT_TYPE, 'Invalid globlalAvg input');
+                throw new CartoValidationError(
+                    'Invalid globlalAvg input',
+                    cvt.INCORRECT_TYPE
+                );
             }
         }
 

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAvg.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAvg.js
@@ -4,7 +4,7 @@ import { checkMaxArguments, checkType } from '../../utils';
 import ClusterAggregation from '../cluster/ClusterAggregation';
 import ClusterAvg from '../cluster/ClusterAvg';
 
-import CartoValidationError, { CartoValidationTypes } from '../../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../../errors/carto-validation-error';
 
 /**
  * Return the average of the feature property for the entire source data.
@@ -44,7 +44,7 @@ export default class GlobalAvg extends GlobalAggregation {
             } else {
                 throw new CartoValidationError(
                     'Invalid globlalAvg input',
-                    CartoValidationTypes.INCORRECT_TYPE
+                    CartoValidationErrorTypes.INCORRECT_TYPE
                 );
             }
         }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAvg.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAvg.js
@@ -4,7 +4,7 @@ import { checkMaxArguments, checkType } from '../../utils';
 import ClusterAggregation from '../cluster/ClusterAggregation';
 import ClusterAvg from '../cluster/ClusterAvg';
 
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../../errors/carto-validation-error';
 
 /**
  * Return the average of the feature property for the entire source data.
@@ -44,7 +44,7 @@ export default class GlobalAvg extends GlobalAggregation {
             } else {
                 throw new CartoValidationError(
                     'Invalid globlalAvg input',
-                    cvt.INCORRECT_TYPE
+                    CartoValidationTypes.INCORRECT_TYPE
                 );
             }
         }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAvg.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAvg.js
@@ -42,7 +42,7 @@ export default class GlobalAvg extends GlobalAggregation {
                 // but we'll allow it
                 baseStats = 'avg';
             } else {
-                throw new CartoValidationError(cvt.INCORRECT_TYPE, `Invalid globlalAvg input`);
+                throw new CartoValidationError(cvt.INCORRECT_TYPE, 'Invalid globlalAvg input');
             }
         }
 

--- a/src/renderer/viz/expressions/aggregation/global/GlobalAvg.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalAvg.js
@@ -42,7 +42,7 @@ export default class GlobalAvg extends GlobalAggregation {
                 // but we'll allow it
                 baseStats = 'avg';
             } else {
-                throw new CartoValidationError(`${cvt.INCORRECT_TYPE} Invalid globlalAvg input`);
+                throw new CartoValidationError(cvt.INCORRECT_TYPE, `Invalid globlalAvg input`);
             }
         }
 

--- a/src/renderer/viz/expressions/aggregation/global/GlobalMax.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalMax.js
@@ -6,7 +6,7 @@ import ClusterAvg from '../cluster/ClusterAvg';
 import ClusterMax from '../cluster/ClusterMax';
 import ClusterMin from '../cluster/ClusterMin';
 
-import CartoValidationError, { CartoValidationTypes } from '../../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../../errors/carto-validation-error';
 
 /**
  * Return the maximum of the feature property for the entire source data.
@@ -47,7 +47,7 @@ export default class GlobalMax extends GlobalAggregation {
             } else {
                 throw new CartoValidationError(
                     'Invalid globlalAvg input',
-                    CartoValidationTypes.INCORRECT_TYPE
+                    CartoValidationErrorTypes.INCORRECT_TYPE
                 );
             }
         }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalMax.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalMax.js
@@ -6,7 +6,7 @@ import ClusterAvg from '../cluster/ClusterAvg';
 import ClusterMax from '../cluster/ClusterMax';
 import ClusterMin from '../cluster/ClusterMin';
 
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../../errors/carto-validation-error';
 
 /**
  * Return the maximum of the feature property for the entire source data.
@@ -47,7 +47,7 @@ export default class GlobalMax extends GlobalAggregation {
             } else {
                 throw new CartoValidationError(
                     'Invalid globlalAvg input',
-                    cvt.INCORRECT_TYPE
+                    CartoValidationTypes.INCORRECT_TYPE
                 );
             }
         }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalMax.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalMax.js
@@ -45,7 +45,7 @@ export default class GlobalMax extends GlobalAggregation {
                 // but we allow for it
                 baseStats = 'max';
             } else {
-                throw new CartoValidationError(cvt.INCORRECT_TYPE, `Invalid globlalAvg input`);
+                throw new CartoValidationError(cvt.INCORRECT_TYPE, 'Invalid globlalAvg input');
             }
         }
 

--- a/src/renderer/viz/expressions/aggregation/global/GlobalMax.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalMax.js
@@ -45,7 +45,10 @@ export default class GlobalMax extends GlobalAggregation {
                 // but we allow for it
                 baseStats = 'max';
             } else {
-                throw new CartoValidationError(cvt.INCORRECT_TYPE, 'Invalid globlalAvg input');
+                throw new CartoValidationError(
+                    'Invalid globlalAvg input',
+                    cvt.INCORRECT_TYPE
+                );
             }
         }
 

--- a/src/renderer/viz/expressions/aggregation/global/GlobalMax.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalMax.js
@@ -45,7 +45,7 @@ export default class GlobalMax extends GlobalAggregation {
                 // but we allow for it
                 baseStats = 'max';
             } else {
-                throw new CartoValidationError(`${cvt.INCORRECT_TYPE} Invalid globlalAvg input`);
+                throw new CartoValidationError(cvt.INCORRECT_TYPE, `Invalid globlalAvg input`);
             }
         }
 

--- a/src/renderer/viz/expressions/aggregation/global/GlobalMin.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalMin.js
@@ -48,7 +48,7 @@ export default class GlobalMin extends GlobalAggregation {
                 // but we allow for it
                 baseStats = 'min';
             } else {
-                throw new CartoValidationError(`${cvt.INCORRECT_TYPE} Invalid globlalAvg input`);
+                throw new CartoValidationError(cvt.INCORRECT_TYPE, `Invalid globlalAvg input`);
             }
         }
 

--- a/src/renderer/viz/expressions/aggregation/global/GlobalMin.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalMin.js
@@ -48,7 +48,7 @@ export default class GlobalMin extends GlobalAggregation {
                 // but we allow for it
                 baseStats = 'min';
             } else {
-                throw new CartoValidationError(cvt.INCORRECT_TYPE, `Invalid globlalAvg input`);
+                throw new CartoValidationError(cvt.INCORRECT_TYPE, 'Invalid globlalAvg input');
             }
         }
 

--- a/src/renderer/viz/expressions/aggregation/global/GlobalMin.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalMin.js
@@ -48,7 +48,10 @@ export default class GlobalMin extends GlobalAggregation {
                 // but we allow for it
                 baseStats = 'min';
             } else {
-                throw new CartoValidationError(cvt.INCORRECT_TYPE, 'Invalid globlalAvg input');
+                throw new CartoValidationError(
+                    'Invalid globlalAvg input',
+                    cvt.INCORRECT_TYPE
+                );
             }
         }
 

--- a/src/renderer/viz/expressions/aggregation/global/GlobalMin.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalMin.js
@@ -6,7 +6,7 @@ import ClusterAvg from '../cluster/ClusterAvg';
 import ClusterMax from '../cluster/ClusterMax';
 import ClusterMin from '../cluster/ClusterMin';
 
-import CartoValidationError, { CartoValidationTypes } from '../../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../../errors/carto-validation-error';
 
 /**
  * Return the minimum of the feature property for the entire source data.
@@ -50,7 +50,7 @@ export default class GlobalMin extends GlobalAggregation {
             } else {
                 throw new CartoValidationError(
                     'Invalid globlalAvg input',
-                    CartoValidationTypes.INCORRECT_TYPE
+                    CartoValidationErrorTypes.INCORRECT_TYPE
                 );
             }
         }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalMin.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalMin.js
@@ -6,7 +6,7 @@ import ClusterAvg from '../cluster/ClusterAvg';
 import ClusterMax from '../cluster/ClusterMax';
 import ClusterMin from '../cluster/ClusterMin';
 
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../../errors/carto-validation-error';
 
 /**
  * Return the minimum of the feature property for the entire source data.
@@ -50,7 +50,7 @@ export default class GlobalMin extends GlobalAggregation {
             } else {
                 throw new CartoValidationError(
                     'Invalid globlalAvg input',
-                    cvt.INCORRECT_TYPE
+                    CartoValidationTypes.INCORRECT_TYPE
                 );
             }
         }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalSum.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalSum.js
@@ -44,7 +44,7 @@ export default class GlobalSum extends GlobalAggregation {
             } else if (property.isA(ClusterCount)) {
                 baseStats = '_count';
             } else {
-                throw new CartoValidationError(cvt.INCORRECT_TYPE, `Invalid globlalAvg input`);
+                throw new CartoValidationError(cvt.INCORRECT_TYPE, 'Invalid globlalAvg input');
             }
         }
 

--- a/src/renderer/viz/expressions/aggregation/global/GlobalSum.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalSum.js
@@ -44,7 +44,7 @@ export default class GlobalSum extends GlobalAggregation {
             } else if (property.isA(ClusterCount)) {
                 baseStats = '_count';
             } else {
-                throw new CartoValidationError(`${cvt.INCORRECT_TYPE} Invalid globlalAvg input`);
+                throw new CartoValidationError(cvt.INCORRECT_TYPE, `Invalid globlalAvg input`);
             }
         }
 

--- a/src/renderer/viz/expressions/aggregation/global/GlobalSum.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalSum.js
@@ -44,7 +44,10 @@ export default class GlobalSum extends GlobalAggregation {
             } else if (property.isA(ClusterCount)) {
                 baseStats = '_count';
             } else {
-                throw new CartoValidationError(cvt.INCORRECT_TYPE, 'Invalid globlalAvg input');
+                throw new CartoValidationError(
+                    'Invalid globlalAvg input',
+                    cvt.INCORRECT_TYPE
+                );
             }
         }
 

--- a/src/renderer/viz/expressions/aggregation/global/GlobalSum.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalSum.js
@@ -5,7 +5,7 @@ import ClusterAggregation from '../cluster/ClusterAggregation';
 import ClusterCount from '../cluster/ClusterCount';
 import ClusterSum from '../cluster/ClusterSum';
 
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../../errors/carto-validation-error';
 
 /**
  * Return the sum of the feature property for the entire source data.
@@ -46,7 +46,7 @@ export default class GlobalSum extends GlobalAggregation {
             } else {
                 throw new CartoValidationError(
                     'Invalid globlalAvg input',
-                    cvt.INCORRECT_TYPE
+                    CartoValidationTypes.INCORRECT_TYPE
                 );
             }
         }

--- a/src/renderer/viz/expressions/aggregation/global/GlobalSum.js
+++ b/src/renderer/viz/expressions/aggregation/global/GlobalSum.js
@@ -5,7 +5,7 @@ import ClusterAggregation from '../cluster/ClusterAggregation';
 import ClusterCount from '../cluster/ClusterCount';
 import ClusterSum from '../cluster/ClusterSum';
 
-import CartoValidationError, { CartoValidationTypes } from '../../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../../errors/carto-validation-error';
 
 /**
  * Return the sum of the feature property for the entire source data.
@@ -46,7 +46,7 @@ export default class GlobalSum extends GlobalAggregation {
             } else {
                 throw new CartoValidationError(
                     'Invalid globlalAvg input',
-                    CartoValidationTypes.INCORRECT_TYPE
+                    CartoValidationErrorTypes.INCORRECT_TYPE
                 );
             }
         }

--- a/src/renderer/viz/expressions/base.js
+++ b/src/renderer/viz/expressions/base.js
@@ -199,7 +199,8 @@ export default class Base {
     _initializeChildrenArray (children) {
         if (this.maxParameters && this.maxParameters < children.length) {
             throw new CartoValidationError(
-                cvt.TOO_MANY_ARGS, `Extra parameters, got ${children.length} but maximum is ${this.maxParameters}`
+                `Extra parameters, got ${children.length} but maximum is ${this.maxParameters}`,
+                cvt.TOO_MANY_ARGS
             );
         }
 

--- a/src/renderer/viz/expressions/base.js
+++ b/src/renderer/viz/expressions/base.js
@@ -199,7 +199,7 @@ export default class Base {
     _initializeChildrenArray (children) {
         if (this.maxParameters && this.maxParameters < children.length) {
             throw new CartoValidationError(
-                `${cvt.TOO_MANY_ARGS} Extra parameters, got ${children.length} but maximum is ${this.maxParameters}`
+                cvt.TOO_MANY_ARGS, `Extra parameters, got ${children.length} but maximum is ${this.maxParameters}`
             );
         }
 
@@ -220,7 +220,7 @@ export default class Base {
 
         if (this.maxParameters && this.maxParameters < this.childrenNames.length) {
             throw new CartoValidationError(
-                `${cvt.TOO_MANY_ARGS} Extra parameters, got ${this.childrenNames.length} but maximum is ${this.maxParameters}`
+                cvt.TOO_MANY_ARGS, `Extra parameters, got ${this.childrenNames.length} but maximum is ${this.maxParameters}`
             );
         }
 

--- a/src/renderer/viz/expressions/base.js
+++ b/src/renderer/viz/expressions/base.js
@@ -1,7 +1,7 @@
 import { implicitCast } from './utils';
 import { blend, transition } from '../expressions';
 import * as schema from '../../schema';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
 import CartoRuntimeError from '../../../errors/carto-runtime-error';
 
 /**
@@ -200,7 +200,7 @@ export default class Base {
         if (this.maxParameters && this.maxParameters < children.length) {
             throw new CartoValidationError(
                 `Extra parameters, got ${children.length} but maximum is ${this.maxParameters}`,
-                cvt.TOO_MANY_ARGS
+                CartoValidationTypes.TOO_MANY_ARGS
             );
         }
 
@@ -221,7 +221,7 @@ export default class Base {
 
         if (this.maxParameters && this.maxParameters < this.childrenNames.length) {
             throw new CartoValidationError(
-                cvt.TOO_MANY_ARGS, `Extra parameters, got ${this.childrenNames.length} but maximum is ${this.maxParameters}`
+                CartoValidationTypes.TOO_MANY_ARGS, `Extra parameters, got ${this.childrenNames.length} but maximum is ${this.maxParameters}`
             );
         }
 

--- a/src/renderer/viz/expressions/base.js
+++ b/src/renderer/viz/expressions/base.js
@@ -1,7 +1,7 @@
 import { implicitCast } from './utils';
 import { blend, transition } from '../expressions';
 import * as schema from '../../schema';
-import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../errors/carto-validation-error';
 import CartoRuntimeError from '../../../errors/carto-runtime-error';
 
 /**
@@ -200,7 +200,7 @@ export default class Base {
         if (this.maxParameters && this.maxParameters < children.length) {
             throw new CartoValidationError(
                 `Extra parameters, got ${children.length} but maximum is ${this.maxParameters}`,
-                CartoValidationTypes.TOO_MANY_ARGS
+                CartoValidationErrorTypes.TOO_MANY_ARGS
             );
         }
 
@@ -221,7 +221,7 @@ export default class Base {
 
         if (this.maxParameters && this.maxParameters < this.childrenNames.length) {
             throw new CartoValidationError(
-                CartoValidationTypes.TOO_MANY_ARGS, `Extra parameters, got ${this.childrenNames.length} but maximum is ${this.maxParameters}`
+                CartoValidationErrorTypes.TOO_MANY_ARGS, `Extra parameters, got ${this.childrenNames.length} but maximum is ${this.maxParameters}`
             );
         }
 

--- a/src/renderer/viz/expressions/basic/List.js
+++ b/src/renderer/viz/expressions/basic/List.js
@@ -38,7 +38,10 @@ export default class List extends Base {
         checkMaxArguments(arguments, 1, 'list');
 
         if (!elems) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, 'list(): invalid parameters: must receive at least one argument.');
+            throw new CartoValidationError(
+                'list(): invalid parameters: must receive at least one argument.',
+                cvt.MISSING_REQUIRED
+            );
         }
 
         if (!Array.isArray(elems)) {
@@ -48,7 +51,10 @@ export default class List extends Base {
         elems = elems.map(implicitCast);
 
         if (!elems.length) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, 'list(): invalid parameters: must receive at least one argument.');
+            throw new CartoValidationError(
+                'list(): invalid parameters: must receive at least one argument.',
+                cvt.MISSING_REQUIRED
+            );
         }
 
         elems.map((item, index) => {
@@ -64,14 +70,20 @@ export default class List extends Base {
         this._setTypes();
 
         if (SUPPORTED_CHILD_TYPES.indexOf(this.childType) === -1) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, `list(): invalid parameters type: ${this.childType}.`);
+            throw new CartoValidationError(
+                `list(): invalid parameters type: ${this.childType}.`,
+                cvt.INCORRECT_TYPE
+            );
         }
 
         this.elems.map((item, index) => {
             checkExpression('list', `item[${index}]`, index, item);
 
             if (item.type !== this.childType) {
-                throw new CartoValidationError(cvt.INCORRECT_TYPE, `list(): invalid ${getOrdinalFromIndex(index + 1)} parameter type, invalid argument type combination.`);
+                throw new CartoValidationError(
+                    `list(): invalid ${getOrdinalFromIndex(index + 1)} parameter type, invalid argument type combination.`,
+                    cvt.INCORRECT_TYPE
+                );
             }
         });
 

--- a/src/renderer/viz/expressions/basic/List.js
+++ b/src/renderer/viz/expressions/basic/List.js
@@ -3,7 +3,7 @@ import { checkExpression, implicitCast, getOrdinalFromIndex, checkMaxArguments }
 import ListImage from '../ListImage';
 import ListGeneric from './ListGeneric';
 import ListTransform from '../ListTransform';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
 
 const SUPPORTED_CHILD_TYPES = ['number', 'category', 'color', 'date', 'image', 'transformation'];
 
@@ -40,7 +40,7 @@ export default class List extends Base {
         if (!elems) {
             throw new CartoValidationError(
                 'list(): invalid parameters: must receive at least one argument.',
-                cvt.MISSING_REQUIRED
+                CartoValidationTypes.MISSING_REQUIRED
             );
         }
 
@@ -53,7 +53,7 @@ export default class List extends Base {
         if (!elems.length) {
             throw new CartoValidationError(
                 'list(): invalid parameters: must receive at least one argument.',
-                cvt.MISSING_REQUIRED
+                CartoValidationTypes.MISSING_REQUIRED
             );
         }
 
@@ -72,7 +72,7 @@ export default class List extends Base {
         if (SUPPORTED_CHILD_TYPES.indexOf(this.childType) === -1) {
             throw new CartoValidationError(
                 `list(): invalid parameters type: ${this.childType}.`,
-                cvt.INCORRECT_TYPE
+                CartoValidationTypes.INCORRECT_TYPE
             );
         }
 
@@ -82,7 +82,7 @@ export default class List extends Base {
             if (item.type !== this.childType) {
                 throw new CartoValidationError(
                     `list(): invalid ${getOrdinalFromIndex(index + 1)} parameter type, invalid argument type combination.`,
-                    cvt.INCORRECT_TYPE
+                    CartoValidationTypes.INCORRECT_TYPE
                 );
             }
         });

--- a/src/renderer/viz/expressions/basic/List.js
+++ b/src/renderer/viz/expressions/basic/List.js
@@ -38,7 +38,7 @@ export default class List extends Base {
         checkMaxArguments(arguments, 1, 'list');
 
         if (!elems) {
-            throw new CartoValidationError(`${cvt.MISSING_REQUIRED} list(): invalid parameters: must receive at least one argument.`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, `list(): invalid parameters: must receive at least one argument.`);
         }
 
         if (!Array.isArray(elems)) {
@@ -48,7 +48,7 @@ export default class List extends Base {
         elems = elems.map(implicitCast);
 
         if (!elems.length) {
-            throw new CartoValidationError(`${cvt.MISSING_REQUIRED} list(): invalid parameters: must receive at least one argument.`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, `list(): invalid parameters: must receive at least one argument.`);
         }
 
         elems.map((item, index) => {
@@ -64,14 +64,14 @@ export default class List extends Base {
         this._setTypes();
 
         if (SUPPORTED_CHILD_TYPES.indexOf(this.childType) === -1) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} list(): invalid parameters type: ${this.childType}.`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, `list(): invalid parameters type: ${this.childType}.`);
         }
 
         this.elems.map((item, index) => {
             checkExpression('list', `item[${index}]`, index, item);
 
             if (item.type !== this.childType) {
-                throw new CartoValidationError(`${cvt.INCORRECT_TYPE} list(): invalid ${getOrdinalFromIndex(index + 1)} parameter type, invalid argument type combination.`);
+                throw new CartoValidationError(cvt.INCORRECT_TYPE, `list(): invalid ${getOrdinalFromIndex(index + 1)} parameter type, invalid argument type combination.`);
             }
         });
 

--- a/src/renderer/viz/expressions/basic/List.js
+++ b/src/renderer/viz/expressions/basic/List.js
@@ -3,7 +3,7 @@ import { checkExpression, implicitCast, getOrdinalFromIndex, checkMaxArguments }
 import ListImage from '../ListImage';
 import ListGeneric from './ListGeneric';
 import ListTransform from '../ListTransform';
-import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../errors/carto-validation-error';
 
 const SUPPORTED_CHILD_TYPES = ['number', 'category', 'color', 'date', 'image', 'transformation'];
 
@@ -40,7 +40,7 @@ export default class List extends Base {
         if (!elems) {
             throw new CartoValidationError(
                 'list(): invalid parameters: must receive at least one argument.',
-                CartoValidationTypes.MISSING_REQUIRED
+                CartoValidationErrorTypes.MISSING_REQUIRED
             );
         }
 
@@ -53,7 +53,7 @@ export default class List extends Base {
         if (!elems.length) {
             throw new CartoValidationError(
                 'list(): invalid parameters: must receive at least one argument.',
-                CartoValidationTypes.MISSING_REQUIRED
+                CartoValidationErrorTypes.MISSING_REQUIRED
             );
         }
 
@@ -72,7 +72,7 @@ export default class List extends Base {
         if (SUPPORTED_CHILD_TYPES.indexOf(this.childType) === -1) {
             throw new CartoValidationError(
                 `list(): invalid parameters type: ${this.childType}.`,
-                CartoValidationTypes.INCORRECT_TYPE
+                CartoValidationErrorTypes.INCORRECT_TYPE
             );
         }
 
@@ -82,7 +82,7 @@ export default class List extends Base {
             if (item.type !== this.childType) {
                 throw new CartoValidationError(
                     `list(): invalid ${getOrdinalFromIndex(index + 1)} parameter type, invalid argument type combination.`,
-                    CartoValidationTypes.INCORRECT_TYPE
+                    CartoValidationErrorTypes.INCORRECT_TYPE
                 );
             }
         });

--- a/src/renderer/viz/expressions/basic/List.js
+++ b/src/renderer/viz/expressions/basic/List.js
@@ -38,7 +38,7 @@ export default class List extends Base {
         checkMaxArguments(arguments, 1, 'list');
 
         if (!elems) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, `list(): invalid parameters: must receive at least one argument.`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, 'list(): invalid parameters: must receive at least one argument.');
         }
 
         if (!Array.isArray(elems)) {
@@ -48,7 +48,7 @@ export default class List extends Base {
         elems = elems.map(implicitCast);
 
         if (!elems.length) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, `list(): invalid parameters: must receive at least one argument.`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, 'list(): invalid parameters: must receive at least one argument.');
         }
 
         elems.map((item, index) => {

--- a/src/renderer/viz/expressions/basic/property.js
+++ b/src/renderer/viz/expressions/basic/property.js
@@ -1,6 +1,6 @@
 import BaseExpression from '../base';
 import { checkString, checkMaxArguments } from '../utils';
-import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../errors/carto-validation-error';
 import { FP32_DESIGNATED_NULL_VALUE } from '../constants';
 import { aggregationTypes } from '../../../../constants/metadata';
 /**
@@ -40,7 +40,7 @@ export default class Property extends BaseExpression {
         if (name === '') {
             throw new CartoValidationError(
                 'property(): invalid parameter, zero-length string',
-                CartoValidationTypes.INCORRECT_VALUE
+                CartoValidationErrorTypes.INCORRECT_VALUE
             );
         }
         super({});
@@ -65,7 +65,7 @@ export default class Property extends BaseExpression {
         if (!feature) {
             throw new CartoValidationError(
                 'A property needs to be evaluated in a \'feature\'.',
-                CartoValidationTypes.MISSING_REQUIRED
+                CartoValidationErrorTypes.MISSING_REQUIRED
             );
         }
 
@@ -90,7 +90,7 @@ export default class Property extends BaseExpression {
         if (!metaColumn) {
             throw new CartoValidationError(
                 `Property '${this.name}' does not exist`,
-                CartoValidationTypes.MISSING_REQUIRED
+                CartoValidationErrorTypes.MISSING_REQUIRED
             );
         }
 

--- a/src/renderer/viz/expressions/basic/property.js
+++ b/src/renderer/viz/expressions/basic/property.js
@@ -1,6 +1,6 @@
 import BaseExpression from '../base';
 import { checkString, checkMaxArguments } from '../utils';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
 import { FP32_DESIGNATED_NULL_VALUE } from '../constants';
 import { aggregationTypes } from '../../../../constants/metadata';
 /**
@@ -40,7 +40,7 @@ export default class Property extends BaseExpression {
         if (name === '') {
             throw new CartoValidationError(
                 'property(): invalid parameter, zero-length string',
-                cvt.INCORRECT_VALUE
+                CartoValidationTypes.INCORRECT_VALUE
             );
         }
         super({});
@@ -65,7 +65,7 @@ export default class Property extends BaseExpression {
         if (!feature) {
             throw new CartoValidationError(
                 'A property needs to be evaluated in a \'feature\'.',
-                cvt.MISSING_REQUIRED
+                CartoValidationTypes.MISSING_REQUIRED
             );
         }
 
@@ -90,7 +90,7 @@ export default class Property extends BaseExpression {
         if (!metaColumn) {
             throw new CartoValidationError(
                 `Property '${this.name}' does not exist`,
-                cvt.MISSING_REQUIRED
+                CartoValidationTypes.MISSING_REQUIRED
             );
         }
 

--- a/src/renderer/viz/expressions/basic/property.js
+++ b/src/renderer/viz/expressions/basic/property.js
@@ -38,7 +38,10 @@ export default class Property extends BaseExpression {
         checkString('property', 'name', 0, name);
 
         if (name === '') {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, 'property(): invalid parameter, zero-length string');
+            throw new CartoValidationError(
+                'property(): invalid parameter, zero-length string',
+                cvt.INCORRECT_VALUE
+            );
         }
         super({});
         this.name = name;
@@ -60,7 +63,10 @@ export default class Property extends BaseExpression {
 
     eval (feature) {
         if (!feature) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, 'A property needs to be evaluated in a \'feature\'.');
+            throw new CartoValidationError(
+                'A property needs to be evaluated in a \'feature\'.',
+                cvt.MISSING_REQUIRED
+            );
         }
 
         return feature[this.name] && feature[this.name] === FP32_DESIGNATED_NULL_VALUE
@@ -82,7 +88,10 @@ export default class Property extends BaseExpression {
         const metaColumn = metadata.properties[this.name];
 
         if (!metaColumn) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, `Property '${this.name}' does not exist`);
+            throw new CartoValidationError(
+                `Property '${this.name}' does not exist`,
+                cvt.MISSING_REQUIRED
+            );
         }
 
         this._metadata = metadata;

--- a/src/renderer/viz/expressions/basic/property.js
+++ b/src/renderer/viz/expressions/basic/property.js
@@ -38,7 +38,7 @@ export default class Property extends BaseExpression {
         checkString('property', 'name', 0, name);
 
         if (name === '') {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, `property(): invalid parameter, zero-length string`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, 'property(): invalid parameter, zero-length string');
         }
         super({});
         this.name = name;
@@ -60,7 +60,7 @@ export default class Property extends BaseExpression {
 
     eval (feature) {
         if (!feature) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, `A property needs to be evaluated in a 'feature'.`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, 'A property needs to be evaluated in a \'feature\'.');
         }
 
         return feature[this.name] && feature[this.name] === FP32_DESIGNATED_NULL_VALUE

--- a/src/renderer/viz/expressions/basic/property.js
+++ b/src/renderer/viz/expressions/basic/property.js
@@ -38,7 +38,7 @@ export default class Property extends BaseExpression {
         checkString('property', 'name', 0, name);
 
         if (name === '') {
-            throw new CartoValidationError(`${cvt.INCORRECT_VALUE} property(): invalid parameter, zero-length string`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, `property(): invalid parameter, zero-length string`);
         }
         super({});
         this.name = name;
@@ -60,7 +60,7 @@ export default class Property extends BaseExpression {
 
     eval (feature) {
         if (!feature) {
-            throw new CartoValidationError(`${cvt.MISSING_REQUIRED} A property needs to be evaluated in a 'feature'.`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, `A property needs to be evaluated in a 'feature'.`);
         }
 
         return feature[this.name] && feature[this.name] === FP32_DESIGNATED_NULL_VALUE
@@ -82,7 +82,7 @@ export default class Property extends BaseExpression {
         const metaColumn = metadata.properties[this.name];
 
         if (!metaColumn) {
-            throw new CartoValidationError(`${cvt.MISSING_REQUIRED} Property '${this.name}' does not exist`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, `Property '${this.name}' does not exist`);
         }
 
         this._metadata = metadata;

--- a/src/renderer/viz/expressions/basic/variable.js
+++ b/src/renderer/viz/expressions/basic/variable.js
@@ -39,7 +39,10 @@ export default function variable (name) {
     checkString('variable', 'name', 0, name);
 
     if (name === '') {
-        throw new CartoValidationError(cvt.INCORRECT_VALUE, 'variable(): invalid parameter, zero-length string');
+        throw new CartoValidationError(
+            'variable(): invalid parameter, zero-length string',
+            cvt.INCORRECT_VALUE
+        );
     }
 
     let alias;
@@ -48,7 +51,10 @@ export default function variable (name) {
         if (aliases[name]) {
             alias = aliases[name];
         } else {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, `variable() with name '${name}' doesn't exist`);
+            throw new CartoValidationError(
+                `variable() with name '${name}' doesn't exist`,
+                cvt.MISSING_REQUIRED
+            );
         }
     };
 

--- a/src/renderer/viz/expressions/basic/variable.js
+++ b/src/renderer/viz/expressions/basic/variable.js
@@ -1,6 +1,6 @@
 import BaseExpression from '../base';
 import { checkString, checkMaxArguments } from '../utils';
-import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../errors/carto-validation-error';
 
 /**
  * Alias to a named variable defined in the Viz.
@@ -41,7 +41,7 @@ export default function variable (name) {
     if (name === '') {
         throw new CartoValidationError(
             'variable(): invalid parameter, zero-length string',
-            CartoValidationTypes.INCORRECT_VALUE
+            CartoValidationErrorTypes.INCORRECT_VALUE
         );
     }
 
@@ -53,7 +53,7 @@ export default function variable (name) {
         } else {
             throw new CartoValidationError(
                 `variable() with name '${name}' doesn't exist`,
-                CartoValidationTypes.MISSING_REQUIRED
+                CartoValidationErrorTypes.MISSING_REQUIRED
             );
         }
     };

--- a/src/renderer/viz/expressions/basic/variable.js
+++ b/src/renderer/viz/expressions/basic/variable.js
@@ -1,6 +1,6 @@
 import BaseExpression from '../base';
 import { checkString, checkMaxArguments } from '../utils';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
 
 /**
  * Alias to a named variable defined in the Viz.
@@ -41,7 +41,7 @@ export default function variable (name) {
     if (name === '') {
         throw new CartoValidationError(
             'variable(): invalid parameter, zero-length string',
-            cvt.INCORRECT_VALUE
+            CartoValidationTypes.INCORRECT_VALUE
         );
     }
 
@@ -53,7 +53,7 @@ export default function variable (name) {
         } else {
             throw new CartoValidationError(
                 `variable() with name '${name}' doesn't exist`,
-                cvt.MISSING_REQUIRED
+                CartoValidationTypes.MISSING_REQUIRED
             );
         }
     };

--- a/src/renderer/viz/expressions/basic/variable.js
+++ b/src/renderer/viz/expressions/basic/variable.js
@@ -39,7 +39,7 @@ export default function variable (name) {
     checkString('variable', 'name', 0, name);
 
     if (name === '') {
-        throw new CartoValidationError(cvt.INCORRECT_VALUE, `variable(): invalid parameter, zero-length string`);
+        throw new CartoValidationError(cvt.INCORRECT_VALUE, 'variable(): invalid parameter, zero-length string');
     }
 
     let alias;

--- a/src/renderer/viz/expressions/basic/variable.js
+++ b/src/renderer/viz/expressions/basic/variable.js
@@ -39,7 +39,7 @@ export default function variable (name) {
     checkString('variable', 'name', 0, name);
 
     if (name === '') {
-        throw new CartoValidationError(`${cvt.INCORRECT_VALUE} variable(): invalid parameter, zero-length string`);
+        throw new CartoValidationError(cvt.INCORRECT_VALUE, `variable(): invalid parameter, zero-length string`);
     }
 
     let alias;
@@ -48,7 +48,7 @@ export default function variable (name) {
         if (aliases[name]) {
             alias = aliases[name];
         } else {
-            throw new CartoValidationError(`${cvt.MISSING_REQUIRED} variable() with name '${name}' doesn't exist`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, `variable() with name '${name}' doesn't exist`);
         }
     };
 

--- a/src/renderer/viz/expressions/binary.js
+++ b/src/renderer/viz/expressions/binary.js
@@ -471,7 +471,7 @@ function genBinaryOp (name, allowedSignature, jsFn, glsl) {
 
             const signature = getSignature(a, b);
             if (signature === UNSUPPORTED_SIGNATURE || !(signature & allowedSignature)) {
-                throw new CartoValidationError(`${cvt.INCORRECT_TYPE} ${name}(): invalid parameter types\n'x' type was ${a.type}, 'y' type was ${b.type}`);
+                throw new CartoValidationError(cvt.INCORRECT_TYPE, `${name}(): invalid parameter types\n'x' type was ${a.type}, 'y' type was ${b.type}`);
             }
             this.type = getReturnTypeFromSignature(signature);
         }

--- a/src/renderer/viz/expressions/binary.js
+++ b/src/renderer/viz/expressions/binary.js
@@ -471,7 +471,10 @@ function genBinaryOp (name, allowedSignature, jsFn, glsl) {
 
             const signature = getSignature(a, b);
             if (signature === UNSUPPORTED_SIGNATURE || !(signature & allowedSignature)) {
-                throw new CartoValidationError(cvt.INCORRECT_TYPE, `${name}(): invalid parameter types\n'x' type was ${a.type}, 'y' type was ${b.type}`);
+                throw new CartoValidationError(
+                    `${name}(): invalid parameter types\n'x' type was ${a.type}, 'y' type was ${b.type}`,
+                    cvt.INCORRECT_TYPE
+                );
             }
             this.type = getReturnTypeFromSignature(signature);
         }

--- a/src/renderer/viz/expressions/binary.js
+++ b/src/renderer/viz/expressions/binary.js
@@ -1,7 +1,7 @@
 import { number } from '../expressions';
 import { implicitCast, checkMaxArguments } from './utils';
 import BaseExpression from './base';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
 
 // Each binary expression can have a set of the following signatures (OR'ed flags)
 const UNSUPPORTED_SIGNATURE = 0;
@@ -473,7 +473,7 @@ function genBinaryOp (name, allowedSignature, jsFn, glsl) {
             if (signature === UNSUPPORTED_SIGNATURE || !(signature & allowedSignature)) {
                 throw new CartoValidationError(
                     `${name}(): invalid parameter types\n'x' type was ${a.type}, 'y' type was ${b.type}`,
-                    cvt.INCORRECT_TYPE
+                    CartoValidationTypes.INCORRECT_TYPE
                 );
             }
             this.type = getReturnTypeFromSignature(signature);

--- a/src/renderer/viz/expressions/binary.js
+++ b/src/renderer/viz/expressions/binary.js
@@ -1,7 +1,7 @@
 import { number } from '../expressions';
 import { implicitCast, checkMaxArguments } from './utils';
 import BaseExpression from './base';
-import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../errors/carto-validation-error';
 
 // Each binary expression can have a set of the following signatures (OR'ed flags)
 const UNSUPPORTED_SIGNATURE = 0;
@@ -473,7 +473,7 @@ function genBinaryOp (name, allowedSignature, jsFn, glsl) {
             if (signature === UNSUPPORTED_SIGNATURE || !(signature & allowedSignature)) {
                 throw new CartoValidationError(
                     `${name}(): invalid parameter types\n'x' type was ${a.type}, 'y' type was ${b.type}`,
-                    CartoValidationTypes.INCORRECT_TYPE
+                    CartoValidationErrorTypes.INCORRECT_TYPE
                 );
             }
             this.type = getReturnTypeFromSignature(signature);

--- a/src/renderer/viz/expressions/blend.js
+++ b/src/renderer/viz/expressions/blend.js
@@ -1,7 +1,7 @@
 import { implicitCast, clamp, mix, checkType, checkExpression, checkMaxArguments } from './utils';
 import Transition from './transition';
 import BaseExpression from './base';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
 
 /**
  * Linearly interpolate from `a` to `b` based on `mix`.
@@ -91,7 +91,7 @@ function abTypeCheck (a, b) {
     if (a.type !== b.type || !(validTypes.includes(a.type))) {
         throw new CartoValidationError(
             `blend(): invalid parameter types\n\t'a' type was '${a.type}'\n\t'b' type was '${b.type}'`,
-            cvt.INCORRECT_TYPE
+            CartoValidationTypes.INCORRECT_TYPE
         );
     }
 }

--- a/src/renderer/viz/expressions/blend.js
+++ b/src/renderer/viz/expressions/blend.js
@@ -1,7 +1,7 @@
 import { implicitCast, clamp, mix, checkType, checkExpression, checkMaxArguments } from './utils';
 import Transition from './transition';
 import BaseExpression from './base';
-import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../errors/carto-validation-error';
 
 /**
  * Linearly interpolate from `a` to `b` based on `mix`.
@@ -91,7 +91,7 @@ function abTypeCheck (a, b) {
     if (a.type !== b.type || !(validTypes.includes(a.type))) {
         throw new CartoValidationError(
             `blend(): invalid parameter types\n\t'a' type was '${a.type}'\n\t'b' type was '${b.type}'`,
-            CartoValidationTypes.INCORRECT_TYPE
+            CartoValidationErrorTypes.INCORRECT_TYPE
         );
     }
 }

--- a/src/renderer/viz/expressions/blend.js
+++ b/src/renderer/viz/expressions/blend.js
@@ -89,6 +89,9 @@ function abTypeCheck (a, b) {
     const validTypes = ['number', 'color', 'image', 'placement'];
 
     if (a.type !== b.type || !(validTypes.includes(a.type))) {
-        throw new CartoValidationError(cvt.INCORRECT_TYPE, `blend(): invalid parameter types\n\t'a' type was '${a.type}'\n\t'b' type was '${b.type}'`);
+        throw new CartoValidationError(
+            `blend(): invalid parameter types\n\t'a' type was '${a.type}'\n\t'b' type was '${b.type}'`,
+            cvt.INCORRECT_TYPE
+        );
     }
 }

--- a/src/renderer/viz/expressions/blend.js
+++ b/src/renderer/viz/expressions/blend.js
@@ -89,6 +89,6 @@ function abTypeCheck (a, b) {
     const validTypes = ['number', 'color', 'image', 'placement'];
 
     if (a.type !== b.type || !(validTypes.includes(a.type))) {
-        throw new CartoValidationError(`${cvt.INCORRECT_TYPE} blend(): invalid parameter types\n\t'a' type was '${a.type}'\n\t'b' type was '${b.type}'`);
+        throw new CartoValidationError(cvt.INCORRECT_TYPE, `blend(): invalid parameter types\n\t'a' type was '${a.type}'\n\t'b' type was '${b.type}'`);
     }
 }

--- a/src/renderer/viz/expressions/buckets.js
+++ b/src/renderer/viz/expressions/buckets.js
@@ -1,6 +1,6 @@
 import BaseExpression from './base';
 import { implicitCast, getOrdinalFromIndex, checkMaxArguments, checkType } from './utils';
-import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../errors/carto-validation-error';
 import { OTHERS_INDEX, OTHERS_GLSL_VALUE } from './constants';
 
 /**
@@ -108,7 +108,7 @@ export default class Buckets extends BaseExpression {
         if (this.input.type !== 'number' && this.input.type !== 'category') {
             throw new CartoValidationError(
                 `buckets(): invalid first parameter type\n\t'input' type was ${this.input.type}`,
-                CartoValidationTypes.INCORRECT_TYPE
+                CartoValidationErrorTypes.INCORRECT_TYPE
             );
         }
 
@@ -119,12 +119,12 @@ export default class Buckets extends BaseExpression {
                 throw new CartoValidationError(
                     `buckets(): invalid ${getOrdinalFromIndex(index + 1)} parameter type` +
                     `\n\texpected type was ${this.input.type}\n\tactual type was ${item.type}`,
-                    CartoValidationTypes.INCORRECT_TYPE
+                    CartoValidationErrorTypes.INCORRECT_TYPE
                 );
             } else if (item.type !== 'number' && item.type !== 'category') {
                 throw new CartoValidationError(
                     `buckets(): invalid ${getOrdinalFromIndex(index + 1)} parameter type\n\ttype was ${item.type}`,
-                    CartoValidationTypes.INCORRECT_TYPE
+                    CartoValidationErrorTypes.INCORRECT_TYPE
                 );
             }
         });

--- a/src/renderer/viz/expressions/buckets.js
+++ b/src/renderer/viz/expressions/buckets.js
@@ -107,7 +107,7 @@ export default class Buckets extends BaseExpression {
 
         if (this.input.type !== 'number' && this.input.type !== 'category') {
             throw new CartoValidationError(
-                `${cvt.INCORRECT_TYPE} buckets(): invalid first parameter type\n\t'input' type was ${this.input.type}`
+                cvt.INCORRECT_TYPE, `buckets(): invalid first parameter type\n\t'input' type was ${this.input.type}`
             );
         }
 
@@ -116,12 +116,12 @@ export default class Buckets extends BaseExpression {
         this.list.elems.map((item, index) => {
             if (this.input.type !== item.type) {
                 throw new CartoValidationError(
-                    `${cvt.INCORRECT_TYPE} buckets(): invalid ${getOrdinalFromIndex(index + 1)} parameter type` +
+                    cvt.INCORRECT_TYPE, `buckets(): invalid ${getOrdinalFromIndex(index + 1)} parameter type` +
                     `\n\texpected type was ${this.input.type}\n\tactual type was ${item.type}`
                 );
             } else if (item.type !== 'number' && item.type !== 'category') {
                 throw new CartoValidationError(
-                    `${cvt.INCORRECT_TYPE} buckets(): invalid ${getOrdinalFromIndex(index + 1)} parameter type\n\ttype was ${item.type}`
+                    cvt.INCORRECT_TYPE, `buckets(): invalid ${getOrdinalFromIndex(index + 1)} parameter type\n\ttype was ${item.type}`
                 );
             }
         });

--- a/src/renderer/viz/expressions/buckets.js
+++ b/src/renderer/viz/expressions/buckets.js
@@ -1,6 +1,6 @@
 import BaseExpression from './base';
 import { implicitCast, getOrdinalFromIndex, checkMaxArguments, checkType } from './utils';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
 import { OTHERS_INDEX, OTHERS_GLSL_VALUE } from './constants';
 
 /**
@@ -108,7 +108,7 @@ export default class Buckets extends BaseExpression {
         if (this.input.type !== 'number' && this.input.type !== 'category') {
             throw new CartoValidationError(
                 `buckets(): invalid first parameter type\n\t'input' type was ${this.input.type}`,
-                cvt.INCORRECT_TYPE
+                CartoValidationTypes.INCORRECT_TYPE
             );
         }
 
@@ -119,12 +119,12 @@ export default class Buckets extends BaseExpression {
                 throw new CartoValidationError(
                     `buckets(): invalid ${getOrdinalFromIndex(index + 1)} parameter type` +
                     `\n\texpected type was ${this.input.type}\n\tactual type was ${item.type}`,
-                    cvt.INCORRECT_TYPE
+                    CartoValidationTypes.INCORRECT_TYPE
                 );
             } else if (item.type !== 'number' && item.type !== 'category') {
                 throw new CartoValidationError(
                     `buckets(): invalid ${getOrdinalFromIndex(index + 1)} parameter type\n\ttype was ${item.type}`,
-                    cvt.INCORRECT_TYPE
+                    CartoValidationTypes.INCORRECT_TYPE
                 );
             }
         });

--- a/src/renderer/viz/expressions/buckets.js
+++ b/src/renderer/viz/expressions/buckets.js
@@ -107,7 +107,8 @@ export default class Buckets extends BaseExpression {
 
         if (this.input.type !== 'number' && this.input.type !== 'category') {
             throw new CartoValidationError(
-                cvt.INCORRECT_TYPE, `buckets(): invalid first parameter type\n\t'input' type was ${this.input.type}`
+                `buckets(): invalid first parameter type\n\t'input' type was ${this.input.type}`,
+                cvt.INCORRECT_TYPE
             );
         }
 
@@ -116,12 +117,14 @@ export default class Buckets extends BaseExpression {
         this.list.elems.map((item, index) => {
             if (this.input.type !== item.type) {
                 throw new CartoValidationError(
-                    cvt.INCORRECT_TYPE, `buckets(): invalid ${getOrdinalFromIndex(index + 1)} parameter type` +
-                    `\n\texpected type was ${this.input.type}\n\tactual type was ${item.type}`
+                    `buckets(): invalid ${getOrdinalFromIndex(index + 1)} parameter type` +
+                    `\n\texpected type was ${this.input.type}\n\tactual type was ${item.type}`,
+                    cvt.INCORRECT_TYPE
                 );
             } else if (item.type !== 'number' && item.type !== 'category') {
                 throw new CartoValidationError(
-                    cvt.INCORRECT_TYPE, `buckets(): invalid ${getOrdinalFromIndex(index + 1)} parameter type\n\ttype was ${item.type}`
+                    `buckets(): invalid ${getOrdinalFromIndex(index + 1)} parameter type\n\ttype was ${item.type}`,
+                    cvt.INCORRECT_TYPE
                 );
             }
         });

--- a/src/renderer/viz/expressions/classification/Classifier.js
+++ b/src/renderer/viz/expressions/classification/Classifier.js
@@ -2,7 +2,7 @@ import BaseExpression from '../base';
 import { number } from '../../expressions';
 
 import { checkType, checkNumber } from '../utils';
-import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../errors/carto-validation-error';
 import ClassifierGLSLHelper from './ClassifierGLSLHelper';
 
 export const DEFAULT_HISTOGRAM_SIZE = 1000;
@@ -57,7 +57,7 @@ export default class Classifier extends BaseExpression {
         if (buckets <= 1) {
             throw new CartoValidationError(
                 `The number of 'buckets' must be >=2, but ${buckets} was used`,
-                CartoValidationTypes.INCORRECT_VALUE
+                CartoValidationErrorTypes.INCORRECT_VALUE
             );
         }
     }

--- a/src/renderer/viz/expressions/classification/Classifier.js
+++ b/src/renderer/viz/expressions/classification/Classifier.js
@@ -2,7 +2,7 @@ import BaseExpression from '../base';
 import { number } from '../../expressions';
 
 import { checkType, checkNumber } from '../utils';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
 import ClassifierGLSLHelper from './ClassifierGLSLHelper';
 
 export const DEFAULT_HISTOGRAM_SIZE = 1000;
@@ -57,7 +57,7 @@ export default class Classifier extends BaseExpression {
         if (buckets <= 1) {
             throw new CartoValidationError(
                 `The number of 'buckets' must be >=2, but ${buckets} was used`,
-                cvt.INCORRECT_VALUE
+                CartoValidationTypes.INCORRECT_VALUE
             );
         }
     }

--- a/src/renderer/viz/expressions/classification/Classifier.js
+++ b/src/renderer/viz/expressions/classification/Classifier.js
@@ -55,7 +55,10 @@ export default class Classifier extends BaseExpression {
         const buckets = this.buckets.value;
         checkNumber(this.expressionName, 'buckets', 1, buckets);
         if (buckets <= 1) {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, `The number of 'buckets' must be >=2, but ${buckets} was used`);
+            throw new CartoValidationError(
+                `The number of 'buckets' must be >=2, but ${buckets} was used`,
+                cvt.INCORRECT_VALUE
+            );
         }
     }
 

--- a/src/renderer/viz/expressions/classification/Classifier.js
+++ b/src/renderer/viz/expressions/classification/Classifier.js
@@ -55,7 +55,7 @@ export default class Classifier extends BaseExpression {
         const buckets = this.buckets.value;
         checkNumber(this.expressionName, 'buckets', 1, buckets);
         if (buckets <= 1) {
-            throw new CartoValidationError(`${cvt.INCORRECT_VALUE} The number of 'buckets' must be >=2, but ${buckets} was used`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, `The number of 'buckets' must be >=2, but ${buckets} was used`);
         }
     }
 

--- a/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
@@ -1,7 +1,7 @@
 import Classifier from './Classifier';
 import { checkExactNumberOfArguments } from '../utils';
 import { CLUSTER_FEATURE_COUNT } from '../../../../constants/metadata';
-import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../errors/carto-validation-error';
 
 /**
  * Classify `input` by using the equal intervals method with `n` buckets.
@@ -44,7 +44,7 @@ export default class GlobalEqIntervals extends Classifier {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
             throw new CartoValidationError(
                 '\'clusterCount\' can not be used in GlobalEqIntervals. Consider using ViewportEqIntervals instead',
-                CartoValidationTypes.INCORRECT_TYPE
+                CartoValidationErrorTypes.INCORRECT_TYPE
             );
         }
 

--- a/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
@@ -1,7 +1,7 @@
 import Classifier from './Classifier';
 import { checkExactNumberOfArguments } from '../utils';
 import { CLUSTER_FEATURE_COUNT } from '../../../../constants/metadata';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
 
 /**
  * Classify `input` by using the equal intervals method with `n` buckets.
@@ -44,7 +44,7 @@ export default class GlobalEqIntervals extends Classifier {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
             throw new CartoValidationError(
                 '\'clusterCount\' can not be used in GlobalEqIntervals. Consider using ViewportEqIntervals instead',
-                cvt.INCORRECT_TYPE
+                CartoValidationTypes.INCORRECT_TYPE
             );
         }
 

--- a/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
@@ -42,7 +42,7 @@ export default class GlobalEqIntervals extends Classifier {
 
     _updateBreakpointsWith (metadata) {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, `'clusterCount' can not be used in GlobalEqIntervals. Consider using ViewportEqIntervals instead`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'clusterCount\' can not be used in GlobalEqIntervals. Consider using ViewportEqIntervals instead');
         }
 
         const name = this.input.name;

--- a/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
@@ -42,7 +42,7 @@ export default class GlobalEqIntervals extends Classifier {
 
     _updateBreakpointsWith (metadata) {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalEqIntervals. Consider using ViewportEqIntervals instead`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, `'clusterCount' can not be used in GlobalEqIntervals. Consider using ViewportEqIntervals instead`);
         }
 
         const name = this.input.name;

--- a/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
@@ -42,7 +42,10 @@ export default class GlobalEqIntervals extends Classifier {
 
     _updateBreakpointsWith (metadata) {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'clusterCount\' can not be used in GlobalEqIntervals. Consider using ViewportEqIntervals instead');
+            throw new CartoValidationError(
+                '\'clusterCount\' can not be used in GlobalEqIntervals. Consider using ViewportEqIntervals instead',
+                cvt.INCORRECT_TYPE
+            );
         }
 
         const name = this.input.name;

--- a/src/renderer/viz/expressions/classification/GlobalQuantiles.js
+++ b/src/renderer/viz/expressions/classification/GlobalQuantiles.js
@@ -45,7 +45,10 @@ export default class GlobalQuantiles extends Classifier {
 
     _updateBreakpointsWith (metadata) {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'clusterCount\' can not be used in GlobalQuantiles. Consider using ViewportQuantiles instead');
+            throw new CartoValidationError(
+                '\'clusterCount\' can not be used in GlobalQuantiles. Consider using ViewportQuantiles instead',
+                cvt.INCORRECT_TYPE
+            );
         }
 
         const name = this.input.name;

--- a/src/renderer/viz/expressions/classification/GlobalQuantiles.js
+++ b/src/renderer/viz/expressions/classification/GlobalQuantiles.js
@@ -45,7 +45,7 @@ export default class GlobalQuantiles extends Classifier {
 
     _updateBreakpointsWith (metadata) {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalQuantiles. Consider using ViewportQuantiles instead`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, `'clusterCount' can not be used in GlobalQuantiles. Consider using ViewportQuantiles instead`);
         }
 
         const name = this.input.name;

--- a/src/renderer/viz/expressions/classification/GlobalQuantiles.js
+++ b/src/renderer/viz/expressions/classification/GlobalQuantiles.js
@@ -1,7 +1,7 @@
 import Classifier from './Classifier';
 import { checkExactNumberOfArguments, checkType } from '../utils';
 import { CLUSTER_FEATURE_COUNT } from '../../../../constants/metadata';
-import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../errors/carto-validation-error';
 
 /**
  * Classify `input` by using the quantiles method with `n` buckets.
@@ -47,7 +47,7 @@ export default class GlobalQuantiles extends Classifier {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
             throw new CartoValidationError(
                 '\'clusterCount\' can not be used in GlobalQuantiles. Consider using ViewportQuantiles instead',
-                CartoValidationTypes.INCORRECT_TYPE
+                CartoValidationErrorTypes.INCORRECT_TYPE
             );
         }
 

--- a/src/renderer/viz/expressions/classification/GlobalQuantiles.js
+++ b/src/renderer/viz/expressions/classification/GlobalQuantiles.js
@@ -45,7 +45,7 @@ export default class GlobalQuantiles extends Classifier {
 
     _updateBreakpointsWith (metadata) {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, `'clusterCount' can not be used in GlobalQuantiles. Consider using ViewportQuantiles instead`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'clusterCount\' can not be used in GlobalQuantiles. Consider using ViewportQuantiles instead');
         }
 
         const name = this.input.name;

--- a/src/renderer/viz/expressions/classification/GlobalQuantiles.js
+++ b/src/renderer/viz/expressions/classification/GlobalQuantiles.js
@@ -1,7 +1,7 @@
 import Classifier from './Classifier';
 import { checkExactNumberOfArguments, checkType } from '../utils';
 import { CLUSTER_FEATURE_COUNT } from '../../../../constants/metadata';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
 
 /**
  * Classify `input` by using the quantiles method with `n` buckets.
@@ -47,7 +47,7 @@ export default class GlobalQuantiles extends Classifier {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
             throw new CartoValidationError(
                 '\'clusterCount\' can not be used in GlobalQuantiles. Consider using ViewportQuantiles instead',
-                cvt.INCORRECT_TYPE
+                CartoValidationTypes.INCORRECT_TYPE
             );
         }
 

--- a/src/renderer/viz/expressions/classification/GlobalStandardDev.js
+++ b/src/renderer/viz/expressions/classification/GlobalStandardDev.js
@@ -1,7 +1,7 @@
 import Classifier from './Classifier';
 import { checkMaxArguments, checkMinArguments, checkNumber } from '../utils';
-import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
-import CartoRuntimeError, { CartoRuntimeTypes } from '../../../../errors/carto-runtime-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../errors/carto-validation-error';
+import CartoRuntimeError, { CartoRuntimeErrorTypes } from '../../../../errors/carto-runtime-error';
 
 import { average, standardDeviation } from '../stats';
 import { CLUSTER_FEATURE_COUNT } from '../../../../constants/metadata';
@@ -69,7 +69,7 @@ export default class GlobalStandardDev extends Classifier {
         if (classSize <= 0) {
             throw new CartoValidationError(
                 `The 'classSize' must be > 0.0, but ${classSize} was used.`,
-                CartoValidationTypes.INCORRECT_VALUE
+                CartoValidationErrorTypes.INCORRECT_VALUE
             );
         }
     }
@@ -84,7 +84,7 @@ export default class GlobalStandardDev extends Classifier {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
             throw new CartoValidationError(
                 '\'clusterCount\' can not be used in GlobalStandardDev. Consider using ViewportStandardDev instead',
-                CartoValidationTypes.INCORRECT_TYPE
+                CartoValidationErrorTypes.INCORRECT_TYPE
             );
         }
         const name = this.input.name;
@@ -113,7 +113,7 @@ export function calculateBreakpoints (avg, stDev, buckets, classSize) {
     if (stDev === 0 || isNaN(stDev)) {
         throw new CartoRuntimeError(
             `There is no Standard Deviation, not possible to compute ${buckets} buckets (just one feature or maybe all share the same value...?)`,
-            CartoRuntimeTypes.NOT_SUPPORTED
+            CartoRuntimeErrorTypes.NOT_SUPPORTED
         );
     }
 

--- a/src/renderer/viz/expressions/classification/GlobalStandardDev.js
+++ b/src/renderer/viz/expressions/classification/GlobalStandardDev.js
@@ -1,7 +1,7 @@
 import Classifier from './Classifier';
 import { checkMaxArguments, checkMinArguments, checkNumber } from '../utils';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
-import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../../../../errors/carto-runtime-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
+import CartoRuntimeError, { CartoRuntimeTypes } from '../../../../errors/carto-runtime-error';
 
 import { average, standardDeviation } from '../stats';
 import { CLUSTER_FEATURE_COUNT } from '../../../../constants/metadata';
@@ -69,7 +69,7 @@ export default class GlobalStandardDev extends Classifier {
         if (classSize <= 0) {
             throw new CartoValidationError(
                 `The 'classSize' must be > 0.0, but ${classSize} was used.`,
-                cvt.INCORRECT_VALUE
+                CartoValidationTypes.INCORRECT_VALUE
             );
         }
     }
@@ -84,7 +84,7 @@ export default class GlobalStandardDev extends Classifier {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
             throw new CartoValidationError(
                 '\'clusterCount\' can not be used in GlobalStandardDev. Consider using ViewportStandardDev instead',
-                cvt.INCORRECT_TYPE
+                CartoValidationTypes.INCORRECT_TYPE
             );
         }
         const name = this.input.name;
@@ -113,7 +113,7 @@ export function calculateBreakpoints (avg, stDev, buckets, classSize) {
     if (stDev === 0 || isNaN(stDev)) {
         throw new CartoRuntimeError(
             `There is no Standard Deviation, not possible to compute ${buckets} buckets (just one feature or maybe all share the same value...?)`,
-            crt.NOT_SUPPORTED
+            CartoRuntimeTypes.NOT_SUPPORTED
         );
     }
 

--- a/src/renderer/viz/expressions/classification/GlobalStandardDev.js
+++ b/src/renderer/viz/expressions/classification/GlobalStandardDev.js
@@ -79,7 +79,7 @@ export default class GlobalStandardDev extends Classifier {
 
     _updateBreakpointsWith (metadata) {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, `'clusterCount' can not be used in GlobalStandardDev. Consider using ViewportStandardDev instead`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'clusterCount\' can not be used in GlobalStandardDev. Consider using ViewportStandardDev instead');
         }
         const name = this.input.name;
         const sample = metadata.sample.map(s => s[name]);

--- a/src/renderer/viz/expressions/classification/GlobalStandardDev.js
+++ b/src/renderer/viz/expressions/classification/GlobalStandardDev.js
@@ -67,7 +67,10 @@ export default class GlobalStandardDev extends Classifier {
         const classSize = this._classSize.value;
         checkNumber(this.expressionName, 'classSize', 2, classSize);
         if (classSize <= 0) {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, `The 'classSize' must be > 0.0, but ${classSize} was used.`);
+            throw new CartoValidationError(
+                `The 'classSize' must be > 0.0, but ${classSize} was used.`,
+                cvt.INCORRECT_VALUE
+            );
         }
     }
 
@@ -79,7 +82,10 @@ export default class GlobalStandardDev extends Classifier {
 
     _updateBreakpointsWith (metadata) {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'clusterCount\' can not be used in GlobalStandardDev. Consider using ViewportStandardDev instead');
+            throw new CartoValidationError(
+                '\'clusterCount\' can not be used in GlobalStandardDev. Consider using ViewportStandardDev instead',
+                cvt.INCORRECT_TYPE
+            );
         }
         const name = this.input.name;
         const sample = metadata.sample.map(s => s[name]);
@@ -106,7 +112,8 @@ export default class GlobalStandardDev extends Classifier {
 export function calculateBreakpoints (avg, stDev, buckets, classSize) {
     if (stDev === 0 || isNaN(stDev)) {
         throw new CartoRuntimeError(
-            crt.NOT_SUPPORTED, `There is no Standard Deviation, not possible to compute ${buckets} buckets (just one feature or maybe all share the same value...?)`
+            `There is no Standard Deviation, not possible to compute ${buckets} buckets (just one feature or maybe all share the same value...?)`,
+            crt.NOT_SUPPORTED
         );
     }
 

--- a/src/renderer/viz/expressions/classification/GlobalStandardDev.js
+++ b/src/renderer/viz/expressions/classification/GlobalStandardDev.js
@@ -1,7 +1,7 @@
 import Classifier from './Classifier';
 import { checkMaxArguments, checkMinArguments, checkNumber } from '../utils';
 import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
-import CartoRuntimeError, { CartoRuntimeTypes as runtimeErrors } from '../../../../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../../../../errors/carto-runtime-error';
 
 import { average, standardDeviation } from '../stats';
 import { CLUSTER_FEATURE_COUNT } from '../../../../constants/metadata';
@@ -67,7 +67,7 @@ export default class GlobalStandardDev extends Classifier {
         const classSize = this._classSize.value;
         checkNumber(this.expressionName, 'classSize', 2, classSize);
         if (classSize <= 0) {
-            throw new CartoValidationError(`${cvt.INCORRECT_VALUE} The 'classSize' must be > 0.0, but ${classSize} was used.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, `The 'classSize' must be > 0.0, but ${classSize} was used.`);
         }
     }
 
@@ -79,7 +79,7 @@ export default class GlobalStandardDev extends Classifier {
 
     _updateBreakpointsWith (metadata) {
         if (this.input.propertyName === CLUSTER_FEATURE_COUNT) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'clusterCount' can not be used in GlobalStandardDev. Consider using ViewportStandardDev instead`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, `'clusterCount' can not be used in GlobalStandardDev. Consider using ViewportStandardDev instead`);
         }
         const name = this.input.name;
         const sample = metadata.sample.map(s => s[name]);
@@ -106,7 +106,7 @@ export default class GlobalStandardDev extends Classifier {
 export function calculateBreakpoints (avg, stDev, buckets, classSize) {
     if (stDev === 0 || isNaN(stDev)) {
         throw new CartoRuntimeError(
-            `${runtimeErrors.NOT_SUPPORTED} There is no Standard Deviation, not possible to compute ${buckets} buckets (just one feature or maybe all share the same value...?)`
+            crt.NOT_SUPPORTED, `There is no Standard Deviation, not possible to compute ${buckets} buckets (just one feature or maybe all share the same value...?)`
         );
     }
 

--- a/src/renderer/viz/expressions/classification/ViewportQuantiles.js
+++ b/src/renderer/viz/expressions/classification/ViewportQuantiles.js
@@ -58,7 +58,10 @@ export default class ViewportQuantiles extends Classifier {
         const histogramSize = this._histogramSize.value;
         checkNumber(this.expressionName, 'histogramSize', 2, histogramSize);
         if (histogramSize <= 0) {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, `The 'histogramSize' must be > 0, but ${histogramSize} was used`);
+            throw new CartoValidationError(
+                `The 'histogramSize' must be > 0, but ${histogramSize} was used`,
+                cvt.INCORRECT_VALUE
+            );
         }
     }
 

--- a/src/renderer/viz/expressions/classification/ViewportQuantiles.js
+++ b/src/renderer/viz/expressions/classification/ViewportQuantiles.js
@@ -1,6 +1,6 @@
 import Classifier from './Classifier';
 import { checkNumber, checkType, checkMaxArguments, checkMinArguments, implicitCast } from '../utils';
-import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../errors/carto-validation-error';
 
 import { viewportHistogram } from '../../expressions';
 import { DEFAULT_HISTOGRAM_SIZE } from './Classifier';
@@ -60,7 +60,7 @@ export default class ViewportQuantiles extends Classifier {
         if (histogramSize <= 0) {
             throw new CartoValidationError(
                 `The 'histogramSize' must be > 0, but ${histogramSize} was used`,
-                CartoValidationTypes.INCORRECT_VALUE
+                CartoValidationErrorTypes.INCORRECT_VALUE
             );
         }
     }

--- a/src/renderer/viz/expressions/classification/ViewportQuantiles.js
+++ b/src/renderer/viz/expressions/classification/ViewportQuantiles.js
@@ -58,7 +58,7 @@ export default class ViewportQuantiles extends Classifier {
         const histogramSize = this._histogramSize.value;
         checkNumber(this.expressionName, 'histogramSize', 2, histogramSize);
         if (histogramSize <= 0) {
-            throw new CartoValidationError(`${cvt.INCORRECT_VALUE} The 'histogramSize' must be > 0, but ${histogramSize} was used`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, `The 'histogramSize' must be > 0, but ${histogramSize} was used`);
         }
     }
 

--- a/src/renderer/viz/expressions/classification/ViewportQuantiles.js
+++ b/src/renderer/viz/expressions/classification/ViewportQuantiles.js
@@ -1,6 +1,6 @@
 import Classifier from './Classifier';
 import { checkNumber, checkType, checkMaxArguments, checkMinArguments, implicitCast } from '../utils';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
 
 import { viewportHistogram } from '../../expressions';
 import { DEFAULT_HISTOGRAM_SIZE } from './Classifier';
@@ -60,7 +60,7 @@ export default class ViewportQuantiles extends Classifier {
         if (histogramSize <= 0) {
             throw new CartoValidationError(
                 `The 'histogramSize' must be > 0, but ${histogramSize} was used`,
-                cvt.INCORRECT_VALUE
+                CartoValidationTypes.INCORRECT_VALUE
             );
         }
     }

--- a/src/renderer/viz/expressions/classification/ViewportStandardDev.js
+++ b/src/renderer/viz/expressions/classification/ViewportStandardDev.js
@@ -80,7 +80,7 @@ export default class ViewportStandardDev extends Classifier {
         const classSize = this._classSize.value;
         checkNumber(this.expressionName, 'classSize', 2, classSize);
         if (classSize <= 0) {
-            throw new CartoValidationError(`${cvt.INCORRECT_VALUE} The 'classSize' must be > 0.0, but ${classSize} was used.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, `The 'classSize' must be > 0.0, but ${classSize} was used.`);
         }
     }
 
@@ -88,7 +88,7 @@ export default class ViewportStandardDev extends Classifier {
         const histogramSize = this._histogramSize.value;
         checkNumber(this.expressionName, 'histogramSize', 3, histogramSize);
         if (histogramSize <= 0) {
-            throw new CartoValidationError(`${cvt.INCORRECT_VALUE} The 'histogramSize' must be > 0, but ${histogramSize} was used`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, `The 'histogramSize' must be > 0, but ${histogramSize} was used`);
         }
     }
 

--- a/src/renderer/viz/expressions/classification/ViewportStandardDev.js
+++ b/src/renderer/viz/expressions/classification/ViewportStandardDev.js
@@ -1,6 +1,6 @@
 import Classifier from './Classifier';
 import { checkNumber, checkType, checkMaxArguments, checkMinArguments } from '../utils';
-import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../errors/carto-validation-error';
 
 import { viewportHistogram } from '../../expressions';
 import { calculateBreakpoints } from './GlobalStandardDev';
@@ -82,7 +82,7 @@ export default class ViewportStandardDev extends Classifier {
         if (classSize <= 0) {
             throw new CartoValidationError(
                 `The 'classSize' must be > 0.0, but ${classSize} was used.`,
-                CartoValidationTypes.INCORRECT_VALUE
+                CartoValidationErrorTypes.INCORRECT_VALUE
             );
         }
     }
@@ -93,7 +93,7 @@ export default class ViewportStandardDev extends Classifier {
         if (histogramSize <= 0) {
             throw new CartoValidationError(
                 `The 'histogramSize' must be > 0, but ${histogramSize} was used`,
-                CartoValidationTypes.INCORRECT_VALUE
+                CartoValidationErrorTypes.INCORRECT_VALUE
             );
         }
     }

--- a/src/renderer/viz/expressions/classification/ViewportStandardDev.js
+++ b/src/renderer/viz/expressions/classification/ViewportStandardDev.js
@@ -1,6 +1,6 @@
 import Classifier from './Classifier';
 import { checkNumber, checkType, checkMaxArguments, checkMinArguments } from '../utils';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
 
 import { viewportHistogram } from '../../expressions';
 import { calculateBreakpoints } from './GlobalStandardDev';
@@ -82,7 +82,7 @@ export default class ViewportStandardDev extends Classifier {
         if (classSize <= 0) {
             throw new CartoValidationError(
                 `The 'classSize' must be > 0.0, but ${classSize} was used.`,
-                cvt.INCORRECT_VALUE
+                CartoValidationTypes.INCORRECT_VALUE
             );
         }
     }
@@ -93,7 +93,7 @@ export default class ViewportStandardDev extends Classifier {
         if (histogramSize <= 0) {
             throw new CartoValidationError(
                 `The 'histogramSize' must be > 0, but ${histogramSize} was used`,
-                cvt.INCORRECT_VALUE
+                CartoValidationTypes.INCORRECT_VALUE
             );
         }
     }

--- a/src/renderer/viz/expressions/classification/ViewportStandardDev.js
+++ b/src/renderer/viz/expressions/classification/ViewportStandardDev.js
@@ -80,7 +80,10 @@ export default class ViewportStandardDev extends Classifier {
         const classSize = this._classSize.value;
         checkNumber(this.expressionName, 'classSize', 2, classSize);
         if (classSize <= 0) {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, `The 'classSize' must be > 0.0, but ${classSize} was used.`);
+            throw new CartoValidationError(
+                `The 'classSize' must be > 0.0, but ${classSize} was used.`,
+                cvt.INCORRECT_VALUE
+            );
         }
     }
 
@@ -88,7 +91,10 @@ export default class ViewportStandardDev extends Classifier {
         const histogramSize = this._histogramSize.value;
         checkNumber(this.expressionName, 'histogramSize', 3, histogramSize);
         if (histogramSize <= 0) {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, `The 'histogramSize' must be > 0, but ${histogramSize} was used`);
+            throw new CartoValidationError(
+                `The 'histogramSize' must be > 0, but ${histogramSize} was used`,
+                cvt.INCORRECT_VALUE
+            );
         }
     }
 

--- a/src/renderer/viz/expressions/color/NamedColor.js
+++ b/src/renderer/viz/expressions/color/NamedColor.js
@@ -1,7 +1,7 @@
 import BaseExpression from '../base';
 import { checkString, checkMaxArguments, getStringErrorPreface } from '../utils';
 import { CSS_COLOR_NAMES } from './cssColorNames';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
 
 /**
  * Create a color from its name.
@@ -34,7 +34,7 @@ export default class NamedColor extends BaseExpression {
             const preface = getStringErrorPreface('namedColor', 'colorName', 0);
             throw new CartoValidationError(
                 `${preface}\nInvalid color name:  '${colorName}'`,
-                cvt.INCORRECT_VALUE
+                CartoValidationTypes.INCORRECT_VALUE
             );
         }
         super({});

--- a/src/renderer/viz/expressions/color/NamedColor.js
+++ b/src/renderer/viz/expressions/color/NamedColor.js
@@ -1,7 +1,7 @@
 import BaseExpression from '../base';
 import { checkString, checkMaxArguments, getStringErrorPreface } from '../utils';
 import { CSS_COLOR_NAMES } from './cssColorNames';
-import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../errors/carto-validation-error';
 
 /**
  * Create a color from its name.
@@ -34,7 +34,7 @@ export default class NamedColor extends BaseExpression {
             const preface = getStringErrorPreface('namedColor', 'colorName', 0);
             throw new CartoValidationError(
                 `${preface}\nInvalid color name:  '${colorName}'`,
-                CartoValidationTypes.INCORRECT_VALUE
+                CartoValidationErrorTypes.INCORRECT_VALUE
             );
         }
         super({});

--- a/src/renderer/viz/expressions/color/NamedColor.js
+++ b/src/renderer/viz/expressions/color/NamedColor.js
@@ -32,7 +32,10 @@ export default class NamedColor extends BaseExpression {
 
         if (!CSS_COLOR_NAMES.includes(colorName.toLowerCase())) {
             const preface = getStringErrorPreface('namedColor', 'colorName', 0);
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, `${preface}\nInvalid color name:  '${colorName}'`);
+            throw new CartoValidationError(
+                `${preface}\nInvalid color name:  '${colorName}'`,
+                cvt.INCORRECT_VALUE
+            );
         }
         super({});
         this.type = 'color';

--- a/src/renderer/viz/expressions/color/NamedColor.js
+++ b/src/renderer/viz/expressions/color/NamedColor.js
@@ -32,7 +32,7 @@ export default class NamedColor extends BaseExpression {
 
         if (!CSS_COLOR_NAMES.includes(colorName.toLowerCase())) {
             const preface = getStringErrorPreface('namedColor', 'colorName', 0);
-            throw new CartoValidationError(`${cvt.INCORRECT_VALUE} ${preface}\nInvalid color name:  '${colorName}'`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, `${preface}\nInvalid color name:  '${colorName}'`);
         }
         super({});
         this.type = 'color';

--- a/src/renderer/viz/expressions/color/hex.js
+++ b/src/renderer/viz/expressions/color/hex.js
@@ -35,7 +35,10 @@ export default class Hex extends BaseExpression {
             this.color = hexToRgb(hexadecimalColor);
         } catch (error) {
             const preface = getStringErrorPreface('hex', 'hexadecimalColor', 0);
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, `${preface} \nInvalid hexadecimal color string`);
+            throw new CartoValidationError(
+                `${preface} \nInvalid hexadecimal color string`,
+                cvt.INCORRECT_VALUE
+            );
         }
         this.hexadecimalColor = hexadecimalColor;
         this.inlineMaker = () => `vec4(${(this.color.r / 255).toFixed(4)}, ${(this.color.g / 255).toFixed(4)}, ${(this.color.b / 255).toFixed(4)}, ${(this.color.a).toFixed(4)})`;

--- a/src/renderer/viz/expressions/color/hex.js
+++ b/src/renderer/viz/expressions/color/hex.js
@@ -1,6 +1,6 @@
 import BaseExpression from '../base';
 import { checkString, hexToRgb, getStringErrorPreface, checkMaxArguments } from '../utils';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
 
 /**
  * Create a color from its hexadecimal description.
@@ -37,7 +37,7 @@ export default class Hex extends BaseExpression {
             const preface = getStringErrorPreface('hex', 'hexadecimalColor', 0);
             throw new CartoValidationError(
                 `${preface} \nInvalid hexadecimal color string`,
-                cvt.INCORRECT_VALUE
+                CartoValidationTypes.INCORRECT_VALUE
             );
         }
         this.hexadecimalColor = hexadecimalColor;

--- a/src/renderer/viz/expressions/color/hex.js
+++ b/src/renderer/viz/expressions/color/hex.js
@@ -1,6 +1,6 @@
 import BaseExpression from '../base';
 import { checkString, hexToRgb, getStringErrorPreface, checkMaxArguments } from '../utils';
-import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../errors/carto-validation-error';
 
 /**
  * Create a color from its hexadecimal description.
@@ -37,7 +37,7 @@ export default class Hex extends BaseExpression {
             const preface = getStringErrorPreface('hex', 'hexadecimalColor', 0);
             throw new CartoValidationError(
                 `${preface} \nInvalid hexadecimal color string`,
-                CartoValidationTypes.INCORRECT_VALUE
+                CartoValidationErrorTypes.INCORRECT_VALUE
             );
         }
         this.hexadecimalColor = hexadecimalColor;

--- a/src/renderer/viz/expressions/color/hex.js
+++ b/src/renderer/viz/expressions/color/hex.js
@@ -35,7 +35,7 @@ export default class Hex extends BaseExpression {
             this.color = hexToRgb(hexadecimalColor);
         } catch (error) {
             const preface = getStringErrorPreface('hex', 'hexadecimalColor', 0);
-            throw new CartoValidationError(`${cvt.INCORRECT_VALUE} ${preface} \nInvalid hexadecimal color string`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, `${preface} \nInvalid hexadecimal color string`);
         }
         this.hexadecimalColor = hexadecimalColor;
         this.inlineMaker = () => `vec4(${(this.color.r / 255).toFixed(4)}, ${(this.color.g / 255).toFixed(4)}, ${(this.color.b / 255).toFixed(4)}, ${(this.color.a).toFixed(4)})`;

--- a/src/renderer/viz/expressions/color/hsl.js
+++ b/src/renderer/viz/expressions/color/hsl.js
@@ -1,7 +1,7 @@
 
 import BaseExpression from '../base';
 import { implicitCast, checkExpression, checkType, checkMaxArguments, clamp } from '../utils';
-import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../errors/carto-validation-error';
 
 /**
  * Evaluates to a hsl color.
@@ -157,7 +157,7 @@ function genHSL (name, alpha) {
         if (parameter.type !== 'number' && parameter.type !== 'category' && parameter.type !== undefined) {
             throw new CartoValidationError(
                 `${name}(): invalid parameter\n\t${parameterName} type was: '${parameter.type}'`,
-                CartoValidationTypes.INCORRECT_TYPE
+                CartoValidationErrorTypes.INCORRECT_TYPE
             );
         }
     }

--- a/src/renderer/viz/expressions/color/hsl.js
+++ b/src/renderer/viz/expressions/color/hsl.js
@@ -155,7 +155,10 @@ function genHSL (name, alpha) {
     function hslCheckType (parameterName, parameterIndex, parameter) {
         checkExpression(name, parameterName, parameterIndex, parameter);
         if (parameter.type !== 'number' && parameter.type !== 'category' && parameter.type !== undefined) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, `${name}(): invalid parameter\n\t${parameterName} type was: '${parameter.type}'`);
+            throw new CartoValidationError(
+                `${name}(): invalid parameter\n\t${parameterName} type was: '${parameter.type}'`,
+                cvt.INCORRECT_TYPE
+            );
         }
     }
 }

--- a/src/renderer/viz/expressions/color/hsl.js
+++ b/src/renderer/viz/expressions/color/hsl.js
@@ -155,7 +155,7 @@ function genHSL (name, alpha) {
     function hslCheckType (parameterName, parameterIndex, parameter) {
         checkExpression(name, parameterName, parameterIndex, parameter);
         if (parameter.type !== 'number' && parameter.type !== 'category' && parameter.type !== undefined) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} ${name}(): invalid parameter\n\t${parameterName} type was: '${parameter.type}'`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, `${name}(): invalid parameter\n\t${parameterName} type was: '${parameter.type}'`);
         }
     }
 }

--- a/src/renderer/viz/expressions/color/hsl.js
+++ b/src/renderer/viz/expressions/color/hsl.js
@@ -1,7 +1,7 @@
 
 import BaseExpression from '../base';
 import { implicitCast, checkExpression, checkType, checkMaxArguments, clamp } from '../utils';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
 
 /**
  * Evaluates to a hsl color.
@@ -157,7 +157,7 @@ function genHSL (name, alpha) {
         if (parameter.type !== 'number' && parameter.type !== 'category' && parameter.type !== undefined) {
             throw new CartoValidationError(
                 `${name}(): invalid parameter\n\t${parameterName} type was: '${parameter.type}'`,
-                cvt.INCORRECT_TYPE
+                CartoValidationTypes.INCORRECT_TYPE
             );
         }
     }

--- a/src/renderer/viz/expressions/color/hsv.js
+++ b/src/renderer/viz/expressions/color/hsv.js
@@ -155,7 +155,10 @@ function genHSV (name, alpha) {
     function hsvCheckType (parameterName, parameterIndex, parameter) {
         checkExpression(name, parameterName, parameterIndex, parameter);
         if (parameter.type !== 'number' && parameter.type !== 'category' && parameter.type !== undefined) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, `${name}(): invalid parameter\n\t${parameterName} type was: '${parameter.type}'`);
+            throw new CartoValidationError(
+                `${name}(): invalid parameter\n\t${parameterName} type was: '${parameter.type}'`,
+                cvt.INCORRECT_TYPE
+            );
         }
     }
 }

--- a/src/renderer/viz/expressions/color/hsv.js
+++ b/src/renderer/viz/expressions/color/hsv.js
@@ -1,6 +1,6 @@
 import BaseExpression from '../base';
 import { implicitCast, checkExpression, checkType, checkMaxArguments, clamp } from '../utils';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
 
 /**
  * Evaluates to a hsv color.
@@ -157,7 +157,7 @@ function genHSV (name, alpha) {
         if (parameter.type !== 'number' && parameter.type !== 'category' && parameter.type !== undefined) {
             throw new CartoValidationError(
                 `${name}(): invalid parameter\n\t${parameterName} type was: '${parameter.type}'`,
-                cvt.INCORRECT_TYPE
+                CartoValidationTypes.INCORRECT_TYPE
             );
         }
     }

--- a/src/renderer/viz/expressions/color/hsv.js
+++ b/src/renderer/viz/expressions/color/hsv.js
@@ -1,6 +1,6 @@
 import BaseExpression from '../base';
 import { implicitCast, checkExpression, checkType, checkMaxArguments, clamp } from '../utils';
-import CartoValidationError, { CartoValidationTypes } from '../../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../errors/carto-validation-error';
 
 /**
  * Evaluates to a hsv color.
@@ -157,7 +157,7 @@ function genHSV (name, alpha) {
         if (parameter.type !== 'number' && parameter.type !== 'category' && parameter.type !== undefined) {
             throw new CartoValidationError(
                 `${name}(): invalid parameter\n\t${parameterName} type was: '${parameter.type}'`,
-                CartoValidationTypes.INCORRECT_TYPE
+                CartoValidationErrorTypes.INCORRECT_TYPE
             );
         }
     }

--- a/src/renderer/viz/expressions/color/hsv.js
+++ b/src/renderer/viz/expressions/color/hsv.js
@@ -155,7 +155,7 @@ function genHSV (name, alpha) {
     function hsvCheckType (parameterName, parameterIndex, parameter) {
         checkExpression(name, parameterName, parameterIndex, parameter);
         if (parameter.type !== 'number' && parameter.type !== 'category' && parameter.type !== undefined) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} ${name}(): invalid parameter\n\t${parameterName} type was: '${parameter.type}'`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, `${name}(): invalid parameter\n\t${parameterName} type was: '${parameter.type}'`);
         }
     }
 }

--- a/src/renderer/viz/expressions/interpolators.js
+++ b/src/renderer/viz/expressions/interpolators.js
@@ -75,7 +75,9 @@ function genInterpolator (name, inlineMaker, preface, jsEval) {
         _bindMetadata (meta) {
             super._bindMetadata(meta);
             if (this.m.type !== 'number') {
-                throw new CartoValidationError(cvt.INCORRECT_TYPE, `Blending cannot be performed by '${this.m.type}'`);
+                throw new CartoValidationError(
+                    `Blending cannot be performed by '${this.m.type}'`,
+                    cvt.INCORRECT_TYPE);
             }
             this.type = 'number';
             this._setGenericGLSL(inline => inlineMaker(inline.m), preface);

--- a/src/renderer/viz/expressions/interpolators.js
+++ b/src/renderer/viz/expressions/interpolators.js
@@ -75,7 +75,7 @@ function genInterpolator (name, inlineMaker, preface, jsEval) {
         _bindMetadata (meta) {
             super._bindMetadata(meta);
             if (this.m.type !== 'number') {
-                throw new CartoValidationError(`${cvt.INCORRECT_TYPE} Blending cannot be performed by '${this.m.type}'`);
+                throw new CartoValidationError(cvt.INCORRECT_TYPE, `Blending cannot be performed by '${this.m.type}'`);
             }
             this.type = 'number';
             this._setGenericGLSL(inline => inlineMaker(inline.m), preface);

--- a/src/renderer/viz/expressions/interpolators.js
+++ b/src/renderer/viz/expressions/interpolators.js
@@ -1,6 +1,6 @@
 import { implicitCast, checkMaxArguments } from './utils';
 import BaseExpression from './base';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
 
 // TODO type checking
 
@@ -77,7 +77,7 @@ function genInterpolator (name, inlineMaker, preface, jsEval) {
             if (this.m.type !== 'number') {
                 throw new CartoValidationError(
                     `Blending cannot be performed by '${this.m.type}'`,
-                    cvt.INCORRECT_TYPE);
+                    CartoValidationTypes.INCORRECT_TYPE);
             }
             this.type = 'number';
             this._setGenericGLSL(inline => inlineMaker(inline.m), preface);

--- a/src/renderer/viz/expressions/interpolators.js
+++ b/src/renderer/viz/expressions/interpolators.js
@@ -1,6 +1,6 @@
 import { implicitCast, checkMaxArguments } from './utils';
 import BaseExpression from './base';
-import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../errors/carto-validation-error';
 
 // TODO type checking
 
@@ -77,7 +77,7 @@ function genInterpolator (name, inlineMaker, preface, jsEval) {
             if (this.m.type !== 'number') {
                 throw new CartoValidationError(
                     `Blending cannot be performed by '${this.m.type}'`,
-                    CartoValidationTypes.INCORRECT_TYPE);
+                    CartoValidationErrorTypes.INCORRECT_TYPE);
             }
             this.type = 'number';
             this._setGenericGLSL(inline => inlineMaker(inline.m), preface);

--- a/src/renderer/viz/expressions/top.js
+++ b/src/renderer/viz/expressions/top.js
@@ -2,7 +2,7 @@ import BaseExpression from './base';
 import { checkType, implicitCast, checkFeatureIndependent, checkInstance, checkMaxArguments } from './utils';
 import Property from './basic/property';
 import { number } from '../expressions';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
 import { OTHERS_INDEX, OTHERS_GLSL_VALUE, OTHERS_LABEL } from './constants';
 
 // Careful! This constant must match with the shader code of the Top expression
@@ -101,7 +101,7 @@ export default class Top extends BaseExpression {
             setTimeout(() => {
                 throw new CartoValidationError(
                     `top() function has a limit of ${MAX_TOP_BUCKETS} buckets but '${prev}' buckets were specified.`,
-                    cvt.INCORRECT_VALUE
+                    CartoValidationTypes.INCORRECT_VALUE
                 );
             });
             buckets = 0;

--- a/src/renderer/viz/expressions/top.js
+++ b/src/renderer/viz/expressions/top.js
@@ -100,7 +100,7 @@ export default class Top extends BaseExpression {
             const prev = this.buckets.eval();
             setTimeout(() => {
                 throw new CartoValidationError(
-                    `${cvt.INCORRECT_VALUE} top() function has a limit of ${MAX_TOP_BUCKETS} buckets but '${prev}' buckets were specified.`
+                    cvt.INCORRECT_VALUE, `top() function has a limit of ${MAX_TOP_BUCKETS} buckets but '${prev}' buckets were specified.`
                 );
             });
             buckets = 0;

--- a/src/renderer/viz/expressions/top.js
+++ b/src/renderer/viz/expressions/top.js
@@ -2,7 +2,7 @@ import BaseExpression from './base';
 import { checkType, implicitCast, checkFeatureIndependent, checkInstance, checkMaxArguments } from './utils';
 import Property from './basic/property';
 import { number } from '../expressions';
-import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../errors/carto-validation-error';
 import { OTHERS_INDEX, OTHERS_GLSL_VALUE, OTHERS_LABEL } from './constants';
 
 // Careful! This constant must match with the shader code of the Top expression
@@ -101,7 +101,7 @@ export default class Top extends BaseExpression {
             setTimeout(() => {
                 throw new CartoValidationError(
                     `top() function has a limit of ${MAX_TOP_BUCKETS} buckets but '${prev}' buckets were specified.`,
-                    CartoValidationTypes.INCORRECT_VALUE
+                    CartoValidationErrorTypes.INCORRECT_VALUE
                 );
             });
             buckets = 0;

--- a/src/renderer/viz/expressions/top.js
+++ b/src/renderer/viz/expressions/top.js
@@ -100,7 +100,8 @@ export default class Top extends BaseExpression {
             const prev = this.buckets.eval();
             setTimeout(() => {
                 throw new CartoValidationError(
-                    cvt.INCORRECT_VALUE, `top() function has a limit of ${MAX_TOP_BUCKETS} buckets but '${prev}' buckets were specified.`
+                    `top() function has a limit of ${MAX_TOP_BUCKETS} buckets but '${prev}' buckets were specified.`,
+                    cvt.INCORRECT_VALUE
                 );
             });
             buckets = 0;

--- a/src/renderer/viz/expressions/transition.js
+++ b/src/renderer/viz/expressions/transition.js
@@ -1,6 +1,6 @@
 import BaseExpression from './base';
 import { checkNumber, checkMaxArguments, getStringErrorPreface } from './utils';
-import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../errors/carto-validation-error';
 
 /**
  * Transition returns a number from zero to one based on the elapsed number of milliseconds since the viz was instantiated.
@@ -23,7 +23,7 @@ export default class Transition extends BaseExpression {
             const preface = getStringErrorPreface('transition', 'duration', 0);
             throw new CartoValidationError(
                 `${preface} 'duration' must be greater than or equal to 0.`,
-                CartoValidationTypes.INCORRECT_VALUE
+                CartoValidationErrorTypes.INCORRECT_VALUE
             );
         }
         super({});

--- a/src/renderer/viz/expressions/transition.js
+++ b/src/renderer/viz/expressions/transition.js
@@ -21,7 +21,10 @@ export default class Transition extends BaseExpression {
         checkNumber('transition', 'duration', 0, duration);
         if (duration < 0) {
             const preface = getStringErrorPreface('transition', 'duration', 0);
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, `${preface} 'duration' must be greater than or equal to 0.`);
+            throw new CartoValidationError(
+                `${preface} 'duration' must be greater than or equal to 0.`,
+                cvt.INCORRECT_VALUE
+            );
         }
         super({});
         this.aTime = Date.now();

--- a/src/renderer/viz/expressions/transition.js
+++ b/src/renderer/viz/expressions/transition.js
@@ -21,7 +21,7 @@ export default class Transition extends BaseExpression {
         checkNumber('transition', 'duration', 0, duration);
         if (duration < 0) {
             const preface = getStringErrorPreface('transition', 'duration', 0);
-            throw new CartoValidationError(`${cvt.INCORRECT_VALUE} ${preface} 'duration' must be greater than or equal to 0.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, `${preface} 'duration' must be greater than or equal to 0.`);
         }
         super({});
         this.aTime = Date.now();

--- a/src/renderer/viz/expressions/transition.js
+++ b/src/renderer/viz/expressions/transition.js
@@ -1,6 +1,6 @@
 import BaseExpression from './base';
 import { checkNumber, checkMaxArguments, getStringErrorPreface } from './utils';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
 
 /**
  * Transition returns a number from zero to one based on the elapsed number of milliseconds since the viz was instantiated.
@@ -23,7 +23,7 @@ export default class Transition extends BaseExpression {
             const preface = getStringErrorPreface('transition', 'duration', 0);
             throw new CartoValidationError(
                 `${preface} 'duration' must be greater than or equal to 0.`,
-                cvt.INCORRECT_VALUE
+                CartoValidationTypes.INCORRECT_VALUE
             );
         }
         super({});

--- a/src/renderer/viz/expressions/utils.js
+++ b/src/renderer/viz/expressions/utils.js
@@ -1,6 +1,6 @@
 import { number, category, list, rgba } from '../expressions';
 import BaseExpression from './base';
-import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../errors/carto-validation-error';
 import CartoParsingError from '../../../errors/carto-parsing-error';
 import { interpolateRGBAinCieLAB } from '../colorspaces';
 
@@ -10,7 +10,7 @@ export function checkMaxArguments (constructorArguments, maxArguments, expressio
     if (constructorArguments.length > maxArguments) {
         throw new CartoValidationError(
             `Expression '${expressionName}' accepts just ${maxArguments} arguments, but ${constructorArguments.length} were passed.`,
-            CartoValidationTypes.TOO_MANY_ARGS
+            CartoValidationErrorTypes.TOO_MANY_ARGS
         );
     }
 }
@@ -19,7 +19,7 @@ export function checkMinArguments (constructorArguments, minArguments, expressio
     if (constructorArguments.length < minArguments) {
         throw new CartoValidationError(
             `Expression '${expressionName}' accepts at least ${minArguments} arguments, but ${constructorArguments.length} were passed.`,
-            CartoValidationTypes.NOT_ENOUGH_ARGS
+            CartoValidationErrorTypes.NOT_ENOUGH_ARGS
         );
     }
 }
@@ -28,7 +28,7 @@ export function checkExactNumberOfArguments (constructorArguments, numArguments,
     if (constructorArguments.length !== numArguments) {
         throw new CartoValidationError(
             `Expression '${expressionName}' accepts exactly ${numArguments} arguments, but ${constructorArguments.length} were passed.`,
-            CartoValidationTypes.WRONG_NUMBER_ARGS
+            CartoValidationErrorTypes.WRONG_NUMBER_ARGS
         );
     }
 }
@@ -118,7 +118,7 @@ export function getStringErrorPreface (expressionName, parameterName, parameterI
 
 export function throwInvalidType (expressionName, parameterName, parameterIndex, expectedType, actualType) {
     throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-        expected type was '${expectedType}', actual type was '${actualType}'`, CartoValidationTypes.INCORRECT_TYPE);
+        expected type was '${expectedType}', actual type was '${actualType}'`, CartoValidationErrorTypes.INCORRECT_TYPE);
 }
 
 export function throwInvalidInstance (expressionName, parameterName, parameterIndex, expectedClass) {
@@ -126,27 +126,27 @@ export function throwInvalidInstance (expressionName, parameterName, parameterIn
         ? expectedClass.join(', ')
         : expectedClass.name;
     throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-    expected type was instance of '${expectedClassNames}'`, CartoValidationTypes.INCORRECT_TYPE);
+    expected type was instance of '${expectedClassNames}'`, CartoValidationErrorTypes.INCORRECT_TYPE);
 }
 
 export function throwInvalidNumber (expressionName, parameterName, parameterIndex, number) {
     throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-    type of '${number}' is ${typeof number}, 'number' was expected`, CartoValidationTypes.INCORRECT_TYPE);
+    type of '${number}' is ${typeof number}, 'number' was expected`, CartoValidationErrorTypes.INCORRECT_TYPE);
 }
 
 export function throwInvalidArray (expressionName, parameterName, parameterIndex, array) {
     throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-    '${array}' is not an array`, CartoValidationTypes.INCORRECT_TYPE);
+    '${array}' is not an array`, CartoValidationErrorTypes.INCORRECT_TYPE);
 }
 
 export function throwInvalidString (expressionName, parameterName, parameterIndex, str) {
     throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-    expected type was 'string', but ${str}' is not a string`, CartoValidationTypes.INCORRECT_TYPE);
+    expected type was 'string', but ${str}' is not a string`, CartoValidationErrorTypes.INCORRECT_TYPE);
 }
 
 export function throwInvalidStringValue (expressionName, parameterName, parameterIndex, str, validValues) {
     throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-    value '${str}' is not valid. It should be one of ${validValues.map(v => `'${v}'`).join(', ')}`, CartoValidationTypes.INCORRECT_TYPE);
+    value '${str}' is not valid. It should be one of ${validValues.map(v => `'${v}'`).join(', ')}`, CartoValidationErrorTypes.INCORRECT_TYPE);
 }
 
 // Returns true if the argument is of a type that cannot be strictly checked at constructor time
@@ -167,7 +167,7 @@ export function isArgConstructorTimeTyped (arg) {
 export function checkExpression (expressionName, parameterName, parameterIndex, parameter) {
     if (!(parameter instanceof BaseExpression)) {
         throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-        '${parameter}' is not of type "carto.expressions.Base"`, CartoValidationTypes.INCORRECT_TYPE);
+        '${parameter}' is not of type "carto.expressions.Base"`, CartoValidationErrorTypes.INCORRECT_TYPE);
     }
 }
 
@@ -179,7 +179,7 @@ export function checkType (expressionName, parameterName, parameterIndex, expect
         );
         if (!ok) {
             throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-            expected type was one of ${expectedType.join()}, actual type was '${parameter.type}'`, CartoValidationTypes.INCORRECT_TYPE);
+            expected type was one of ${expectedType.join()}, actual type was '${parameter.type}'`, CartoValidationErrorTypes.INCORRECT_TYPE);
         }
     } else if (parameter.type !== expectedType) {
         throwInvalidType(expressionName, parameterName, parameterIndex, expectedType, parameter.type);
@@ -231,14 +231,14 @@ export function checkArray (expressionName, parameterName, parameterIndex, array
 export function checkFeatureIndependent (expressionName, parameterName, parameterIndex, parameter) {
     if (parameter.isFeatureDependent()) {
         throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-        parameter cannot be feature dependent`, CartoValidationTypes.INCORRECT_VALUE);
+        parameter cannot be feature dependent`, CartoValidationErrorTypes.INCORRECT_VALUE);
     }
 }
 
 export function checkFeatureDependent (expressionName, parameterName, parameterIndex, parameter) {
     if (!parameter.isFeatureDependent()) {
         throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-        parameter must be feature dependent`, CartoValidationTypes.INCORRECT_VALUE);
+        parameter must be feature dependent`, CartoValidationErrorTypes.INCORRECT_VALUE);
     }
 }
 

--- a/src/renderer/viz/expressions/utils.js
+++ b/src/renderer/viz/expressions/utils.js
@@ -8,19 +8,19 @@ export const DEFAULT = undefined;
 
 export function checkMaxArguments (constructorArguments, maxArguments, expressionName) {
     if (constructorArguments.length > maxArguments) {
-        throw new CartoValidationError(`${cvt.TOO_MANY_ARGS} Expression '${expressionName}' accepts just ${maxArguments} arguments, but ${constructorArguments.length} were passed.`);
+        throw new CartoValidationError(cvt.TOO_MANY_ARGS, `Expression '${expressionName}' accepts just ${maxArguments} arguments, but ${constructorArguments.length} were passed.`);
     }
 }
 
 export function checkMinArguments (constructorArguments, minArguments, expressionName) {
     if (constructorArguments.length < minArguments) {
-        throw new CartoValidationError(`${cvt.NOT_ENOUGH_ARGS} Expression '${expressionName}' accepts at least ${minArguments} arguments, but ${constructorArguments.length} were passed.`);
+        throw new CartoValidationError(cvt.NOT_ENOUGH_ARGS, `Expression '${expressionName}' accepts at least ${minArguments} arguments, but ${constructorArguments.length} were passed.`);
     }
 }
 
 export function checkExactNumberOfArguments (constructorArguments, numArguments, expressionName) {
     if (constructorArguments.length !== numArguments) {
-        throw new CartoValidationError(`${cvt.WRONG_NUMBER_ARGS} Expression '${expressionName}' accepts exactly ${numArguments} arguments, but ${constructorArguments.length} were passed.`);
+        throw new CartoValidationError(cvt.WRONG_NUMBER_ARGS, `Expression '${expressionName}' accepts exactly ${numArguments} arguments, but ${constructorArguments.length} were passed.`);
     }
 }
 
@@ -108,7 +108,7 @@ export function getStringErrorPreface (expressionName, parameterName, parameterI
 }
 
 export function throwInvalidType (expressionName, parameterName, parameterIndex, expectedType, actualType) {
-    throw new CartoValidationError(`${cvt.INCORRECT_TYPE} ${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+    throw new CartoValidationError(cvt.INCORRECT_TYPE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
     expected type was '${expectedType}', actual type was '${actualType}'`);
 }
 
@@ -116,27 +116,27 @@ export function throwInvalidInstance (expressionName, parameterName, parameterIn
     const expectedClassNames = Array.isArray(expectedClass)
         ? expectedClass.join(', ')
         : expectedClass.name;
-    throw new CartoValidationError(`${cvt.INCORRECT_TYPE} ${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+    throw new CartoValidationError(cvt.INCORRECT_TYPE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
     expected type was instance of '${expectedClassNames}'`);
 }
 
 export function throwInvalidNumber (expressionName, parameterName, parameterIndex, number) {
-    throw new CartoValidationError(`${cvt.INCORRECT_TYPE} ${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+    throw new CartoValidationError(cvt.INCORRECT_TYPE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
     type of '${number}' is ${typeof number}, 'number' was expected`);
 }
 
 export function throwInvalidArray (expressionName, parameterName, parameterIndex, array) {
-    throw new CartoValidationError(`${cvt.INCORRECT_TYPE} ${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+    throw new CartoValidationError(cvt.INCORRECT_TYPE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
     '${array}' is not an array`);
 }
 
 export function throwInvalidString (expressionName, parameterName, parameterIndex, str) {
-    throw new CartoValidationError(`${cvt.INCORRECT_TYPE} ${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+    throw new CartoValidationError(cvt.INCORRECT_TYPE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
     expected type was 'string', but ${str}' is not a string`);
 }
 
 export function throwInvalidStringValue (expressionName, parameterName, parameterIndex, str, validValues) {
-    throw new CartoValidationError(`${cvt.INCORRECT_TYPE} ${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+    throw new CartoValidationError(cvt.INCORRECT_TYPE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
     value '${str}' is not valid. It should be one of ${validValues.map(v => `'${v}'`).join(', ')}`);
 }
 
@@ -157,7 +157,7 @@ export function isArgConstructorTimeTyped (arg) {
 
 export function checkExpression (expressionName, parameterName, parameterIndex, parameter) {
     if (!(parameter instanceof BaseExpression)) {
-        throw new CartoValidationError(`${cvt.INCORRECT_TYPE} ${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+        throw new CartoValidationError(cvt.INCORRECT_TYPE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
         '${parameter}' is not of type "carto.expressions.Base"`);
     }
 }
@@ -169,7 +169,7 @@ export function checkType (expressionName, parameterName, parameterIndex, expect
             parameter.type === type
         );
         if (!ok) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} ${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
             expected type was one of ${expectedType.join()}, actual type was '${parameter.type}'`);
         }
     } else if (parameter.type !== expectedType) {
@@ -221,14 +221,14 @@ export function checkArray (expressionName, parameterName, parameterIndex, array
 
 export function checkFeatureIndependent (expressionName, parameterName, parameterIndex, parameter) {
     if (parameter.isFeatureDependent()) {
-        throw new CartoValidationError(`${cvt.INCORRECT_VALUE} ${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+        throw new CartoValidationError(cvt.INCORRECT_VALUE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
         parameter cannot be feature dependent`);
     }
 }
 
 export function checkFeatureDependent (expressionName, parameterName, parameterIndex, parameter) {
     if (!parameter.isFeatureDependent()) {
-        throw new CartoValidationError(`${cvt.INCORRECT_VALUE} ${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+        throw new CartoValidationError(cvt.INCORRECT_VALUE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
         parameter must be feature dependent`);
     }
 }

--- a/src/renderer/viz/expressions/utils.js
+++ b/src/renderer/viz/expressions/utils.js
@@ -1,6 +1,6 @@
 import { number, category, list, rgba } from '../expressions';
 import BaseExpression from './base';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
 import CartoParsingError from '../../../errors/carto-parsing-error';
 import { interpolateRGBAinCieLAB } from '../colorspaces';
 
@@ -10,7 +10,7 @@ export function checkMaxArguments (constructorArguments, maxArguments, expressio
     if (constructorArguments.length > maxArguments) {
         throw new CartoValidationError(
             `Expression '${expressionName}' accepts just ${maxArguments} arguments, but ${constructorArguments.length} were passed.`,
-            cvt.TOO_MANY_ARGS
+            CartoValidationTypes.TOO_MANY_ARGS
         );
     }
 }
@@ -19,7 +19,7 @@ export function checkMinArguments (constructorArguments, minArguments, expressio
     if (constructorArguments.length < minArguments) {
         throw new CartoValidationError(
             `Expression '${expressionName}' accepts at least ${minArguments} arguments, but ${constructorArguments.length} were passed.`,
-            cvt.NOT_ENOUGH_ARGS
+            CartoValidationTypes.NOT_ENOUGH_ARGS
         );
     }
 }
@@ -28,7 +28,7 @@ export function checkExactNumberOfArguments (constructorArguments, numArguments,
     if (constructorArguments.length !== numArguments) {
         throw new CartoValidationError(
             `Expression '${expressionName}' accepts exactly ${numArguments} arguments, but ${constructorArguments.length} were passed.`,
-            cvt.WRONG_NUMBER_ARGS
+            CartoValidationTypes.WRONG_NUMBER_ARGS
         );
     }
 }
@@ -118,7 +118,7 @@ export function getStringErrorPreface (expressionName, parameterName, parameterI
 
 export function throwInvalidType (expressionName, parameterName, parameterIndex, expectedType, actualType) {
     throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-        expected type was '${expectedType}', actual type was '${actualType}'`, cvt.INCORRECT_TYPE);
+        expected type was '${expectedType}', actual type was '${actualType}'`, CartoValidationTypes.INCORRECT_TYPE);
 }
 
 export function throwInvalidInstance (expressionName, parameterName, parameterIndex, expectedClass) {
@@ -126,27 +126,27 @@ export function throwInvalidInstance (expressionName, parameterName, parameterIn
         ? expectedClass.join(', ')
         : expectedClass.name;
     throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-    expected type was instance of '${expectedClassNames}'`, cvt.INCORRECT_TYPE);
+    expected type was instance of '${expectedClassNames}'`, CartoValidationTypes.INCORRECT_TYPE);
 }
 
 export function throwInvalidNumber (expressionName, parameterName, parameterIndex, number) {
     throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-    type of '${number}' is ${typeof number}, 'number' was expected`, cvt.INCORRECT_TYPE);
+    type of '${number}' is ${typeof number}, 'number' was expected`, CartoValidationTypes.INCORRECT_TYPE);
 }
 
 export function throwInvalidArray (expressionName, parameterName, parameterIndex, array) {
     throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-    '${array}' is not an array`, cvt.INCORRECT_TYPE);
+    '${array}' is not an array`, CartoValidationTypes.INCORRECT_TYPE);
 }
 
 export function throwInvalidString (expressionName, parameterName, parameterIndex, str) {
     throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-    expected type was 'string', but ${str}' is not a string`, cvt.INCORRECT_TYPE);
+    expected type was 'string', but ${str}' is not a string`, CartoValidationTypes.INCORRECT_TYPE);
 }
 
 export function throwInvalidStringValue (expressionName, parameterName, parameterIndex, str, validValues) {
     throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-    value '${str}' is not valid. It should be one of ${validValues.map(v => `'${v}'`).join(', ')}`, cvt.INCORRECT_TYPE);
+    value '${str}' is not valid. It should be one of ${validValues.map(v => `'${v}'`).join(', ')}`, CartoValidationTypes.INCORRECT_TYPE);
 }
 
 // Returns true if the argument is of a type that cannot be strictly checked at constructor time
@@ -167,7 +167,7 @@ export function isArgConstructorTimeTyped (arg) {
 export function checkExpression (expressionName, parameterName, parameterIndex, parameter) {
     if (!(parameter instanceof BaseExpression)) {
         throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-        '${parameter}' is not of type "carto.expressions.Base"`, cvt.INCORRECT_TYPE);
+        '${parameter}' is not of type "carto.expressions.Base"`, CartoValidationTypes.INCORRECT_TYPE);
     }
 }
 
@@ -179,7 +179,7 @@ export function checkType (expressionName, parameterName, parameterIndex, expect
         );
         if (!ok) {
             throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-            expected type was one of ${expectedType.join()}, actual type was '${parameter.type}'`, cvt.INCORRECT_TYPE);
+            expected type was one of ${expectedType.join()}, actual type was '${parameter.type}'`, CartoValidationTypes.INCORRECT_TYPE);
         }
     } else if (parameter.type !== expectedType) {
         throwInvalidType(expressionName, parameterName, parameterIndex, expectedType, parameter.type);
@@ -231,14 +231,14 @@ export function checkArray (expressionName, parameterName, parameterIndex, array
 export function checkFeatureIndependent (expressionName, parameterName, parameterIndex, parameter) {
     if (parameter.isFeatureDependent()) {
         throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-        parameter cannot be feature dependent`, cvt.INCORRECT_VALUE);
+        parameter cannot be feature dependent`, CartoValidationTypes.INCORRECT_VALUE);
     }
 }
 
 export function checkFeatureDependent (expressionName, parameterName, parameterIndex, parameter) {
     if (!parameter.isFeatureDependent()) {
         throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-        parameter must be feature dependent`, cvt.INCORRECT_VALUE);
+        parameter must be feature dependent`, CartoValidationTypes.INCORRECT_VALUE);
     }
 }
 

--- a/src/renderer/viz/expressions/utils.js
+++ b/src/renderer/viz/expressions/utils.js
@@ -8,19 +8,28 @@ export const DEFAULT = undefined;
 
 export function checkMaxArguments (constructorArguments, maxArguments, expressionName) {
     if (constructorArguments.length > maxArguments) {
-        throw new CartoValidationError(cvt.TOO_MANY_ARGS, `Expression '${expressionName}' accepts just ${maxArguments} arguments, but ${constructorArguments.length} were passed.`);
+        throw new CartoValidationError(
+            `Expression '${expressionName}' accepts just ${maxArguments} arguments, but ${constructorArguments.length} were passed.`,
+            cvt.TOO_MANY_ARGS
+        );
     }
 }
 
 export function checkMinArguments (constructorArguments, minArguments, expressionName) {
     if (constructorArguments.length < minArguments) {
-        throw new CartoValidationError(cvt.NOT_ENOUGH_ARGS, `Expression '${expressionName}' accepts at least ${minArguments} arguments, but ${constructorArguments.length} were passed.`);
+        throw new CartoValidationError(
+            `Expression '${expressionName}' accepts at least ${minArguments} arguments, but ${constructorArguments.length} were passed.`,
+            cvt.NOT_ENOUGH_ARGS
+        );
     }
 }
 
 export function checkExactNumberOfArguments (constructorArguments, numArguments, expressionName) {
     if (constructorArguments.length !== numArguments) {
-        throw new CartoValidationError(cvt.WRONG_NUMBER_ARGS, `Expression '${expressionName}' accepts exactly ${numArguments} arguments, but ${constructorArguments.length} were passed.`);
+        throw new CartoValidationError(
+            `Expression '${expressionName}' accepts exactly ${numArguments} arguments, but ${constructorArguments.length} were passed.`,
+            cvt.WRONG_NUMBER_ARGS
+        );
     }
 }
 
@@ -108,36 +117,36 @@ export function getStringErrorPreface (expressionName, parameterName, parameterI
 }
 
 export function throwInvalidType (expressionName, parameterName, parameterIndex, expectedType, actualType) {
-    throw new CartoValidationError(cvt.INCORRECT_TYPE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-    expected type was '${expectedType}', actual type was '${actualType}'`);
+    throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+        expected type was '${expectedType}', actual type was '${actualType}'`, cvt.INCORRECT_TYPE);
 }
 
 export function throwInvalidInstance (expressionName, parameterName, parameterIndex, expectedClass) {
     const expectedClassNames = Array.isArray(expectedClass)
         ? expectedClass.join(', ')
         : expectedClass.name;
-    throw new CartoValidationError(cvt.INCORRECT_TYPE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-    expected type was instance of '${expectedClassNames}'`);
+    throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+    expected type was instance of '${expectedClassNames}'`, cvt.INCORRECT_TYPE);
 }
 
 export function throwInvalidNumber (expressionName, parameterName, parameterIndex, number) {
-    throw new CartoValidationError(cvt.INCORRECT_TYPE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-    type of '${number}' is ${typeof number}, 'number' was expected`);
+    throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+    type of '${number}' is ${typeof number}, 'number' was expected`, cvt.INCORRECT_TYPE);
 }
 
 export function throwInvalidArray (expressionName, parameterName, parameterIndex, array) {
-    throw new CartoValidationError(cvt.INCORRECT_TYPE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-    '${array}' is not an array`);
+    throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+    '${array}' is not an array`, cvt.INCORRECT_TYPE);
 }
 
 export function throwInvalidString (expressionName, parameterName, parameterIndex, str) {
-    throw new CartoValidationError(cvt.INCORRECT_TYPE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-    expected type was 'string', but ${str}' is not a string`);
+    throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+    expected type was 'string', but ${str}' is not a string`, cvt.INCORRECT_TYPE);
 }
 
 export function throwInvalidStringValue (expressionName, parameterName, parameterIndex, str, validValues) {
-    throw new CartoValidationError(cvt.INCORRECT_TYPE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-    value '${str}' is not valid. It should be one of ${validValues.map(v => `'${v}'`).join(', ')}`);
+    throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+    value '${str}' is not valid. It should be one of ${validValues.map(v => `'${v}'`).join(', ')}`, cvt.INCORRECT_TYPE);
 }
 
 // Returns true if the argument is of a type that cannot be strictly checked at constructor time
@@ -157,8 +166,8 @@ export function isArgConstructorTimeTyped (arg) {
 
 export function checkExpression (expressionName, parameterName, parameterIndex, parameter) {
     if (!(parameter instanceof BaseExpression)) {
-        throw new CartoValidationError(cvt.INCORRECT_TYPE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-        '${parameter}' is not of type "carto.expressions.Base"`);
+        throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+        '${parameter}' is not of type "carto.expressions.Base"`, cvt.INCORRECT_TYPE);
     }
 }
 
@@ -169,8 +178,8 @@ export function checkType (expressionName, parameterName, parameterIndex, expect
             parameter.type === type
         );
         if (!ok) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-            expected type was one of ${expectedType.join()}, actual type was '${parameter.type}'`);
+            throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+            expected type was one of ${expectedType.join()}, actual type was '${parameter.type}'`, cvt.INCORRECT_TYPE);
         }
     } else if (parameter.type !== expectedType) {
         throwInvalidType(expressionName, parameterName, parameterIndex, expectedType, parameter.type);
@@ -221,15 +230,15 @@ export function checkArray (expressionName, parameterName, parameterIndex, array
 
 export function checkFeatureIndependent (expressionName, parameterName, parameterIndex, parameter) {
     if (parameter.isFeatureDependent()) {
-        throw new CartoValidationError(cvt.INCORRECT_VALUE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-        parameter cannot be feature dependent`);
+        throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+        parameter cannot be feature dependent`, cvt.INCORRECT_VALUE);
     }
 }
 
 export function checkFeatureDependent (expressionName, parameterName, parameterIndex, parameter) {
     if (!parameter.isFeatureDependent()) {
-        throw new CartoValidationError(cvt.INCORRECT_VALUE, `${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
-        parameter must be feature dependent`);
+        throw new CartoValidationError(`${getStringErrorPreface(expressionName, parameterName, parameterIndex)}
+        parameter must be feature dependent`, cvt.INCORRECT_VALUE);
     }
 }
 

--- a/src/renderer/viz/expressions/viewportFeatures.js
+++ b/src/renderer/viz/expressions/viewportFeatures.js
@@ -87,7 +87,7 @@ export default class ViewportFeatures extends BaseExpression {
     _resetViewportAgg (metadata, renderLayer) {
         if (!this._FeatureProxy) {
             if (!this._requiredProperties.every(p => validProperty(p))) {
-                throw new CartoValidationError(cvt.INCORRECT_TYPE, `viewportFeatures arguments can only be properties`);
+                throw new CartoValidationError(cvt.INCORRECT_TYPE, 'viewportFeatures arguments can only be properties');
             }
 
             const propertyNames = this._requiredProperties.map((p) => {

--- a/src/renderer/viz/expressions/viewportFeatures.js
+++ b/src/renderer/viz/expressions/viewportFeatures.js
@@ -87,7 +87,7 @@ export default class ViewportFeatures extends BaseExpression {
     _resetViewportAgg (metadata, renderLayer) {
         if (!this._FeatureProxy) {
             if (!this._requiredProperties.every(p => validProperty(p))) {
-                throw new CartoValidationError(`${cvt.INCORRECT_TYPE} viewportFeatures arguments can only be properties`);
+                throw new CartoValidationError(cvt.INCORRECT_TYPE, `viewportFeatures arguments can only be properties`);
             }
 
             const propertyNames = this._requiredProperties.map((p) => {

--- a/src/renderer/viz/expressions/viewportFeatures.js
+++ b/src/renderer/viz/expressions/viewportFeatures.js
@@ -4,7 +4,7 @@ import ClusterTimeDimension from './aggregation/cluster/ClusterTimeDimension';
 import ClusterAggregation from './aggregation/cluster/ClusterAggregation';
 import ClusterCount from './aggregation/cluster/ClusterCount';
 import { implicitCast } from './utils';
-import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../errors/carto-validation-error';
 import CartoRuntimeError from '../../../errors/carto-runtime-error';
 import { genLightweightFeatureClass } from '../../../interactivity/lightweightFeature';
 import { getCompoundFeature } from '../../../interactivity/commonFeature';
@@ -87,7 +87,7 @@ export default class ViewportFeatures extends BaseExpression {
     _resetViewportAgg (metadata, renderLayer) {
         if (!this._FeatureProxy) {
             if (!this._requiredProperties.every(p => validProperty(p))) {
-                throw new CartoValidationError('viewportFeatures arguments can only be properties', CartoValidationTypes.INCORRECT_TYPE);
+                throw new CartoValidationError('viewportFeatures arguments can only be properties', CartoValidationErrorTypes.INCORRECT_TYPE);
             }
 
             const propertyNames = this._requiredProperties.map((p) => {

--- a/src/renderer/viz/expressions/viewportFeatures.js
+++ b/src/renderer/viz/expressions/viewportFeatures.js
@@ -87,7 +87,7 @@ export default class ViewportFeatures extends BaseExpression {
     _resetViewportAgg (metadata, renderLayer) {
         if (!this._FeatureProxy) {
             if (!this._requiredProperties.every(p => validProperty(p))) {
-                throw new CartoValidationError(cvt.INCORRECT_TYPE, 'viewportFeatures arguments can only be properties');
+                throw new CartoValidationError('viewportFeatures arguments can only be properties', cvt.INCORRECT_TYPE);
             }
 
             const propertyNames = this._requiredProperties.map((p) => {

--- a/src/renderer/viz/expressions/viewportFeatures.js
+++ b/src/renderer/viz/expressions/viewportFeatures.js
@@ -4,7 +4,7 @@ import ClusterTimeDimension from './aggregation/cluster/ClusterTimeDimension';
 import ClusterAggregation from './aggregation/cluster/ClusterAggregation';
 import ClusterCount from './aggregation/cluster/ClusterCount';
 import { implicitCast } from './utils';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../errors/carto-validation-error';
 import CartoRuntimeError from '../../../errors/carto-runtime-error';
 import { genLightweightFeatureClass } from '../../../interactivity/lightweightFeature';
 import { getCompoundFeature } from '../../../interactivity/commonFeature';
@@ -87,7 +87,7 @@ export default class ViewportFeatures extends BaseExpression {
     _resetViewportAgg (metadata, renderLayer) {
         if (!this._FeatureProxy) {
             if (!this._requiredProperties.every(p => validProperty(p))) {
-                throw new CartoValidationError('viewportFeatures arguments can only be properties', cvt.INCORRECT_TYPE);
+                throw new CartoValidationError('viewportFeatures arguments can only be properties', CartoValidationTypes.INCORRECT_TYPE);
             }
 
             const propertyNames = this._requiredProperties.map((p) => {

--- a/src/setup/auth-service.js
+++ b/src/setup/auth-service.js
@@ -1,5 +1,5 @@
 import * as util from '../utils/util';
-import CartoValidationError, { CartoValidationTypes } from '../../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../src/errors/carto-validation-error';
 
 let defaultAuth;
 
@@ -40,10 +40,10 @@ function cleanDefaultAuth () {
  */
 function checkAuth (auth) {
     if (util.isUndefined(auth)) {
-        throw new CartoValidationError('\'auth\'', CartoValidationTypes.MISSING_REQUIRED);
+        throw new CartoValidationError('\'auth\'', CartoValidationErrorTypes.MISSING_REQUIRED);
     }
     if (!util.isObject(auth)) {
-        throw new CartoValidationError('\'auth\' property must be an object.', CartoValidationTypes.INCORRECT_TYPE);
+        throw new CartoValidationError('\'auth\' property must be an object.', CartoValidationErrorTypes.INCORRECT_TYPE);
     }
     auth.username = util.isUndefined(auth.username) ? auth.user : auth.username; // backwards compatibility
     checkApiKey(auth.apiKey);
@@ -52,25 +52,25 @@ function checkAuth (auth) {
 
 function checkApiKey (apiKey) {
     if (util.isUndefined(apiKey)) {
-        throw new CartoValidationError('\'apiKey\'', CartoValidationTypes.MISSING_REQUIRED);
+        throw new CartoValidationError('\'apiKey\'', CartoValidationErrorTypes.MISSING_REQUIRED);
     }
     if (!util.isString(apiKey)) {
-        throw new CartoValidationError('\'apiKey\' property must be a string.', CartoValidationTypes.INCORRECT_TYPE);
+        throw new CartoValidationError('\'apiKey\' property must be a string.', CartoValidationErrorTypes.INCORRECT_TYPE);
     }
     if (apiKey === '') {
-        throw new CartoValidationError('\'apiKey\' property must be not empty.', CartoValidationTypes.INCORRECT_VALUE);
+        throw new CartoValidationError('\'apiKey\' property must be not empty.', CartoValidationErrorTypes.INCORRECT_VALUE);
     }
 }
 
 function checkUsername (username) {
     if (util.isUndefined(username)) {
-        throw new CartoValidationError('\'username\'', CartoValidationTypes.MISSING_REQUIRED);
+        throw new CartoValidationError('\'username\'', CartoValidationErrorTypes.MISSING_REQUIRED);
     }
     if (!util.isString(username)) {
-        throw new CartoValidationError('\'username\' property must be a string.', CartoValidationTypes.INCORRECT_TYPE);
+        throw new CartoValidationError('\'username\' property must be a string.', CartoValidationErrorTypes.INCORRECT_TYPE);
     }
     if (username === '') {
-        throw new CartoValidationError('\'username\' property must be not empty.', CartoValidationTypes.INCORRECT_VALUE);
+        throw new CartoValidationError('\'username\' property must be not empty.', CartoValidationErrorTypes.INCORRECT_VALUE);
     }
 }
 

--- a/src/setup/auth-service.js
+++ b/src/setup/auth-service.js
@@ -1,5 +1,5 @@
 import * as util from '../utils/util';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../src/errors/carto-validation-error';
 
 let defaultAuth;
 
@@ -40,10 +40,10 @@ function cleanDefaultAuth () {
  */
 function checkAuth (auth) {
     if (util.isUndefined(auth)) {
-        throw new CartoValidationError('\'auth\'', cvt.MISSING_REQUIRED);
+        throw new CartoValidationError('\'auth\'', CartoValidationTypes.MISSING_REQUIRED);
     }
     if (!util.isObject(auth)) {
-        throw new CartoValidationError('\'auth\' property must be an object.', cvt.INCORRECT_TYPE);
+        throw new CartoValidationError('\'auth\' property must be an object.', CartoValidationTypes.INCORRECT_TYPE);
     }
     auth.username = util.isUndefined(auth.username) ? auth.user : auth.username; // backwards compatibility
     checkApiKey(auth.apiKey);
@@ -52,25 +52,25 @@ function checkAuth (auth) {
 
 function checkApiKey (apiKey) {
     if (util.isUndefined(apiKey)) {
-        throw new CartoValidationError('\'apiKey\'', cvt.MISSING_REQUIRED);
+        throw new CartoValidationError('\'apiKey\'', CartoValidationTypes.MISSING_REQUIRED);
     }
     if (!util.isString(apiKey)) {
-        throw new CartoValidationError('\'apiKey\' property must be a string.', cvt.INCORRECT_TYPE);
+        throw new CartoValidationError('\'apiKey\' property must be a string.', CartoValidationTypes.INCORRECT_TYPE);
     }
     if (apiKey === '') {
-        throw new CartoValidationError('\'apiKey\' property must be not empty.', cvt.INCORRECT_VALUE);
+        throw new CartoValidationError('\'apiKey\' property must be not empty.', CartoValidationTypes.INCORRECT_VALUE);
     }
 }
 
 function checkUsername (username) {
     if (util.isUndefined(username)) {
-        throw new CartoValidationError('\'username\'', cvt.MISSING_REQUIRED);
+        throw new CartoValidationError('\'username\'', CartoValidationTypes.MISSING_REQUIRED);
     }
     if (!util.isString(username)) {
-        throw new CartoValidationError('\'username\' property must be a string.', cvt.INCORRECT_TYPE);
+        throw new CartoValidationError('\'username\' property must be a string.', CartoValidationTypes.INCORRECT_TYPE);
     }
     if (username === '') {
-        throw new CartoValidationError('\'username\' property must be not empty.', cvt.INCORRECT_VALUE);
+        throw new CartoValidationError('\'username\' property must be not empty.', CartoValidationTypes.INCORRECT_VALUE);
     }
 }
 

--- a/src/setup/auth-service.js
+++ b/src/setup/auth-service.js
@@ -40,10 +40,10 @@ function cleanDefaultAuth () {
  */
 function checkAuth (auth) {
     if (util.isUndefined(auth)) {
-        throw new CartoValidationError(cvt.MISSING_REQUIRED, '\'auth\'');
+        throw new CartoValidationError('\'auth\'', cvt.MISSING_REQUIRED);
     }
     if (!util.isObject(auth)) {
-        throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'auth\' property must be an object.');
+        throw new CartoValidationError('\'auth\' property must be an object.', cvt.INCORRECT_TYPE);
     }
     auth.username = util.isUndefined(auth.username) ? auth.user : auth.username; // backwards compatibility
     checkApiKey(auth.apiKey);
@@ -52,25 +52,25 @@ function checkAuth (auth) {
 
 function checkApiKey (apiKey) {
     if (util.isUndefined(apiKey)) {
-        throw new CartoValidationError(cvt.MISSING_REQUIRED, '\'apiKey\'');
+        throw new CartoValidationError('\'apiKey\'', cvt.MISSING_REQUIRED);
     }
     if (!util.isString(apiKey)) {
-        throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'apiKey\' property must be a string.');
+        throw new CartoValidationError('\'apiKey\' property must be a string.', cvt.INCORRECT_TYPE);
     }
     if (apiKey === '') {
-        throw new CartoValidationError(cvt.INCORRECT_VALUE, '\'apiKey\' property must be not empty.');
+        throw new CartoValidationError('\'apiKey\' property must be not empty.', cvt.INCORRECT_VALUE);
     }
 }
 
 function checkUsername (username) {
     if (util.isUndefined(username)) {
-        throw new CartoValidationError(cvt.MISSING_REQUIRED, '\'username\'');
+        throw new CartoValidationError('\'username\'', cvt.MISSING_REQUIRED);
     }
     if (!util.isString(username)) {
-        throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'username\' property must be a string.');
+        throw new CartoValidationError('\'username\' property must be a string.', cvt.INCORRECT_TYPE);
     }
     if (username === '') {
-        throw new CartoValidationError(cvt.INCORRECT_VALUE, '\'username\' property must be not empty.');
+        throw new CartoValidationError('\'username\' property must be not empty.', cvt.INCORRECT_VALUE);
     }
 }
 

--- a/src/setup/auth-service.js
+++ b/src/setup/auth-service.js
@@ -40,10 +40,10 @@ function cleanDefaultAuth () {
  */
 function checkAuth (auth) {
     if (util.isUndefined(auth)) {
-        throw new CartoValidationError(cvt.MISSING_REQUIRED, `'auth'`);
+        throw new CartoValidationError(cvt.MISSING_REQUIRED, '\'auth\'');
     }
     if (!util.isObject(auth)) {
-        throw new CartoValidationError(cvt.INCORRECT_TYPE, `'auth' property must be an object.`);
+        throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'auth\' property must be an object.');
     }
     auth.username = util.isUndefined(auth.username) ? auth.user : auth.username; // backwards compatibility
     checkApiKey(auth.apiKey);
@@ -52,25 +52,25 @@ function checkAuth (auth) {
 
 function checkApiKey (apiKey) {
     if (util.isUndefined(apiKey)) {
-        throw new CartoValidationError(cvt.MISSING_REQUIRED, `'apiKey'`);
+        throw new CartoValidationError(cvt.MISSING_REQUIRED, '\'apiKey\'');
     }
     if (!util.isString(apiKey)) {
-        throw new CartoValidationError(cvt.INCORRECT_TYPE, `'apiKey' property must be a string.`);
+        throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'apiKey\' property must be a string.');
     }
     if (apiKey === '') {
-        throw new CartoValidationError(cvt.INCORRECT_VALUE, `'apiKey' property must be not empty.`);
+        throw new CartoValidationError(cvt.INCORRECT_VALUE, '\'apiKey\' property must be not empty.');
     }
 }
 
 function checkUsername (username) {
     if (util.isUndefined(username)) {
-        throw new CartoValidationError(cvt.MISSING_REQUIRED, `'username'`);
+        throw new CartoValidationError(cvt.MISSING_REQUIRED, '\'username\'');
     }
     if (!util.isString(username)) {
-        throw new CartoValidationError(cvt.INCORRECT_TYPE, `'username' property must be a string.`);
+        throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'username\' property must be a string.');
     }
     if (username === '') {
-        throw new CartoValidationError(cvt.INCORRECT_VALUE, `'username' property must be not empty.`);
+        throw new CartoValidationError(cvt.INCORRECT_VALUE, '\'username\' property must be not empty.');
     }
 }
 

--- a/src/setup/auth-service.js
+++ b/src/setup/auth-service.js
@@ -40,10 +40,10 @@ function cleanDefaultAuth () {
  */
 function checkAuth (auth) {
     if (util.isUndefined(auth)) {
-        throw new CartoValidationError(`${cvt.MISSING_REQUIRED} 'auth'`);
+        throw new CartoValidationError(cvt.MISSING_REQUIRED, `'auth'`);
     }
     if (!util.isObject(auth)) {
-        throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'auth' property must be an object.`);
+        throw new CartoValidationError(cvt.INCORRECT_TYPE, `'auth' property must be an object.`);
     }
     auth.username = util.isUndefined(auth.username) ? auth.user : auth.username; // backwards compatibility
     checkApiKey(auth.apiKey);
@@ -52,25 +52,25 @@ function checkAuth (auth) {
 
 function checkApiKey (apiKey) {
     if (util.isUndefined(apiKey)) {
-        throw new CartoValidationError(`${cvt.MISSING_REQUIRED} 'apiKey'`);
+        throw new CartoValidationError(cvt.MISSING_REQUIRED, `'apiKey'`);
     }
     if (!util.isString(apiKey)) {
-        throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'apiKey' property must be a string.`);
+        throw new CartoValidationError(cvt.INCORRECT_TYPE, `'apiKey' property must be a string.`);
     }
     if (apiKey === '') {
-        throw new CartoValidationError(`${cvt.INCORRECT_VALUE} 'apiKey' property must be not empty.`);
+        throw new CartoValidationError(cvt.INCORRECT_VALUE, `'apiKey' property must be not empty.`);
     }
 }
 
 function checkUsername (username) {
     if (util.isUndefined(username)) {
-        throw new CartoValidationError(`${cvt.MISSING_REQUIRED} 'username'`);
+        throw new CartoValidationError(cvt.MISSING_REQUIRED, `'username'`);
     }
     if (!util.isString(username)) {
-        throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'username' property must be a string.`);
+        throw new CartoValidationError(cvt.INCORRECT_TYPE, `'username' property must be a string.`);
     }
     if (username === '') {
-        throw new CartoValidationError(`${cvt.INCORRECT_VALUE} 'username' property must be not empty.`);
+        throw new CartoValidationError(cvt.INCORRECT_VALUE, `'username' property must be not empty.`);
     }
 }
 

--- a/src/setup/config-service.js
+++ b/src/setup/config-service.js
@@ -40,7 +40,7 @@ function cleanDefaultConfig () {
 function checkConfig (config) {
     if (config) {
         if (!util.isObject(config)) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'config' property must be an object.`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, `'config' property must be an object.`);
         }
         _checkServerURL(config.serverURL);
     }
@@ -48,7 +48,7 @@ function checkConfig (config) {
 
 function _checkServerURL (serverURL) {
     if (!util.isString(serverURL)) {
-        throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'serverURL' property must be a string.`);
+        throw new CartoValidationError(cvt.INCORRECT_TYPE, `'serverURL' property must be a string.`);
     }
 }
 

--- a/src/setup/config-service.js
+++ b/src/setup/config-service.js
@@ -1,5 +1,5 @@
 import * as util from '../utils/util';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../src/errors/carto-validation-error';
 
 let defaultConfig;
 
@@ -40,7 +40,7 @@ function cleanDefaultConfig () {
 function checkConfig (config) {
     if (config) {
         if (!util.isObject(config)) {
-            throw new CartoValidationError('\'config\' property must be an object.', cvt.INCORRECT_TYPE);
+            throw new CartoValidationError('\'config\' property must be an object.', CartoValidationTypes.INCORRECT_TYPE);
         }
         _checkServerURL(config.serverURL);
     }
@@ -48,7 +48,7 @@ function checkConfig (config) {
 
 function _checkServerURL (serverURL) {
     if (!util.isString(serverURL)) {
-        throw new CartoValidationError('\'serverURL\' property must be a string.', cvt.INCORRECT_TYPE);
+        throw new CartoValidationError('\'serverURL\' property must be a string.', CartoValidationTypes.INCORRECT_TYPE);
     }
 }
 

--- a/src/setup/config-service.js
+++ b/src/setup/config-service.js
@@ -40,7 +40,7 @@ function cleanDefaultConfig () {
 function checkConfig (config) {
     if (config) {
         if (!util.isObject(config)) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'config\' property must be an object.');
+            throw new CartoValidationError('\'config\' property must be an object.', cvt.INCORRECT_TYPE);
         }
         _checkServerURL(config.serverURL);
     }
@@ -48,7 +48,7 @@ function checkConfig (config) {
 
 function _checkServerURL (serverURL) {
     if (!util.isString(serverURL)) {
-        throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'serverURL\' property must be a string.');
+        throw new CartoValidationError('\'serverURL\' property must be a string.', cvt.INCORRECT_TYPE);
     }
 }
 

--- a/src/setup/config-service.js
+++ b/src/setup/config-service.js
@@ -1,5 +1,5 @@
 import * as util from '../utils/util';
-import CartoValidationError, { CartoValidationTypes } from '../../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../src/errors/carto-validation-error';
 
 let defaultConfig;
 
@@ -40,7 +40,7 @@ function cleanDefaultConfig () {
 function checkConfig (config) {
     if (config) {
         if (!util.isObject(config)) {
-            throw new CartoValidationError('\'config\' property must be an object.', CartoValidationTypes.INCORRECT_TYPE);
+            throw new CartoValidationError('\'config\' property must be an object.', CartoValidationErrorTypes.INCORRECT_TYPE);
         }
         _checkServerURL(config.serverURL);
     }
@@ -48,7 +48,7 @@ function checkConfig (config) {
 
 function _checkServerURL (serverURL) {
     if (!util.isString(serverURL)) {
-        throw new CartoValidationError('\'serverURL\' property must be a string.', CartoValidationTypes.INCORRECT_TYPE);
+        throw new CartoValidationError('\'serverURL\' property must be a string.', CartoValidationErrorTypes.INCORRECT_TYPE);
     }
 }
 

--- a/src/setup/config-service.js
+++ b/src/setup/config-service.js
@@ -40,7 +40,7 @@ function cleanDefaultConfig () {
 function checkConfig (config) {
     if (config) {
         if (!util.isObject(config)) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, `'config' property must be an object.`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'config\' property must be an object.');
         }
         _checkServerURL(config.serverURL);
     }
@@ -48,7 +48,7 @@ function checkConfig (config) {
 
 function _checkServerURL (serverURL) {
     if (!util.isString(serverURL)) {
-        throw new CartoValidationError(cvt.INCORRECT_TYPE, `'serverURL' property must be a string.`);
+        throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'serverURL\' property must be a string.');
     }
 }
 

--- a/src/sources/Dataset.js
+++ b/src/sources/Dataset.js
@@ -1,4 +1,4 @@
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../src/errors/carto-validation-error';
 import util from '../utils/util';
 import BaseWindshaft from './BaseWindshaft';
 
@@ -57,13 +57,13 @@ export default class Dataset extends BaseWindshaft {
 
     _checkTableName (tableName) {
         if (util.isUndefined(tableName)) {
-            throw new CartoValidationError('\'tableName\'', cvt.MISSING_REQUIRED);
+            throw new CartoValidationError('\'tableName\'', CartoValidationTypes.MISSING_REQUIRED);
         }
         if (!util.isString(tableName)) {
-            throw new CartoValidationError('\'tableName\' property must be a string.', cvt.INCORRECT_TYPE);
+            throw new CartoValidationError('\'tableName\' property must be a string.', CartoValidationTypes.INCORRECT_TYPE);
         }
         if (tableName === '') {
-            throw new CartoValidationError('\'tableName\' property must be not empty.', cvt.INCORRECT_VALUE);
+            throw new CartoValidationError('\'tableName\' property must be not empty.', CartoValidationTypes.INCORRECT_VALUE);
         }
     }
 }

--- a/src/sources/Dataset.js
+++ b/src/sources/Dataset.js
@@ -57,13 +57,13 @@ export default class Dataset extends BaseWindshaft {
 
     _checkTableName (tableName) {
         if (util.isUndefined(tableName)) {
-            throw new CartoValidationError(`${cvt.MISSING_REQUIRED} 'tableName'`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, `'tableName'`);
         }
         if (!util.isString(tableName)) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'tableName' property must be a string.`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, `'tableName' property must be a string.`);
         }
         if (tableName === '') {
-            throw new CartoValidationError(`${cvt.INCORRECT_VALUE} 'tableName' property must be not empty.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, `'tableName' property must be not empty.`);
         }
     }
 }

--- a/src/sources/Dataset.js
+++ b/src/sources/Dataset.js
@@ -57,13 +57,13 @@ export default class Dataset extends BaseWindshaft {
 
     _checkTableName (tableName) {
         if (util.isUndefined(tableName)) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, '\'tableName\'');
+            throw new CartoValidationError('\'tableName\'', cvt.MISSING_REQUIRED);
         }
         if (!util.isString(tableName)) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'tableName\' property must be a string.');
+            throw new CartoValidationError('\'tableName\' property must be a string.', cvt.INCORRECT_TYPE);
         }
         if (tableName === '') {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, '\'tableName\' property must be not empty.');
+            throw new CartoValidationError('\'tableName\' property must be not empty.', cvt.INCORRECT_VALUE);
         }
     }
 }

--- a/src/sources/Dataset.js
+++ b/src/sources/Dataset.js
@@ -1,4 +1,4 @@
-import CartoValidationError, { CartoValidationTypes } from '../../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../src/errors/carto-validation-error';
 import util from '../utils/util';
 import BaseWindshaft from './BaseWindshaft';
 
@@ -57,13 +57,13 @@ export default class Dataset extends BaseWindshaft {
 
     _checkTableName (tableName) {
         if (util.isUndefined(tableName)) {
-            throw new CartoValidationError('\'tableName\'', CartoValidationTypes.MISSING_REQUIRED);
+            throw new CartoValidationError('\'tableName\'', CartoValidationErrorTypes.MISSING_REQUIRED);
         }
         if (!util.isString(tableName)) {
-            throw new CartoValidationError('\'tableName\' property must be a string.', CartoValidationTypes.INCORRECT_TYPE);
+            throw new CartoValidationError('\'tableName\' property must be a string.', CartoValidationErrorTypes.INCORRECT_TYPE);
         }
         if (tableName === '') {
-            throw new CartoValidationError('\'tableName\' property must be not empty.', CartoValidationTypes.INCORRECT_VALUE);
+            throw new CartoValidationError('\'tableName\' property must be not empty.', CartoValidationErrorTypes.INCORRECT_VALUE);
         }
     }
 }

--- a/src/sources/Dataset.js
+++ b/src/sources/Dataset.js
@@ -57,13 +57,13 @@ export default class Dataset extends BaseWindshaft {
 
     _checkTableName (tableName) {
         if (util.isUndefined(tableName)) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, `'tableName'`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, '\'tableName\'');
         }
         if (!util.isString(tableName)) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, `'tableName' property must be a string.`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'tableName\' property must be a string.');
         }
         if (tableName === '') {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, `'tableName' property must be not empty.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, '\'tableName\' property must be not empty.');
         }
     }
 }

--- a/src/sources/GeoJSON.js
+++ b/src/sources/GeoJSON.js
@@ -1,8 +1,8 @@
 import * as rsys from '../client/rsys';
 import Dataframe from '../renderer/Dataframe';
 import Metadata from './GeoJSONMetadata';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../src/errors/carto-validation-error';
-import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../../src/errors/carto-runtime-error';
+import CartoValidationError, { CartoValidationTypes } from '../../src/errors/carto-validation-error';
+import CartoRuntimeError, { CartoRuntimeTypes } from '../../src/errors/carto-runtime-error';
 import util from '../utils/util';
 import Base from './Base';
 import schema from '../renderer/schema';
@@ -58,7 +58,7 @@ export default class GeoJSON extends Base {
         } else if (data.type === 'Feature') {
             this._features = [data];
         } else {
-            throw new CartoValidationError('\'data\' property must be a GeoJSON object.', cvt.INCORRECT_VALUE);
+            throw new CartoValidationError('\'data\' property must be a GeoJSON object.', CartoValidationTypes.INCORRECT_VALUE);
         }
 
         this._features = this._initializeFeatureProperties(this._features);
@@ -109,10 +109,10 @@ export default class GeoJSON extends Base {
 
     _checkData (data) {
         if (util.isUndefined(data)) {
-            throw new CartoValidationError('\'data\'', cvt.MISSING_REQUIRED);
+            throw new CartoValidationError('\'data\'', CartoValidationTypes.MISSING_REQUIRED);
         }
         if (!util.isObject(data)) {
-            throw new CartoValidationError('\'data\' property must be an object.', cvt.INCORRECT_TYPE);
+            throw new CartoValidationError('\'data\' property must be an object.', CartoValidationTypes.INCORRECT_TYPE);
         }
     }
 
@@ -175,7 +175,7 @@ export default class GeoJSON extends Base {
         if (this._catFields.has(propertyName) || this._dateFields.has(propertyName)) {
             throw new CartoValidationError(
                 `Unsupported GeoJSON: the property '${propertyName}' has different types in different features.`,
-                cvt.INCORRECT_TYPE
+                CartoValidationTypes.INCORRECT_TYPE
             );
         }
         this._addNumericColumnField(propertyName);
@@ -203,7 +203,7 @@ export default class GeoJSON extends Base {
         if (this._catFields.has(propertyName) || this._numFields.has(propertyName)) {
             throw new CartoRuntimeError(
                 `Unsupported GeoJSON: the property '${propertyName}' has different types in different features.`,
-                crt.NOT_SUPPORTED
+                CartoRuntimeTypes.NOT_SUPPORTED
             );
         }
         this._addDateColumnField(propertyName);
@@ -246,7 +246,7 @@ export default class GeoJSON extends Base {
         if (this._numFields.has(propertyName) || this._dateFields.has(propertyName)) {
             throw new CartoRuntimeError(
                 `Unsupported GeoJSON: the property '${propertyName}' has different types in different features.`,
-                crt.NOT_SUPPORTED
+                CartoRuntimeTypes.NOT_SUPPORTED
             );
         }
         if (!this._catFields.has(propertyName)) {
@@ -339,7 +339,7 @@ export default class GeoJSON extends Base {
             if (this._type !== type) {
                 throw new CartoValidationError(
                     `multiple geometry types not supported: found '${type}' instead of '${this._type}'.`,
-                    cvt.INCORRECT_TYPE
+                    CartoValidationTypes.INCORRECT_TYPE
                 );
             }
             if (type === 'Point') {

--- a/src/sources/GeoJSON.js
+++ b/src/sources/GeoJSON.js
@@ -58,7 +58,7 @@ export default class GeoJSON extends Base {
         } else if (data.type === 'Feature') {
             this._features = [data];
         } else {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, `'data' property must be a GeoJSON object.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, '\'data\' property must be a GeoJSON object.');
         }
 
         this._features = this._initializeFeatureProperties(this._features);
@@ -109,10 +109,10 @@ export default class GeoJSON extends Base {
 
     _checkData (data) {
         if (util.isUndefined(data)) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, `'data'`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, '\'data\'');
         }
         if (!util.isObject(data)) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, `'data' property must be an object.`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'data\' property must be an object.');
         }
     }
 

--- a/src/sources/GeoJSON.js
+++ b/src/sources/GeoJSON.js
@@ -58,7 +58,7 @@ export default class GeoJSON extends Base {
         } else if (data.type === 'Feature') {
             this._features = [data];
         } else {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, '\'data\' property must be a GeoJSON object.');
+            throw new CartoValidationError('\'data\' property must be a GeoJSON object.', cvt.INCORRECT_VALUE);
         }
 
         this._features = this._initializeFeatureProperties(this._features);
@@ -109,10 +109,10 @@ export default class GeoJSON extends Base {
 
     _checkData (data) {
         if (util.isUndefined(data)) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, '\'data\'');
+            throw new CartoValidationError('\'data\'', cvt.MISSING_REQUIRED);
         }
         if (!util.isObject(data)) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'data\' property must be an object.');
+            throw new CartoValidationError('\'data\' property must be an object.', cvt.INCORRECT_TYPE);
         }
     }
 
@@ -173,7 +173,10 @@ export default class GeoJSON extends Base {
 
     _addNumericPropertyToMetadata (propertyName, value) {
         if (this._catFields.has(propertyName) || this._dateFields.has(propertyName)) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, `Unsupported GeoJSON: the property '${propertyName}' has different types in different features.`);
+            throw new CartoValidationError(
+                `Unsupported GeoJSON: the property '${propertyName}' has different types in different features.`,
+                cvt.INCORRECT_TYPE
+            );
         }
         this._addNumericColumnField(propertyName);
         const property = this._properties[propertyName];
@@ -199,7 +202,8 @@ export default class GeoJSON extends Base {
     _addDatePropertyToMetadata (propertyName, value) {
         if (this._catFields.has(propertyName) || this._numFields.has(propertyName)) {
             throw new CartoRuntimeError(
-                crt.NOT_SUPPORTED, `Unsupported GeoJSON: the property '${propertyName}' has different types in different features.`
+                `Unsupported GeoJSON: the property '${propertyName}' has different types in different features.`,
+                crt.NOT_SUPPORTED
             );
         }
         this._addDateColumnField(propertyName);
@@ -241,7 +245,8 @@ export default class GeoJSON extends Base {
     _addCategoryPropertyToMetadata (propertyName, value) {
         if (this._numFields.has(propertyName) || this._dateFields.has(propertyName)) {
             throw new CartoRuntimeError(
-                crt.NOT_SUPPORTED, `Unsupported GeoJSON: the property '${propertyName}' has different types in different features.`
+                `Unsupported GeoJSON: the property '${propertyName}' has different types in different features.`,
+                crt.NOT_SUPPORTED
             );
         }
         if (!this._catFields.has(propertyName)) {
@@ -332,7 +337,10 @@ export default class GeoJSON extends Base {
             const type = geometry.type;
             const coordinates = geometry.coordinates;
             if (this._type !== type) {
-                throw new CartoValidationError(cvt.INCORRECT_TYPE, `multiple geometry types not supported: found '${type}' instead of '${this._type}'.`);
+                throw new CartoValidationError(
+                    `multiple geometry types not supported: found '${type}' instead of '${this._type}'.`,
+                    cvt.INCORRECT_TYPE
+                );
             }
             if (type === 'Point') {
                 const point = this._computePointGeometry(coordinates);

--- a/src/sources/GeoJSON.js
+++ b/src/sources/GeoJSON.js
@@ -1,8 +1,8 @@
 import * as rsys from '../client/rsys';
 import Dataframe from '../renderer/Dataframe';
 import Metadata from './GeoJSONMetadata';
-import CartoValidationError, { CartoValidationTypes } from '../../src/errors/carto-validation-error';
-import CartoRuntimeError, { CartoRuntimeTypes } from '../../src/errors/carto-runtime-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../src/errors/carto-validation-error';
+import CartoRuntimeError, { CartoRuntimeErrorTypes } from '../../src/errors/carto-runtime-error';
 import util from '../utils/util';
 import Base from './Base';
 import schema from '../renderer/schema';
@@ -58,7 +58,7 @@ export default class GeoJSON extends Base {
         } else if (data.type === 'Feature') {
             this._features = [data];
         } else {
-            throw new CartoValidationError('\'data\' property must be a GeoJSON object.', CartoValidationTypes.INCORRECT_VALUE);
+            throw new CartoValidationError('\'data\' property must be a GeoJSON object.', CartoValidationErrorTypes.INCORRECT_VALUE);
         }
 
         this._features = this._initializeFeatureProperties(this._features);
@@ -109,10 +109,10 @@ export default class GeoJSON extends Base {
 
     _checkData (data) {
         if (util.isUndefined(data)) {
-            throw new CartoValidationError('\'data\'', CartoValidationTypes.MISSING_REQUIRED);
+            throw new CartoValidationError('\'data\'', CartoValidationErrorTypes.MISSING_REQUIRED);
         }
         if (!util.isObject(data)) {
-            throw new CartoValidationError('\'data\' property must be an object.', CartoValidationTypes.INCORRECT_TYPE);
+            throw new CartoValidationError('\'data\' property must be an object.', CartoValidationErrorTypes.INCORRECT_TYPE);
         }
     }
 
@@ -175,7 +175,7 @@ export default class GeoJSON extends Base {
         if (this._catFields.has(propertyName) || this._dateFields.has(propertyName)) {
             throw new CartoValidationError(
                 `Unsupported GeoJSON: the property '${propertyName}' has different types in different features.`,
-                CartoValidationTypes.INCORRECT_TYPE
+                CartoValidationErrorTypes.INCORRECT_TYPE
             );
         }
         this._addNumericColumnField(propertyName);
@@ -203,7 +203,7 @@ export default class GeoJSON extends Base {
         if (this._catFields.has(propertyName) || this._numFields.has(propertyName)) {
             throw new CartoRuntimeError(
                 `Unsupported GeoJSON: the property '${propertyName}' has different types in different features.`,
-                CartoRuntimeTypes.NOT_SUPPORTED
+                CartoRuntimeErrorTypes.NOT_SUPPORTED
             );
         }
         this._addDateColumnField(propertyName);
@@ -246,7 +246,7 @@ export default class GeoJSON extends Base {
         if (this._numFields.has(propertyName) || this._dateFields.has(propertyName)) {
             throw new CartoRuntimeError(
                 `Unsupported GeoJSON: the property '${propertyName}' has different types in different features.`,
-                CartoRuntimeTypes.NOT_SUPPORTED
+                CartoRuntimeErrorTypes.NOT_SUPPORTED
             );
         }
         if (!this._catFields.has(propertyName)) {
@@ -339,7 +339,7 @@ export default class GeoJSON extends Base {
             if (this._type !== type) {
                 throw new CartoValidationError(
                     `multiple geometry types not supported: found '${type}' instead of '${this._type}'.`,
-                    CartoValidationTypes.INCORRECT_TYPE
+                    CartoValidationErrorTypes.INCORRECT_TYPE
                 );
             }
             if (type === 'Point') {

--- a/src/sources/GeoJSON.js
+++ b/src/sources/GeoJSON.js
@@ -2,7 +2,7 @@ import * as rsys from '../client/rsys';
 import Dataframe from '../renderer/Dataframe';
 import Metadata from './GeoJSONMetadata';
 import CartoValidationError, { CartoValidationTypes as cvt } from '../../src/errors/carto-validation-error';
-import CartoRuntimeError, { CartoRuntimeTypes as runtimeErrors } from '../../src/errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../../src/errors/carto-runtime-error';
 import util from '../utils/util';
 import Base from './Base';
 import schema from '../renderer/schema';
@@ -58,7 +58,7 @@ export default class GeoJSON extends Base {
         } else if (data.type === 'Feature') {
             this._features = [data];
         } else {
-            throw new CartoValidationError(`${cvt.INCORRECT_VALUE} 'data' property must be a GeoJSON object.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, `'data' property must be a GeoJSON object.`);
         }
 
         this._features = this._initializeFeatureProperties(this._features);
@@ -109,10 +109,10 @@ export default class GeoJSON extends Base {
 
     _checkData (data) {
         if (util.isUndefined(data)) {
-            throw new CartoValidationError(`${cvt.MISSING_REQUIRED} 'data'`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, `'data'`);
         }
         if (!util.isObject(data)) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'data' property must be an object.`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, `'data' property must be an object.`);
         }
     }
 
@@ -173,7 +173,7 @@ export default class GeoJSON extends Base {
 
     _addNumericPropertyToMetadata (propertyName, value) {
         if (this._catFields.has(propertyName) || this._dateFields.has(propertyName)) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} Unsupported GeoJSON: the property '${propertyName}' has different types in different features.`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, `Unsupported GeoJSON: the property '${propertyName}' has different types in different features.`);
         }
         this._addNumericColumnField(propertyName);
         const property = this._properties[propertyName];
@@ -199,7 +199,7 @@ export default class GeoJSON extends Base {
     _addDatePropertyToMetadata (propertyName, value) {
         if (this._catFields.has(propertyName) || this._numFields.has(propertyName)) {
             throw new CartoRuntimeError(
-                `${runtimeErrors.NOT_SUPPORTED} Unsupported GeoJSON: the property '${propertyName}' has different types in different features.`
+                crt.NOT_SUPPORTED, `Unsupported GeoJSON: the property '${propertyName}' has different types in different features.`
             );
         }
         this._addDateColumnField(propertyName);
@@ -241,7 +241,7 @@ export default class GeoJSON extends Base {
     _addCategoryPropertyToMetadata (propertyName, value) {
         if (this._numFields.has(propertyName) || this._dateFields.has(propertyName)) {
             throw new CartoRuntimeError(
-                `${runtimeErrors.NOT_SUPPORTED} Unsupported GeoJSON: the property '${propertyName}' has different types in different features.`
+                crt.NOT_SUPPORTED, `Unsupported GeoJSON: the property '${propertyName}' has different types in different features.`
             );
         }
         if (!this._catFields.has(propertyName)) {
@@ -332,7 +332,7 @@ export default class GeoJSON extends Base {
             const type = geometry.type;
             const coordinates = geometry.coordinates;
             if (this._type !== type) {
-                throw new CartoValidationError(`${cvt.INCORRECT_TYPE} multiple geometry types not supported: found '${type}' instead of '${this._type}'.`);
+                throw new CartoValidationError(cvt.INCORRECT_TYPE, `multiple geometry types not supported: found '${type}' instead of '${this._type}'.`);
             }
             if (type === 'Point') {
                 const point = this._computePointGeometry(coordinates);

--- a/src/sources/MVTWorker.js
+++ b/src/sources/MVTWorker.js
@@ -69,7 +69,8 @@ export class MVTWorker {
 
         if (Object.keys(tile.layers).length > 1 && !layerID) {
             throw new CartoValidationError(
-                cvt.MISSING_REQUIRED, `LayerID parameter wasn't specified and the MVT tile contains multiple layers: ${JSON.stringify(Object.keys(tile.layers))}.`
+                `LayerID parameter wasn't specified and the MVT tile contains multiple layers: ${JSON.stringify(Object.keys(tile.layers))}.`,
+                cvt.MISSING_REQUIRED
             );
         }
 
@@ -102,7 +103,7 @@ export class MVTWorker {
             case GEOMETRY_TYPE.POLYGON:
                 return this._decode(mvtLayer, metadata, mvtExtent, [], decodePolygons);
             default:
-                throw new CartoValidationError(cvt.INCORRECT_TYPE, `MVT: invalid geometry type '${metadata.geomType}'`);
+                throw new CartoValidationError(`MVT: invalid geometry type '${metadata.geomType}'`, cvt.INCORRECT_TYPE);
         }
     }
 
@@ -116,7 +117,7 @@ export class MVTWorker {
             case mvtDecoderGeomTypes.polygon:
                 return GEOMETRY_TYPE.POLYGON;
             default:
-                throw new CartoValidationError(cvt.INCORRECT_TYPE, `MVT: invalid geometry type '${type}'`);
+                throw new CartoValidationError(`MVT: invalid geometry type '${type}'`, cvt.INCORRECT_TYPE);
         }
     }
 
@@ -154,7 +155,8 @@ export class MVTWorker {
             }
             if (f.properties[metadata.idProperty] === undefined) {
                 throw new CartoRuntimeError(
-                    crt.MVT, `MVT feature with undefined idProperty '${metadata.idProperty}'`
+                    `MVT feature with undefined idProperty '${metadata.idProperty}'`,
+                    crt.MVT
                 );
             }
             this._decodeProperties(metadata, scalarPropertyCodecs, rangePropertyCodecs, properties, f, numFeatures);
@@ -170,7 +172,8 @@ export class MVTWorker {
         const actual = MVT_TO_CARTO_TYPES[type];
         if (actual !== expected) {
             throw new CartoRuntimeError(
-                crt.MVT, `MVT: mixed geometry types in the same layer. Layer has type: ${expected} but feature was ${actual}`
+                `MVT: mixed geometry types in the same layer. Layer has type: ${expected} but feature was ${actual}`,
+                crt.MVT
             );
         }
     }

--- a/src/sources/MVTWorker.js
+++ b/src/sources/MVTWorker.js
@@ -5,7 +5,7 @@ import { decodeLines, decodePolygons } from '../client/mvt/feature-decoder';
 import MVTMetadata from './MVTMetadata';
 import DummyDataframe from '../renderer/DummyDataframe';
 import CartoValidationError, { CartoValidationTypes as cvt } from '../errors/carto-validation-error';
-import CartoRuntimeError, { CartoRuntimeTypes as runtimeErrors } from '../errors/carto-runtime-error';
+import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../errors/carto-runtime-error';
 import { GEOMETRY_TYPE } from '../utils/geometry';
 
 // TODO import correctly
@@ -69,7 +69,7 @@ export class MVTWorker {
 
         if (Object.keys(tile.layers).length > 1 && !layerID) {
             throw new CartoValidationError(
-                `${cvt.MISSING_REQUIRED} LayerID parameter wasn't specified and the MVT tile contains multiple layers: ${JSON.stringify(Object.keys(tile.layers))}.`
+                cvt.MISSING_REQUIRED, `LayerID parameter wasn't specified and the MVT tile contains multiple layers: ${JSON.stringify(Object.keys(tile.layers))}.`
             );
         }
 
@@ -102,7 +102,7 @@ export class MVTWorker {
             case GEOMETRY_TYPE.POLYGON:
                 return this._decode(mvtLayer, metadata, mvtExtent, [], decodePolygons);
             default:
-                throw new CartoValidationError(`${cvt.INCORRECT_TYPE} MVT: invalid geometry type '${metadata.geomType}'`);
+                throw new CartoValidationError(cvt.INCORRECT_TYPE, `MVT: invalid geometry type '${metadata.geomType}'`);
         }
     }
 
@@ -116,7 +116,7 @@ export class MVTWorker {
             case mvtDecoderGeomTypes.polygon:
                 return GEOMETRY_TYPE.POLYGON;
             default:
-                throw new CartoValidationError(`${cvt.INCORRECT_TYPE} MVT: invalid geometry type '${type}'`);
+                throw new CartoValidationError(cvt.INCORRECT_TYPE, `MVT: invalid geometry type '${type}'`);
         }
     }
 
@@ -154,7 +154,7 @@ export class MVTWorker {
             }
             if (f.properties[metadata.idProperty] === undefined) {
                 throw new CartoRuntimeError(
-                    `${runtimeErrors.MVT} MVT feature with undefined idProperty '${metadata.idProperty}'`
+                    crt.MVT, `MVT feature with undefined idProperty '${metadata.idProperty}'`
                 );
             }
             this._decodeProperties(metadata, scalarPropertyCodecs, rangePropertyCodecs, properties, f, numFeatures);
@@ -170,7 +170,7 @@ export class MVTWorker {
         const actual = MVT_TO_CARTO_TYPES[type];
         if (actual !== expected) {
             throw new CartoRuntimeError(
-                `${runtimeErrors.MVT} MVT: mixed geometry types in the same layer. Layer has type: ${expected} but feature was ${actual}`
+                crt.MVT, `MVT: mixed geometry types in the same layer. Layer has type: ${expected} but feature was ${actual}`
             );
         }
     }

--- a/src/sources/MVTWorker.js
+++ b/src/sources/MVTWorker.js
@@ -4,8 +4,8 @@ import * as rsys from '../client/rsys';
 import { decodeLines, decodePolygons } from '../client/mvt/feature-decoder';
 import MVTMetadata from './MVTMetadata';
 import DummyDataframe from '../renderer/DummyDataframe';
-import CartoValidationError, { CartoValidationTypes } from '../errors/carto-validation-error';
-import CartoRuntimeError, { CartoRuntimeTypes } from '../errors/carto-runtime-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../errors/carto-validation-error';
+import CartoRuntimeError, { CartoRuntimeErrorTypes } from '../errors/carto-runtime-error';
 import { GEOMETRY_TYPE } from '../utils/geometry';
 
 // TODO import correctly
@@ -70,7 +70,7 @@ export class MVTWorker {
         if (Object.keys(tile.layers).length > 1 && !layerID) {
             throw new CartoValidationError(
                 `LayerID parameter wasn't specified and the MVT tile contains multiple layers: ${JSON.stringify(Object.keys(tile.layers))}.`,
-                CartoValidationTypes.MISSING_REQUIRED
+                CartoValidationErrorTypes.MISSING_REQUIRED
             );
         }
 
@@ -103,7 +103,7 @@ export class MVTWorker {
             case GEOMETRY_TYPE.POLYGON:
                 return this._decode(mvtLayer, metadata, mvtExtent, [], decodePolygons);
             default:
-                throw new CartoValidationError(`MVT: invalid geometry type '${metadata.geomType}'`, CartoValidationTypes.INCORRECT_TYPE);
+                throw new CartoValidationError(`MVT: invalid geometry type '${metadata.geomType}'`, CartoValidationErrorTypes.INCORRECT_TYPE);
         }
     }
 
@@ -117,7 +117,7 @@ export class MVTWorker {
             case mvtDecoderGeomTypes.polygon:
                 return GEOMETRY_TYPE.POLYGON;
             default:
-                throw new CartoValidationError(`MVT: invalid geometry type '${type}'`, CartoValidationTypes.INCORRECT_TYPE);
+                throw new CartoValidationError(`MVT: invalid geometry type '${type}'`, CartoValidationErrorTypes.INCORRECT_TYPE);
         }
     }
 
@@ -156,7 +156,7 @@ export class MVTWorker {
             if (f.properties[metadata.idProperty] === undefined) {
                 throw new CartoRuntimeError(
                     `MVT feature with undefined idProperty '${metadata.idProperty}'`,
-                    CartoRuntimeTypes.MVT
+                    CartoRuntimeErrorTypes.MVT
                 );
             }
             this._decodeProperties(metadata, scalarPropertyCodecs, rangePropertyCodecs, properties, f, numFeatures);
@@ -173,7 +173,7 @@ export class MVTWorker {
         if (actual !== expected) {
             throw new CartoRuntimeError(
                 `MVT: mixed geometry types in the same layer. Layer has type: ${expected} but feature was ${actual}`,
-                CartoRuntimeTypes.MVT
+                CartoRuntimeErrorTypes.MVT
             );
         }
     }

--- a/src/sources/MVTWorker.js
+++ b/src/sources/MVTWorker.js
@@ -4,8 +4,8 @@ import * as rsys from '../client/rsys';
 import { decodeLines, decodePolygons } from '../client/mvt/feature-decoder';
 import MVTMetadata from './MVTMetadata';
 import DummyDataframe from '../renderer/DummyDataframe';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../errors/carto-validation-error';
-import CartoRuntimeError, { CartoRuntimeTypes as crt } from '../errors/carto-runtime-error';
+import CartoValidationError, { CartoValidationTypes } from '../errors/carto-validation-error';
+import CartoRuntimeError, { CartoRuntimeTypes } from '../errors/carto-runtime-error';
 import { GEOMETRY_TYPE } from '../utils/geometry';
 
 // TODO import correctly
@@ -70,7 +70,7 @@ export class MVTWorker {
         if (Object.keys(tile.layers).length > 1 && !layerID) {
             throw new CartoValidationError(
                 `LayerID parameter wasn't specified and the MVT tile contains multiple layers: ${JSON.stringify(Object.keys(tile.layers))}.`,
-                cvt.MISSING_REQUIRED
+                CartoValidationTypes.MISSING_REQUIRED
             );
         }
 
@@ -103,7 +103,7 @@ export class MVTWorker {
             case GEOMETRY_TYPE.POLYGON:
                 return this._decode(mvtLayer, metadata, mvtExtent, [], decodePolygons);
             default:
-                throw new CartoValidationError(`MVT: invalid geometry type '${metadata.geomType}'`, cvt.INCORRECT_TYPE);
+                throw new CartoValidationError(`MVT: invalid geometry type '${metadata.geomType}'`, CartoValidationTypes.INCORRECT_TYPE);
         }
     }
 
@@ -117,7 +117,7 @@ export class MVTWorker {
             case mvtDecoderGeomTypes.polygon:
                 return GEOMETRY_TYPE.POLYGON;
             default:
-                throw new CartoValidationError(`MVT: invalid geometry type '${type}'`, cvt.INCORRECT_TYPE);
+                throw new CartoValidationError(`MVT: invalid geometry type '${type}'`, CartoValidationTypes.INCORRECT_TYPE);
         }
     }
 
@@ -156,7 +156,7 @@ export class MVTWorker {
             if (f.properties[metadata.idProperty] === undefined) {
                 throw new CartoRuntimeError(
                     `MVT feature with undefined idProperty '${metadata.idProperty}'`,
-                    crt.MVT
+                    CartoRuntimeTypes.MVT
                 );
             }
             this._decodeProperties(metadata, scalarPropertyCodecs, rangePropertyCodecs, properties, f, numFeatures);
@@ -173,7 +173,7 @@ export class MVTWorker {
         if (actual !== expected) {
             throw new CartoRuntimeError(
                 `MVT: mixed geometry types in the same layer. Layer has type: ${expected} but feature was ${actual}`,
-                crt.MVT
+                CartoRuntimeTypes.MVT
             );
         }
     }

--- a/src/sources/SQL.js
+++ b/src/sources/SQL.js
@@ -64,17 +64,17 @@ export default class SQL extends BaseWindshaft {
 
     _checkQuery (query) {
         if (util.isUndefined(query)) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, '\'query\'');
+            throw new CartoValidationError('\'query\'', cvt.MISSING_REQUIRED);
         }
         if (!util.isString(query)) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'query\' property must be a string.');
+            throw new CartoValidationError('\'query\' property must be a string.', cvt.INCORRECT_TYPE);
         }
         if (query === '') {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, '\'query\' property must be not empty.');
+            throw new CartoValidationError('\'query\' property must be not empty.', cvt.INCORRECT_VALUE);
         }
         let sqlRegex = /\bSELECT\b/i;
         if (!query.match(sqlRegex)) {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, '\'query\' property must be a SQL query.');
+            throw new CartoValidationError('\'query\' property must be a SQL query.', cvt.INCORRECT_VALUE);
         }
     }
 }

--- a/src/sources/SQL.js
+++ b/src/sources/SQL.js
@@ -1,4 +1,4 @@
-import CartoValidationError, { CartoValidationTypes } from '../../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../src/errors/carto-validation-error';
 import util from '../utils/util';
 import BaseWindshaft from './BaseWindshaft';
 
@@ -64,17 +64,17 @@ export default class SQL extends BaseWindshaft {
 
     _checkQuery (query) {
         if (util.isUndefined(query)) {
-            throw new CartoValidationError('\'query\'', CartoValidationTypes.MISSING_REQUIRED);
+            throw new CartoValidationError('\'query\'', CartoValidationErrorTypes.MISSING_REQUIRED);
         }
         if (!util.isString(query)) {
-            throw new CartoValidationError('\'query\' property must be a string.', CartoValidationTypes.INCORRECT_TYPE);
+            throw new CartoValidationError('\'query\' property must be a string.', CartoValidationErrorTypes.INCORRECT_TYPE);
         }
         if (query === '') {
-            throw new CartoValidationError('\'query\' property must be not empty.', CartoValidationTypes.INCORRECT_VALUE);
+            throw new CartoValidationError('\'query\' property must be not empty.', CartoValidationErrorTypes.INCORRECT_VALUE);
         }
         let sqlRegex = /\bSELECT\b/i;
         if (!query.match(sqlRegex)) {
-            throw new CartoValidationError('\'query\' property must be a SQL query.', CartoValidationTypes.INCORRECT_VALUE);
+            throw new CartoValidationError('\'query\' property must be a SQL query.', CartoValidationErrorTypes.INCORRECT_VALUE);
         }
     }
 }

--- a/src/sources/SQL.js
+++ b/src/sources/SQL.js
@@ -64,17 +64,17 @@ export default class SQL extends BaseWindshaft {
 
     _checkQuery (query) {
         if (util.isUndefined(query)) {
-            throw new CartoValidationError(cvt.MISSING_REQUIRED, `'query'`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, '\'query\'');
         }
         if (!util.isString(query)) {
-            throw new CartoValidationError(cvt.INCORRECT_TYPE, `'query' property must be a string.`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, '\'query\' property must be a string.');
         }
         if (query === '') {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, `'query' property must be not empty.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, '\'query\' property must be not empty.');
         }
         let sqlRegex = /\bSELECT\b/i;
         if (!query.match(sqlRegex)) {
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, `'query' property must be a SQL query.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, '\'query\' property must be a SQL query.');
         }
     }
 }

--- a/src/sources/SQL.js
+++ b/src/sources/SQL.js
@@ -64,17 +64,17 @@ export default class SQL extends BaseWindshaft {
 
     _checkQuery (query) {
         if (util.isUndefined(query)) {
-            throw new CartoValidationError(`${cvt.MISSING_REQUIRED} 'query'`);
+            throw new CartoValidationError(cvt.MISSING_REQUIRED, `'query'`);
         }
         if (!util.isString(query)) {
-            throw new CartoValidationError(`${cvt.INCORRECT_TYPE} 'query' property must be a string.`);
+            throw new CartoValidationError(cvt.INCORRECT_TYPE, `'query' property must be a string.`);
         }
         if (query === '') {
-            throw new CartoValidationError(`${cvt.INCORRECT_VALUE} 'query' property must be not empty.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, `'query' property must be not empty.`);
         }
         let sqlRegex = /\bSELECT\b/i;
         if (!query.match(sqlRegex)) {
-            throw new CartoValidationError(`${cvt.INCORRECT_VALUE} 'query' property must be a SQL query.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, `'query' property must be a SQL query.`);
         }
     }
 }

--- a/src/sources/SQL.js
+++ b/src/sources/SQL.js
@@ -1,4 +1,4 @@
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../src/errors/carto-validation-error';
 import util from '../utils/util';
 import BaseWindshaft from './BaseWindshaft';
 
@@ -64,17 +64,17 @@ export default class SQL extends BaseWindshaft {
 
     _checkQuery (query) {
         if (util.isUndefined(query)) {
-            throw new CartoValidationError('\'query\'', cvt.MISSING_REQUIRED);
+            throw new CartoValidationError('\'query\'', CartoValidationTypes.MISSING_REQUIRED);
         }
         if (!util.isString(query)) {
-            throw new CartoValidationError('\'query\' property must be a string.', cvt.INCORRECT_TYPE);
+            throw new CartoValidationError('\'query\' property must be a string.', CartoValidationTypes.INCORRECT_TYPE);
         }
         if (query === '') {
-            throw new CartoValidationError('\'query\' property must be not empty.', cvt.INCORRECT_VALUE);
+            throw new CartoValidationError('\'query\' property must be not empty.', CartoValidationTypes.INCORRECT_VALUE);
         }
         let sqlRegex = /\bSELECT\b/i;
         if (!query.match(sqlRegex)) {
-            throw new CartoValidationError('\'query\' property must be a SQL query.', cvt.INCORRECT_VALUE);
+            throw new CartoValidationError('\'query\' property must be a SQL query.', CartoValidationTypes.INCORRECT_VALUE);
         }
     }
 }

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -45,7 +45,7 @@ export function on (eventName, layerList, callback) {
             internalCallbacks.push(internalCallback);
         });
     } else {
-        throw new CartoValidationError(`${cvt.INCORRECT_VALUE} Event name '${eventName}' is not supported by "carto.on". Supported event names are: 'loaded' and 'updated'.`);
+        throw new CartoValidationError(cvt.INCORRECT_VALUE, `Event name '${eventName}' is not supported by "carto.on". Supported event names are: 'loaded' and 'updated'.`);
     }
     registeredHandlers.push({
         eventName,

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -1,4 +1,4 @@
-import CartoValidationError, { CartoValidationTypes as cvt } from '../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../errors/carto-validation-error';
 
 let registeredHandlers = [];
 
@@ -47,7 +47,7 @@ export function on (eventName, layerList, callback) {
     } else {
         throw new CartoValidationError(
             `Event name '${eventName}' is not supported by "carto.on". Supported event names are: 'loaded' and 'updated'.`,
-            cvt.INCORRECT_VALUE
+            CartoValidationTypes.INCORRECT_VALUE
         );
     }
     registeredHandlers.push({

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -1,4 +1,4 @@
-import CartoValidationError, { CartoValidationTypes } from '../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../errors/carto-validation-error';
 
 let registeredHandlers = [];
 
@@ -47,7 +47,7 @@ export function on (eventName, layerList, callback) {
     } else {
         throw new CartoValidationError(
             `Event name '${eventName}' is not supported by "carto.on". Supported event names are: 'loaded' and 'updated'.`,
-            CartoValidationTypes.INCORRECT_VALUE
+            CartoValidationErrorTypes.INCORRECT_VALUE
         );
     }
     registeredHandlers.push({

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -45,7 +45,10 @@ export function on (eventName, layerList, callback) {
             internalCallbacks.push(internalCallback);
         });
     } else {
-        throw new CartoValidationError(cvt.INCORRECT_VALUE, `Event name '${eventName}' is not supported by "carto.on". Supported event names are: 'loaded' and 'updated'.`);
+        throw new CartoValidationError(
+            `Event name '${eventName}' is not supported by "carto.on". Supported event names are: 'loaded' and 'updated'.`,
+            cvt.INCORRECT_VALUE
+        );
     }
     registeredHandlers.push({
         eventName,

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -187,7 +187,10 @@ export function computeCentroids (decodedGeometry, type) {
         case GEOMETRY_TYPE.POLYGON:
             return _computeCentroidsForLinesOrPolygons(decodedGeometry, type);
         default:
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, 'Invalid type argument, decoded geometry must have a point, line or polygon type.');
+            throw new CartoValidationError(
+                'Invalid type argument, decoded geometry must have a point, line or polygon type.',
+                cvt.INCORRECT_VALUE
+            );
     }
 }
 

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -187,7 +187,7 @@ export function computeCentroids (decodedGeometry, type) {
         case GEOMETRY_TYPE.POLYGON:
             return _computeCentroidsForLinesOrPolygons(decodedGeometry, type);
         default:
-            throw new CartoValidationError(cvt.INCORRECT_VALUE, `Invalid type argument, decoded geometry must have a point, line or polygon type.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, 'Invalid type argument, decoded geometry must have a point, line or polygon type.');
     }
 }
 

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -1,6 +1,6 @@
 import { vec4 } from 'gl-matrix';
 import { average } from '../renderer/viz/expressions/stats';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../errors/carto-validation-error';
 
 export const GEOMETRY_TYPE = {
     UNKNOWN: 'unknown',
@@ -189,7 +189,7 @@ export function computeCentroids (decodedGeometry, type) {
         default:
             throw new CartoValidationError(
                 'Invalid type argument, decoded geometry must have a point, line or polygon type.',
-                cvt.INCORRECT_VALUE
+                CartoValidationTypes.INCORRECT_VALUE
             );
     }
 }

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -1,6 +1,6 @@
 import { vec4 } from 'gl-matrix';
 import { average } from '../renderer/viz/expressions/stats';
-import CartoValidationError, { CartoValidationTypes } from '../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../errors/carto-validation-error';
 
 export const GEOMETRY_TYPE = {
     UNKNOWN: 'unknown',
@@ -189,7 +189,7 @@ export function computeCentroids (decodedGeometry, type) {
         default:
             throw new CartoValidationError(
                 'Invalid type argument, decoded geometry must have a point, line or polygon type.',
-                CartoValidationTypes.INCORRECT_VALUE
+                CartoValidationErrorTypes.INCORRECT_VALUE
             );
     }
 }

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -187,7 +187,7 @@ export function computeCentroids (decodedGeometry, type) {
         case GEOMETRY_TYPE.POLYGON:
             return _computeCentroidsForLinesOrPolygons(decodedGeometry, type);
         default:
-            throw new CartoValidationError(`${cvt.INCORRECT_VALUE} Invalid type argument, decoded geometry must have a point, line or polygon type.`);
+            throw new CartoValidationError(cvt.INCORRECT_VALUE, `Invalid type argument, decoded geometry must have a point, line or polygon type.`);
     }
 }
 

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -50,7 +50,7 @@ export function castDate (date) {
     if (isString(date)) {
         return new Date(date);
     } else {
-        throw new CartoValidationError(cvt.INCORRECT_TYPE, `Invalid Date type`);
+        throw new CartoValidationError(cvt.INCORRECT_TYPE, 'Invalid Date type');
     }
 }
 

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -5,7 +5,7 @@ import { unproject } from './geometry';
 /**
  * Export util functions
  */
-import CartoValidationError, { CartoValidationTypes as cvt } from '../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../errors/carto-validation-error';
 
 const DEG2RAD = Math.PI / 180;
 const EARTH_RADIUS = 6378137;
@@ -52,7 +52,7 @@ export function castDate (date) {
     } else {
         throw new CartoValidationError(
             'Invalid Date type',
-            cvt.INCORRECT_TYPE
+            CartoValidationTypes.INCORRECT_TYPE
         );
     }
 }

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -50,7 +50,10 @@ export function castDate (date) {
     if (isString(date)) {
         return new Date(date);
     } else {
-        throw new CartoValidationError(cvt.INCORRECT_TYPE, 'Invalid Date type');
+        throw new CartoValidationError(
+            'Invalid Date type',
+            cvt.INCORRECT_TYPE
+        );
     }
 }
 

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -50,7 +50,7 @@ export function castDate (date) {
     if (isString(date)) {
         return new Date(date);
     } else {
-        throw new CartoValidationError(`${cvt.INCORRECT_TYPE} Invalid Date type`);
+        throw new CartoValidationError(cvt.INCORRECT_TYPE, `Invalid Date type`);
     }
 }
 

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -5,7 +5,7 @@ import { unproject } from './geometry';
 /**
  * Export util functions
  */
-import CartoValidationError, { CartoValidationTypes } from '../errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../errors/carto-validation-error';
 
 const DEG2RAD = Math.PI / 180;
 const EARTH_RADIUS = 6378137;
@@ -52,7 +52,7 @@ export function castDate (date) {
     } else {
         throw new CartoValidationError(
             'Invalid Date type',
-            CartoValidationTypes.INCORRECT_TYPE
+            CartoValidationErrorTypes.INCORRECT_TYPE
         );
     }
 }

--- a/test/integration/user/test/interactivity.test.js
+++ b/test/integration/user/test/interactivity.test.js
@@ -1,6 +1,6 @@
 import carto from '../../../../src';
 import * as util from '../../util';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../src/errors/carto-validation-error';
 
 // More info: https://github.com/CartoDB/carto-vl/wiki/Interactivity-tests
 
@@ -434,7 +434,7 @@ describe('Interactivity', () => {
 
             const int = new carto.Interactivity([layerA, layerB]);
             int._init([layerA, layerB]).catch((err) => {
-                expect(err).toEqual(new CartoValidationError('Invalid argument, all layers must belong to the same map.', cvt.INCORRECT_VALUE));
+                expect(err).toEqual(new CartoValidationError('Invalid argument, all layers must belong to the same map.', CartoValidationTypes.INCORRECT_VALUE));
                 document.body.removeChild(setupA.div);
                 document.body.removeChild(setupB.div);
                 done();

--- a/test/integration/user/test/interactivity.test.js
+++ b/test/integration/user/test/interactivity.test.js
@@ -434,7 +434,7 @@ describe('Interactivity', () => {
 
             const int = new carto.Interactivity([layerA, layerB]);
             int._init([layerA, layerB]).catch((err) => {
-                expect(err).toEqual(new CartoValidationError(cvt.INCORRECT_VALUE, `Invalid argument, all layers must belong to the same map.`));
+                expect(err).toEqual(new CartoValidationError(cvt.INCORRECT_VALUE, 'Invalid argument, all layers must belong to the same map.'));
                 document.body.removeChild(setupA.div);
                 document.body.removeChild(setupB.div);
                 done();

--- a/test/integration/user/test/interactivity.test.js
+++ b/test/integration/user/test/interactivity.test.js
@@ -434,7 +434,7 @@ describe('Interactivity', () => {
 
             const int = new carto.Interactivity([layerA, layerB]);
             int._init([layerA, layerB]).catch((err) => {
-                expect(err).toEqual(new CartoValidationError(cvt.INCORRECT_VALUE, 'Invalid argument, all layers must belong to the same map.'));
+                expect(err).toEqual(new CartoValidationError('Invalid argument, all layers must belong to the same map.', cvt.INCORRECT_VALUE));
                 document.body.removeChild(setupA.div);
                 document.body.removeChild(setupB.div);
                 done();

--- a/test/integration/user/test/interactivity.test.js
+++ b/test/integration/user/test/interactivity.test.js
@@ -1,6 +1,6 @@
 import carto from '../../../../src';
 import * as util from '../../util';
-import CartoValidationError, { CartoValidationTypes } from '../../../../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../src/errors/carto-validation-error';
 
 // More info: https://github.com/CartoDB/carto-vl/wiki/Interactivity-tests
 
@@ -434,7 +434,7 @@ describe('Interactivity', () => {
 
             const int = new carto.Interactivity([layerA, layerB]);
             int._init([layerA, layerB]).catch((err) => {
-                expect(err).toEqual(new CartoValidationError('Invalid argument, all layers must belong to the same map.', CartoValidationTypes.INCORRECT_VALUE));
+                expect(err).toEqual(new CartoValidationError('Invalid argument, all layers must belong to the same map.', CartoValidationErrorTypes.INCORRECT_VALUE));
                 document.body.removeChild(setupA.div);
                 document.body.removeChild(setupB.div);
                 done();

--- a/test/integration/user/test/interactivity.test.js
+++ b/test/integration/user/test/interactivity.test.js
@@ -434,7 +434,7 @@ describe('Interactivity', () => {
 
             const int = new carto.Interactivity([layerA, layerB]);
             int._init([layerA, layerB]).catch((err) => {
-                expect(err).toEqual(new CartoValidationError(`${cvt.INCORRECT_VALUE} Invalid argument, all layers must belong to the same map.`));
+                expect(err).toEqual(new CartoValidationError(cvt.INCORRECT_VALUE, `Invalid argument, all layers must belong to the same map.`));
                 document.body.removeChild(setupA.div);
                 document.body.removeChild(setupB.div);
                 done();

--- a/test/unit/errors/carto-validation-error.test.js
+++ b/test/unit/errors/carto-validation-error.test.js
@@ -1,5 +1,5 @@
 import CartoError from '../../../src/errors/carto-error';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../src/errors/carto-validation-error';
 
 describe('errors/CartoValidationError', () => {
     it('should allow a simple error', () => {
@@ -8,7 +8,7 @@ describe('errors/CartoValidationError', () => {
         expect(error instanceof CartoError);
         expect(error instanceof CartoValidationError);
         expect(error.name).toBe('CartoValidationError');
-        expect(error.message).toBe('[Error]: my error');
+        expect(error.message).toBe('[Error] my error');
     });
 
     it('shouldn\'t allow an error without a message', () => {
@@ -17,12 +17,12 @@ describe('errors/CartoValidationError', () => {
 
     it('should allow an error message using several predefined categories', () => {
         const errors = [];
-        errors.push(new CartoValidationError('\'id\'', cvt.MISSING_REQUIRED));
-        errors.push(new CartoValidationError('\'id\' property must be a string.', cvt.INCORRECT_TYPE));
-        errors.push(new CartoValidationError('\'resolution\' must be less than 100.', cvt.INCORRECT_VALUE));
-        errors.push(new CartoValidationError(cvt.TOO_MANY_ARGS));
-        errors.push(new CartoValidationError(cvt.NOT_ENOUGH_ARGS));
-        errors.push(new CartoValidationError(cvt.WRONG_NUMBER_ARGS));
+        errors.push(new CartoValidationError('\'id\'', CartoValidationTypes.MISSING_REQUIRED));
+        errors.push(new CartoValidationError('\'id\' property must be a string.', CartoValidationTypes.INCORRECT_TYPE));
+        errors.push(new CartoValidationError('\'resolution\' must be less than 100.', CartoValidationTypes.INCORRECT_VALUE));
+        errors.push(new CartoValidationError(CartoValidationTypes.TOO_MANY_ARGS));
+        errors.push(new CartoValidationError(CartoValidationTypes.NOT_ENOUGH_ARGS));
+        errors.push(new CartoValidationError(CartoValidationTypes.WRONG_NUMBER_ARGS));
 
         errors.forEach(error => {
             expect(error instanceof CartoValidationError);

--- a/test/unit/errors/carto-validation-error.test.js
+++ b/test/unit/errors/carto-validation-error.test.js
@@ -1,5 +1,5 @@
 import CartoError from '../../../src/errors/carto-error';
-import CartoValidationError, { CartoValidationTypes } from '../../../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../src/errors/carto-validation-error';
 
 describe('errors/CartoValidationError', () => {
     it('should allow a simple error', () => {
@@ -17,12 +17,12 @@ describe('errors/CartoValidationError', () => {
 
     it('should allow an error message using several predefined categories', () => {
         const errors = [];
-        errors.push(new CartoValidationError('\'id\'', CartoValidationTypes.MISSING_REQUIRED));
-        errors.push(new CartoValidationError('\'id\' property must be a string.', CartoValidationTypes.INCORRECT_TYPE));
-        errors.push(new CartoValidationError('\'resolution\' must be less than 100.', CartoValidationTypes.INCORRECT_VALUE));
-        errors.push(new CartoValidationError(CartoValidationTypes.TOO_MANY_ARGS));
-        errors.push(new CartoValidationError(CartoValidationTypes.NOT_ENOUGH_ARGS));
-        errors.push(new CartoValidationError(CartoValidationTypes.WRONG_NUMBER_ARGS));
+        errors.push(new CartoValidationError('\'id\'', CartoValidationErrorTypes.MISSING_REQUIRED));
+        errors.push(new CartoValidationError('\'id\' property must be a string.', CartoValidationErrorTypes.INCORRECT_TYPE));
+        errors.push(new CartoValidationError('\'resolution\' must be less than 100.', CartoValidationErrorTypes.INCORRECT_VALUE));
+        errors.push(new CartoValidationError(CartoValidationErrorTypes.TOO_MANY_ARGS));
+        errors.push(new CartoValidationError(CartoValidationErrorTypes.NOT_ENOUGH_ARGS));
+        errors.push(new CartoValidationError(CartoValidationErrorTypes.WRONG_NUMBER_ARGS));
 
         errors.forEach(error => {
             expect(error instanceof CartoValidationError);

--- a/test/unit/errors/carto-validation-error.test.js
+++ b/test/unit/errors/carto-validation-error.test.js
@@ -8,7 +8,7 @@ describe('errors/CartoValidationError', () => {
         expect(error instanceof CartoError);
         expect(error instanceof CartoValidationError);
         expect(error.name).toBe('CartoValidationError');
-        expect(error.message).toBe('my error');
+        expect(error.message).toBe('[Error]: my error');
     });
 
     it('shouldn\'t allow an error without a message', () => {
@@ -17,9 +17,9 @@ describe('errors/CartoValidationError', () => {
 
     it('should allow an error message using several predefined categories', () => {
         const errors = [];
-        errors.push(new CartoValidationError(cvt.MISSING_REQUIRED, '\'id\''));
-        errors.push(new CartoValidationError(cvt.INCORRECT_TYPE, '\'id\' property must be a string.'));
-        errors.push(new CartoValidationError(cvt.INCORRECT_VALUE, '\'resolution\' must be less than 100.'));
+        errors.push(new CartoValidationError('\'id\'', cvt.MISSING_REQUIRED));
+        errors.push(new CartoValidationError('\'id\' property must be a string.', cvt.INCORRECT_TYPE));
+        errors.push(new CartoValidationError('\'resolution\' must be less than 100.', cvt.INCORRECT_VALUE));
         errors.push(new CartoValidationError(cvt.TOO_MANY_ARGS));
         errors.push(new CartoValidationError(cvt.NOT_ENOUGH_ARGS));
         errors.push(new CartoValidationError(cvt.WRONG_NUMBER_ARGS));

--- a/test/unit/errors/carto-validation-error.test.js
+++ b/test/unit/errors/carto-validation-error.test.js
@@ -17,9 +17,9 @@ describe('errors/CartoValidationError', () => {
 
     it('should allow an error message using several predefined categories', () => {
         const errors = [];
-        errors.push(new CartoValidationError(`${cvt.MISSING_REQUIRED} 'id'`));
-        errors.push(new CartoValidationError(`${cvt.INCORRECT_TYPE} 'id' property must be a string.`));
-        errors.push(new CartoValidationError(`${cvt.INCORRECT_VALUE} 'resolution' must be less than 100.`));
+        errors.push(new CartoValidationError(cvt.MISSING_REQUIRED, `'id'`));
+        errors.push(new CartoValidationError(cvt.INCORRECT_TYPE, `'id' property must be a string.`));
+        errors.push(new CartoValidationError(cvt.INCORRECT_VALUE, `'resolution' must be less than 100.`));
         errors.push(new CartoValidationError(cvt.TOO_MANY_ARGS));
         errors.push(new CartoValidationError(cvt.NOT_ENOUGH_ARGS));
         errors.push(new CartoValidationError(cvt.WRONG_NUMBER_ARGS));

--- a/test/unit/errors/carto-validation-error.test.js
+++ b/test/unit/errors/carto-validation-error.test.js
@@ -17,9 +17,9 @@ describe('errors/CartoValidationError', () => {
 
     it('should allow an error message using several predefined categories', () => {
         const errors = [];
-        errors.push(new CartoValidationError(cvt.MISSING_REQUIRED, `'id'`));
-        errors.push(new CartoValidationError(cvt.INCORRECT_TYPE, `'id' property must be a string.`));
-        errors.push(new CartoValidationError(cvt.INCORRECT_VALUE, `'resolution' must be less than 100.`));
+        errors.push(new CartoValidationError(cvt.MISSING_REQUIRED, '\'id\''));
+        errors.push(new CartoValidationError(cvt.INCORRECT_TYPE, '\'id\' property must be a string.'));
+        errors.push(new CartoValidationError(cvt.INCORRECT_VALUE, '\'resolution\' must be less than 100.'));
         errors.push(new CartoValidationError(cvt.TOO_MANY_ARGS));
         errors.push(new CartoValidationError(cvt.NOT_ENOUGH_ARGS));
         errors.push(new CartoValidationError(cvt.WRONG_NUMBER_ARGS));

--- a/test/unit/interactivity.test.js
+++ b/test/unit/interactivity.test.js
@@ -1,5 +1,5 @@
 import { Interactivity, Viz, Layer, source } from '../../src/index';
-import { CartoValidationTypes as cvt } from '../../src/errors/carto-validation-error';
+import { CartoValidationTypes } from '../../src/errors/carto-validation-error';
 
 const { Dataset } = source;
 
@@ -42,15 +42,15 @@ describe('api/interactivity', () => {
         });
 
         it('should throw an error when the layer list is not an array', () => {
-            expect(() => new Interactivity('wadus')).toThrowError(cvt.INCORRECT_TYPE + ' Invalid layer list, parameter must be an array of "carto.Layer" objects.');
+            expect(() => new Interactivity('wadus')).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' Invalid layer list, parameter must be an array of "carto.Layer" objects.');
         });
 
         it('should throw an error when the layer list is empty', () => {
-            expect(() => new Interactivity([])).toThrowError(cvt.INCORRECT_VALUE + ' Invalid argument, layer list must not be empty.');
+            expect(() => new Interactivity([])).toThrowError(CartoValidationTypes.INCORRECT_VALUE + ' Invalid argument, layer list must not be empty.');
         });
 
         it('should throw an error when a layer is not a carto.Layer instance', () => {
-            expect(() => new Interactivity(['wadus'])).toThrowError(cvt.INCORRECT_TYPE + ' Invalid layer, layer must be an instance of "carto.Layer".');
+            expect(() => new Interactivity(['wadus'])).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' Invalid layer, layer must be an instance of "carto.Layer".');
         });
 
         xit('should throw an error when the layers have different map', () => {

--- a/test/unit/interactivity.test.js
+++ b/test/unit/interactivity.test.js
@@ -1,5 +1,5 @@
 import { Interactivity, Viz, Layer, source } from '../../src/index';
-import { CartoValidationTypes } from '../../src/errors/carto-validation-error';
+import { CartoValidationErrorTypes } from '../../src/errors/carto-validation-error';
 
 const { Dataset } = source;
 
@@ -42,15 +42,15 @@ describe('api/interactivity', () => {
         });
 
         it('should throw an error when the layer list is not an array', () => {
-            expect(() => new Interactivity('wadus')).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' Invalid layer list, parameter must be an array of "carto.Layer" objects.');
+            expect(() => new Interactivity('wadus')).toThrowError(CartoValidationErrorTypes.INCORRECT_TYPE + ' Invalid layer list, parameter must be an array of "carto.Layer" objects.');
         });
 
         it('should throw an error when the layer list is empty', () => {
-            expect(() => new Interactivity([])).toThrowError(CartoValidationTypes.INCORRECT_VALUE + ' Invalid argument, layer list must not be empty.');
+            expect(() => new Interactivity([])).toThrowError(CartoValidationErrorTypes.INCORRECT_VALUE + ' Invalid argument, layer list must not be empty.');
         });
 
         it('should throw an error when a layer is not a carto.Layer instance', () => {
-            expect(() => new Interactivity(['wadus'])).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' Invalid layer, layer must be an instance of "carto.Layer".');
+            expect(() => new Interactivity(['wadus'])).toThrowError(CartoValidationErrorTypes.INCORRECT_TYPE + ' Invalid layer, layer must be an instance of "carto.Layer".');
         });
 
         xit('should throw an error when the layers have different map', () => {

--- a/test/unit/layer.test.js
+++ b/test/unit/layer.test.js
@@ -114,7 +114,7 @@ describe('api/layer', () => {
             layer.metadata = { geomType: GEOMETRY_TYPE.POINT };
             layer._context = Promise.resolve(null);
             layer.map = { triggerRepaint: () => { } };
-            layer.updateLayer.then(() => {
+            layer._updateLayer.then(() => {
                 layer.blendToViz(viz2).then(done);
             });
         });

--- a/test/unit/layer.test.js
+++ b/test/unit/layer.test.js
@@ -1,5 +1,5 @@
 import { Layer, Viz, source } from '../../src/index';
-import { CartoValidationTypes as cvt } from '../../src/errors/carto-validation-error';
+import { CartoValidationTypes } from '../../src/errors/carto-validation-error';
 import { GEOMETRY_TYPE } from '../../src/utils/geometry';
 const { Dataset, GeoJSON, SQL } = source;
 
@@ -36,42 +36,42 @@ describe('api/layer', () => {
         it('should throw an error if id is not valid', () => {
             expect(() => {
                 new Layer();
-            }).toThrowError(cvt.MISSING_REQUIRED + ' \'id\'');
+            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'id\'');
 
             expect(() => {
                 new Layer({});
-            }).toThrowError(cvt.INCORRECT_TYPE + ' \'id\' property must be a string.');
+            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' \'id\' property must be a string.');
 
             expect(() => {
                 new Layer('');
-            }).toThrowError(cvt.INCORRECT_VALUE + ' \'id\' property must be not empty.');
+            }).toThrowError(CartoValidationTypes.INCORRECT_VALUE + ' \'id\' property must be not empty.');
         });
 
         it('should throw an error if source is not valid', () => {
             expect(() => {
                 new Layer('layer0');
-            }).toThrowError(cvt.MISSING_REQUIRED + ' \'source\'');
+            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'source\'');
 
             expect(() => {
                 new Layer('layer0', {});
-            }).toThrowError(cvt.INCORRECT_TYPE + ' The given object is not a valid \'source\'. See "carto.source".');
+            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' The given object is not a valid \'source\'. See "carto.source".');
         });
 
         it('should throw an error if viz is not valid', () => {
             expect(() => {
                 new Layer('layer0', source);
-            }).toThrowError(cvt.MISSING_REQUIRED + ' \'viz\'');
+            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'viz\'');
 
             expect(() => {
                 new Layer('layer0', source, {});
-            }).toThrowError(cvt.INCORRECT_TYPE + ' The given object is not a valid \'viz\'. See "carto.Viz".');
+            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' The given object is not a valid \'viz\'. See "carto.Viz".');
         });
 
         it('should throw an error if a viz is already added to another layer', () => {
             new Layer('layer1', source, viz);
             expect(() => {
                 new Layer('layer2', source, viz);
-            }).toThrowError(cvt.INCORRECT_VALUE + ' The given Viz object is already bound to another layer. Vizs cannot be shared between different layers.');
+            }).toThrowError(CartoValidationTypes.INCORRECT_VALUE + ' The given Viz object is already bound to another layer. Vizs cannot be shared between different layers.');
         });
     });
 
@@ -121,14 +121,14 @@ describe('api/layer', () => {
         it('should reject the promise if viz is undefined', (done) => {
             const layer = new Layer('layer0', source, viz);
             layer.blendToViz().catch(error => {
-                expect(error.message).toBe(cvt.MISSING_REQUIRED + ' \'viz\'');
+                expect(error.message).toBe(CartoValidationTypes.MISSING_REQUIRED + ' \'viz\'');
                 done();
             });
         });
         it('should reject the promise when viz is not a valid viz', (done) => {
             const layer = new Layer('layer0', source, viz);
             layer.blendToViz(2).catch(error => {
-                expect(error.message).toBe(cvt.INCORRECT_TYPE + ' The given object is not a valid \'viz\'. See "carto.Viz".');
+                expect(error.message).toBe(CartoValidationTypes.INCORRECT_TYPE + ' The given object is not a valid \'viz\'. See "carto.Viz".');
                 done();
             });
         });
@@ -136,7 +136,7 @@ describe('api/layer', () => {
             const layer = new Layer('layer0', source, viz);
             new Layer('layer1', source, viz2);
             layer.blendToViz(viz2).catch(error => {
-                expect(error.message).toBe(cvt.INCORRECT_VALUE + ' The given Viz object is already bound to another layer. Vizs cannot be shared between different layers.');
+                expect(error.message).toBe(CartoValidationTypes.INCORRECT_VALUE + ' The given Viz object is already bound to another layer. Vizs cannot be shared between different layers.');
                 done();
             });
         });

--- a/test/unit/layer.test.js
+++ b/test/unit/layer.test.js
@@ -1,5 +1,5 @@
 import { Layer, Viz, source } from '../../src/index';
-import { CartoValidationTypes } from '../../src/errors/carto-validation-error';
+import { CartoValidationErrorTypes } from '../../src/errors/carto-validation-error';
 import { GEOMETRY_TYPE } from '../../src/utils/geometry';
 const { Dataset, GeoJSON, SQL } = source;
 
@@ -36,42 +36,42 @@ describe('api/layer', () => {
         it('should throw an error if id is not valid', () => {
             expect(() => {
                 new Layer();
-            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'id\'');
+            }).toThrowError(CartoValidationErrorTypes.MISSING_REQUIRED + ' \'id\'');
 
             expect(() => {
                 new Layer({});
-            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' \'id\' property must be a string.');
+            }).toThrowError(CartoValidationErrorTypes.INCORRECT_TYPE + ' \'id\' property must be a string.');
 
             expect(() => {
                 new Layer('');
-            }).toThrowError(CartoValidationTypes.INCORRECT_VALUE + ' \'id\' property must be not empty.');
+            }).toThrowError(CartoValidationErrorTypes.INCORRECT_VALUE + ' \'id\' property must be not empty.');
         });
 
         it('should throw an error if source is not valid', () => {
             expect(() => {
                 new Layer('layer0');
-            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'source\'');
+            }).toThrowError(CartoValidationErrorTypes.MISSING_REQUIRED + ' \'source\'');
 
             expect(() => {
                 new Layer('layer0', {});
-            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' The given object is not a valid \'source\'. See "carto.source".');
+            }).toThrowError(CartoValidationErrorTypes.INCORRECT_TYPE + ' The given object is not a valid \'source\'. See "carto.source".');
         });
 
         it('should throw an error if viz is not valid', () => {
             expect(() => {
                 new Layer('layer0', source);
-            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'viz\'');
+            }).toThrowError(CartoValidationErrorTypes.MISSING_REQUIRED + ' \'viz\'');
 
             expect(() => {
                 new Layer('layer0', source, {});
-            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' The given object is not a valid \'viz\'. See "carto.Viz".');
+            }).toThrowError(CartoValidationErrorTypes.INCORRECT_TYPE + ' The given object is not a valid \'viz\'. See "carto.Viz".');
         });
 
         it('should throw an error if a viz is already added to another layer', () => {
             new Layer('layer1', source, viz);
             expect(() => {
                 new Layer('layer2', source, viz);
-            }).toThrowError(CartoValidationTypes.INCORRECT_VALUE + ' The given Viz object is already bound to another layer. Vizs cannot be shared between different layers.');
+            }).toThrowError(CartoValidationErrorTypes.INCORRECT_VALUE + ' The given Viz object is already bound to another layer. Vizs cannot be shared between different layers.');
         });
     });
 
@@ -121,14 +121,14 @@ describe('api/layer', () => {
         it('should reject the promise if viz is undefined', (done) => {
             const layer = new Layer('layer0', source, viz);
             layer.blendToViz().catch(error => {
-                expect(error.message).toBe(CartoValidationTypes.MISSING_REQUIRED + ' \'viz\'');
+                expect(error.message).toBe(CartoValidationErrorTypes.MISSING_REQUIRED + ' \'viz\'');
                 done();
             });
         });
         it('should reject the promise when viz is not a valid viz', (done) => {
             const layer = new Layer('layer0', source, viz);
             layer.blendToViz(2).catch(error => {
-                expect(error.message).toBe(CartoValidationTypes.INCORRECT_TYPE + ' The given object is not a valid \'viz\'. See "carto.Viz".');
+                expect(error.message).toBe(CartoValidationErrorTypes.INCORRECT_TYPE + ' The given object is not a valid \'viz\'. See "carto.Viz".');
                 done();
             });
         });
@@ -136,7 +136,7 @@ describe('api/layer', () => {
             const layer = new Layer('layer0', source, viz);
             new Layer('layer1', source, viz2);
             layer.blendToViz(viz2).catch(error => {
-                expect(error.message).toBe(CartoValidationTypes.INCORRECT_VALUE + ' The given Viz object is already bound to another layer. Vizs cannot be shared between different layers.');
+                expect(error.message).toBe(CartoValidationErrorTypes.INCORRECT_VALUE + ' The given Viz object is already bound to another layer. Vizs cannot be shared between different layers.');
                 done();
             });
         });

--- a/test/unit/layer.test.js
+++ b/test/unit/layer.test.js
@@ -114,7 +114,7 @@ describe('api/layer', () => {
             layer.metadata = { geomType: GEOMETRY_TYPE.POINT };
             layer._context = Promise.resolve(null);
             layer.map = { triggerRepaint: () => { } };
-            layer._sourcePromise.then(() => {
+            layer.updateLayer.then(() => {
                 layer.blendToViz(viz2).then(done);
             });
         });

--- a/test/unit/renderer/viz/expressions/basic/list.test.js
+++ b/test/unit/renderer/viz/expressions/basic/list.test.js
@@ -5,8 +5,8 @@ import { CartoValidationTypes as cvt } from '../../../../../../src/errors/carto-
 describe('src/renderer/viz/expressions/basic/list', () => {
     describe('error control', () => {
         validateMaxArgumentsError('list', ['number', 'number']);
-        validateTypeErrors('list', [], () => cvt.MISSING_REQUIRED, `list(): invalid parameters: must receive at least one argument.`);
-        validateTypeErrors('list', [[]], () => cvt.MISSING_REQUIRED, `list(): invalid parameters: must receive at least one argument.`);
+        validateTypeErrors('list', [], () => cvt.MISSING_REQUIRED, 'list(): invalid parameters: must receive at least one argument.');
+        validateTypeErrors('list', [[]], () => cvt.MISSING_REQUIRED, 'list(): invalid parameters: must receive at least one argument.');
         validateTypeErrors('list', [[1, 'a']]);
         validateTypeErrors('list', [[function () { }]]);
     });

--- a/test/unit/renderer/viz/expressions/basic/list.test.js
+++ b/test/unit/renderer/viz/expressions/basic/list.test.js
@@ -1,12 +1,12 @@
 import * as s from '../../../../../../src/renderer/viz/expressions';
 import { validateMaxArgumentsError, validateTypeErrors } from '../utils';
-import { CartoValidationTypes } from '../../../../../../src/errors/carto-validation-error';
+import { CartoValidationErrorTypes } from '../../../../../../src/errors/carto-validation-error';
 
 describe('src/renderer/viz/expressions/basic/list', () => {
     describe('error control', () => {
         validateMaxArgumentsError('list', ['number', 'number']);
-        validateTypeErrors('list', [], () => `${CartoValidationTypes.MISSING_REQUIRED} list(): invalid parameters: must receive at least one argument.`);
-        validateTypeErrors('list', [[]], () => `${CartoValidationTypes.MISSING_REQUIRED} list(): invalid parameters: must receive at least one argument.`);
+        validateTypeErrors('list', [], () => `${CartoValidationErrorTypes.MISSING_REQUIRED} list(): invalid parameters: must receive at least one argument.`);
+        validateTypeErrors('list', [[]], () => `${CartoValidationErrorTypes.MISSING_REQUIRED} list(): invalid parameters: must receive at least one argument.`);
         validateTypeErrors('list', [[1, 'a']]);
         validateTypeErrors('list', [[function () { }]]);
     });

--- a/test/unit/renderer/viz/expressions/basic/list.test.js
+++ b/test/unit/renderer/viz/expressions/basic/list.test.js
@@ -5,8 +5,8 @@ import { CartoValidationTypes as cvt } from '../../../../../../src/errors/carto-
 describe('src/renderer/viz/expressions/basic/list', () => {
     describe('error control', () => {
         validateMaxArgumentsError('list', ['number', 'number']);
-        validateTypeErrors('list', [], () => cvt.MISSING_REQUIRED, 'list(): invalid parameters: must receive at least one argument.');
-        validateTypeErrors('list', [[]], () => cvt.MISSING_REQUIRED, 'list(): invalid parameters: must receive at least one argument.');
+        validateTypeErrors('list', [], () => `${cvt.MISSING_REQUIRED} list(): invalid parameters: must receive at least one argument.`);
+        validateTypeErrors('list', [[]], () => `${cvt.MISSING_REQUIRED} list(): invalid parameters: must receive at least one argument.`);
         validateTypeErrors('list', [[1, 'a']]);
         validateTypeErrors('list', [[function () { }]]);
     });

--- a/test/unit/renderer/viz/expressions/basic/list.test.js
+++ b/test/unit/renderer/viz/expressions/basic/list.test.js
@@ -5,8 +5,8 @@ import { CartoValidationTypes as cvt } from '../../../../../../src/errors/carto-
 describe('src/renderer/viz/expressions/basic/list', () => {
     describe('error control', () => {
         validateMaxArgumentsError('list', ['number', 'number']);
-        validateTypeErrors('list', [], () => `${cvt.MISSING_REQUIRED} list(): invalid parameters: must receive at least one argument.`);
-        validateTypeErrors('list', [[]], () => `${cvt.MISSING_REQUIRED} list(): invalid parameters: must receive at least one argument.`);
+        validateTypeErrors('list', [], () => cvt.MISSING_REQUIRED, `list(): invalid parameters: must receive at least one argument.`);
+        validateTypeErrors('list', [[]], () => cvt.MISSING_REQUIRED, `list(): invalid parameters: must receive at least one argument.`);
         validateTypeErrors('list', [[1, 'a']]);
         validateTypeErrors('list', [[function () { }]]);
     });

--- a/test/unit/renderer/viz/expressions/basic/list.test.js
+++ b/test/unit/renderer/viz/expressions/basic/list.test.js
@@ -1,12 +1,12 @@
 import * as s from '../../../../../../src/renderer/viz/expressions';
 import { validateMaxArgumentsError, validateTypeErrors } from '../utils';
-import { CartoValidationTypes as cvt } from '../../../../../../src/errors/carto-validation-error';
+import { CartoValidationTypes } from '../../../../../../src/errors/carto-validation-error';
 
 describe('src/renderer/viz/expressions/basic/list', () => {
     describe('error control', () => {
         validateMaxArgumentsError('list', ['number', 'number']);
-        validateTypeErrors('list', [], () => `${cvt.MISSING_REQUIRED} list(): invalid parameters: must receive at least one argument.`);
-        validateTypeErrors('list', [[]], () => `${cvt.MISSING_REQUIRED} list(): invalid parameters: must receive at least one argument.`);
+        validateTypeErrors('list', [], () => `${CartoValidationTypes.MISSING_REQUIRED} list(): invalid parameters: must receive at least one argument.`);
+        validateTypeErrors('list', [[]], () => `${CartoValidationTypes.MISSING_REQUIRED} list(): invalid parameters: must receive at least one argument.`);
         validateTypeErrors('list', [[1, 'a']]);
         validateTypeErrors('list', [[function () { }]]);
     });

--- a/test/unit/renderer/viz/expressions/top.test.js
+++ b/test/unit/renderer/viz/expressions/top.test.js
@@ -1,6 +1,6 @@
 import { validateTypeErrors, validateStaticType, validateFeatureDependentErrors, validateMaxArgumentsError } from './utils';
 import * as s from '../../../../../src/renderer/viz/expressions';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../../../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../../../src/errors/carto-validation-error';
 import { OTHERS_LABEL } from '../../../../../src/renderer/viz/expressions/constants';
 
 describe('src/renderer/viz/expressions/top', () => {
@@ -40,7 +40,7 @@ describe('src/renderer/viz/expressions/top', () => {
             const top = s.top(s.property('numericProperty'), 17);
             expect(() => {
                 top.numBuckets();
-            }).toThrowError(CartoValidationError, cvt.INCORRECT_VALUE + ' top() function has a limit of 16 buckets but \'17\' buckets were specified.');
+            }).toThrowError(CartoValidationError, CartoValidationTypes.INCORRECT_VALUE + ' top() function has a limit of 16 buckets but \'17\' buckets were specified.');
         });
 
         afterAll(() => {

--- a/test/unit/renderer/viz/expressions/top.test.js
+++ b/test/unit/renderer/viz/expressions/top.test.js
@@ -1,6 +1,6 @@
 import { validateTypeErrors, validateStaticType, validateFeatureDependentErrors, validateMaxArgumentsError } from './utils';
 import * as s from '../../../../../src/renderer/viz/expressions';
-import CartoValidationError, { CartoValidationTypes } from '../../../../../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../../../src/errors/carto-validation-error';
 import { OTHERS_LABEL } from '../../../../../src/renderer/viz/expressions/constants';
 
 describe('src/renderer/viz/expressions/top', () => {
@@ -40,7 +40,7 @@ describe('src/renderer/viz/expressions/top', () => {
             const top = s.top(s.property('numericProperty'), 17);
             expect(() => {
                 top.numBuckets();
-            }).toThrowError(CartoValidationError, CartoValidationTypes.INCORRECT_VALUE + ' top() function has a limit of 16 buckets but \'17\' buckets were specified.');
+            }).toThrowError(CartoValidationError, CartoValidationErrorTypes.INCORRECT_VALUE + ' top() function has a limit of 16 buckets but \'17\' buckets were specified.');
         });
 
         afterAll(() => {

--- a/test/unit/renderer/viz/parser.test.js
+++ b/test/unit/renderer/viz/parser.test.js
@@ -1,6 +1,8 @@
 /* eslint quotes: "off" */
 
 import { parseVizDefinition, cleanComments } from '../../../../src/renderer/viz/parser';
+import CartoError from '../../../../src/errors/carto-error';
+import { regExpThatContains as thatContains } from '../../../../src/utils/util';
 
 describe('src/renderer/viz/parser', () => {
     // TODO: missing lots of tests here
@@ -85,7 +87,7 @@ describe('src/renderer/viz/parser', () => {
             expect(() => parseVizDefinition(`
                 width: 1
                 width: 2
-            `)).toThrowError('Property \'width\' is already defined.');
+            `)).toThrowError(CartoError, thatContains('Property \'width\' is already defined.'));
         });
     });
 
@@ -94,7 +96,7 @@ describe('src/renderer/viz/parser', () => {
             expect(() => parseVizDefinition(`
                 @a: 1
                 @a: 2
-            `)).toThrowError('Variable \'a\' is already defined.');
+            `)).toThrowError(CartoError, thatContains('Variable \'a\' is already defined.'));
         });
     });
 

--- a/test/unit/setup/auth-service.test.js
+++ b/test/unit/setup/auth-service.test.js
@@ -1,5 +1,5 @@
 import { setDefaultAuth, getDefaultAuth, checkAuth, cleanDefaultAuth } from '../../../src/setup/auth-service';
-import { CartoValidationTypes } from '../../../src/errors/carto-validation-error';
+import { CartoValidationErrorTypes } from '../../../src/errors/carto-validation-error';
 
 describe('api/setup/auth-service', () => {
     const auth = {
@@ -22,37 +22,37 @@ describe('api/setup/auth-service', () => {
         it('should throw an error if auth is not valid', function () {
             expect(function () {
                 checkAuth();
-            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'auth\'');
+            }).toThrowError(CartoValidationErrorTypes.MISSING_REQUIRED + ' \'auth\'');
 
             expect(function () {
                 checkAuth(1234);
-            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' \'auth\' property must be an object.');
+            }).toThrowError(CartoValidationErrorTypes.INCORRECT_TYPE + ' \'auth\' property must be an object.');
         });
 
         it('should throw an error if auth.apiKey is not valid', function () {
             expect(function () {
                 checkAuth({});
-            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'apiKey\'');
+            }).toThrowError(CartoValidationErrorTypes.MISSING_REQUIRED + ' \'apiKey\'');
 
             expect(function () {
                 checkAuth({ apiKey: 1234 });
-            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' \'apiKey\' property must be a string.');
+            }).toThrowError(CartoValidationErrorTypes.INCORRECT_TYPE + ' \'apiKey\' property must be a string.');
 
             expect(function () {
                 checkAuth({ apiKey: '' });
-            }).toThrowError(CartoValidationTypes.INCORRECT_VALUE + ' \'apiKey\' property must be not empty.');
+            }).toThrowError(CartoValidationErrorTypes.INCORRECT_VALUE + ' \'apiKey\' property must be not empty.');
         });
 
         it('should throw an error if auth.username is not valid', function () {
             expect(function () {
                 checkAuth({ apiKey: '123456789' });
-            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'username\'');
+            }).toThrowError(CartoValidationErrorTypes.MISSING_REQUIRED + ' \'username\'');
 
-            const userMustBeString = CartoValidationTypes.INCORRECT_TYPE + ' \'username\' property must be a string.';
+            const userMustBeString = CartoValidationErrorTypes.INCORRECT_TYPE + ' \'username\' property must be a string.';
             expect(function () { checkAuth({ username: 1234, apiKey: '123456789' }); }).toThrowError(userMustBeString);
             expect(function () { checkAuth({ user: 1234, apiKey: '123456789' }); }).toThrowError(userMustBeString);
 
-            const userMustBeNotEmpty = CartoValidationTypes.INCORRECT_VALUE + ' \'username\' property must be not empty.';
+            const userMustBeNotEmpty = CartoValidationErrorTypes.INCORRECT_VALUE + ' \'username\' property must be not empty.';
             expect(function () { checkAuth({ username: '', apiKey: '123456789' }); }).toThrowError(userMustBeNotEmpty);
             expect(function () { checkAuth({ user: '', apiKey: '123456789' }); }).toThrowError(userMustBeNotEmpty);
         });

--- a/test/unit/setup/auth-service.test.js
+++ b/test/unit/setup/auth-service.test.js
@@ -1,5 +1,5 @@
 import { setDefaultAuth, getDefaultAuth, checkAuth, cleanDefaultAuth } from '../../../src/setup/auth-service';
-import { CartoValidationTypes as cvt } from '../../../src/errors/carto-validation-error';
+import { CartoValidationTypes } from '../../../src/errors/carto-validation-error';
 
 describe('api/setup/auth-service', () => {
     const auth = {
@@ -22,37 +22,37 @@ describe('api/setup/auth-service', () => {
         it('should throw an error if auth is not valid', function () {
             expect(function () {
                 checkAuth();
-            }).toThrowError(cvt.MISSING_REQUIRED + ' \'auth\'');
+            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'auth\'');
 
             expect(function () {
                 checkAuth(1234);
-            }).toThrowError(cvt.INCORRECT_TYPE + ' \'auth\' property must be an object.');
+            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' \'auth\' property must be an object.');
         });
 
         it('should throw an error if auth.apiKey is not valid', function () {
             expect(function () {
                 checkAuth({});
-            }).toThrowError(cvt.MISSING_REQUIRED + ' \'apiKey\'');
+            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'apiKey\'');
 
             expect(function () {
                 checkAuth({ apiKey: 1234 });
-            }).toThrowError(cvt.INCORRECT_TYPE + ' \'apiKey\' property must be a string.');
+            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' \'apiKey\' property must be a string.');
 
             expect(function () {
                 checkAuth({ apiKey: '' });
-            }).toThrowError(cvt.INCORRECT_VALUE + ' \'apiKey\' property must be not empty.');
+            }).toThrowError(CartoValidationTypes.INCORRECT_VALUE + ' \'apiKey\' property must be not empty.');
         });
 
         it('should throw an error if auth.username is not valid', function () {
             expect(function () {
                 checkAuth({ apiKey: '123456789' });
-            }).toThrowError(cvt.MISSING_REQUIRED + ' \'username\'');
+            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'username\'');
 
-            const userMustBeString = cvt.INCORRECT_TYPE + ' \'username\' property must be a string.';
+            const userMustBeString = CartoValidationTypes.INCORRECT_TYPE + ' \'username\' property must be a string.';
             expect(function () { checkAuth({ username: 1234, apiKey: '123456789' }); }).toThrowError(userMustBeString);
             expect(function () { checkAuth({ user: 1234, apiKey: '123456789' }); }).toThrowError(userMustBeString);
 
-            const userMustBeNotEmpty = cvt.INCORRECT_VALUE + ' \'username\' property must be not empty.';
+            const userMustBeNotEmpty = CartoValidationTypes.INCORRECT_VALUE + ' \'username\' property must be not empty.';
             expect(function () { checkAuth({ username: '', apiKey: '123456789' }); }).toThrowError(userMustBeNotEmpty);
             expect(function () { checkAuth({ user: '', apiKey: '123456789' }); }).toThrowError(userMustBeNotEmpty);
         });

--- a/test/unit/setup/config-service.test.js
+++ b/test/unit/setup/config-service.test.js
@@ -1,5 +1,5 @@
 import { setDefaultConfig, getDefaultConfig, checkConfig, cleanDefaultConfig } from '../../../src/setup/config-service';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../../src/errors/carto-validation-error';
 import { regExpThatContains as thatContains } from '../../../src/utils/util';
 
 describe('api/setup/config-service', () => {
@@ -29,13 +29,13 @@ describe('api/setup/config-service', () => {
         it('should throw an error if config is not valid', function () {
             expect(function () {
                 checkConfig(1234);
-            }).toThrowError(CartoValidationError, thatContains(cvt.INCORRECT_TYPE + ' \'config\''));
+            }).toThrowError(CartoValidationError, thatContains(CartoValidationTypes.INCORRECT_TYPE + ' \'config\''));
         });
 
         it('should throw an error if config.serverURL is not valid', function () {
             expect(function () {
                 checkConfig({ serverURL: 1234 });
-            }).toThrowError(CartoValidationError, thatContains(cvt.INCORRECT_TYPE + ' \'serverURL\''));
+            }).toThrowError(CartoValidationError, thatContains(CartoValidationTypes.INCORRECT_TYPE + ' \'serverURL\''));
         });
     });
 

--- a/test/unit/setup/config-service.test.js
+++ b/test/unit/setup/config-service.test.js
@@ -1,5 +1,5 @@
 import { setDefaultConfig, getDefaultConfig, checkConfig, cleanDefaultConfig } from '../../../src/setup/config-service';
-import CartoValidationError, { CartoValidationTypes } from '../../../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../../src/errors/carto-validation-error';
 import { regExpThatContains as thatContains } from '../../../src/utils/util';
 
 describe('api/setup/config-service', () => {
@@ -29,13 +29,13 @@ describe('api/setup/config-service', () => {
         it('should throw an error if config is not valid', function () {
             expect(function () {
                 checkConfig(1234);
-            }).toThrowError(CartoValidationError, thatContains(CartoValidationTypes.INCORRECT_TYPE + ' \'config\''));
+            }).toThrowError(CartoValidationError, thatContains(CartoValidationErrorTypes.INCORRECT_TYPE + ' \'config\''));
         });
 
         it('should throw an error if config.serverURL is not valid', function () {
             expect(function () {
                 checkConfig({ serverURL: 1234 });
-            }).toThrowError(CartoValidationError, thatContains(CartoValidationTypes.INCORRECT_TYPE + ' \'serverURL\''));
+            }).toThrowError(CartoValidationError, thatContains(CartoValidationErrorTypes.INCORRECT_TYPE + ' \'serverURL\''));
         });
     });
 

--- a/test/unit/source/GeoJSON.test.js
+++ b/test/unit/source/GeoJSON.test.js
@@ -1,5 +1,5 @@
 import GeoJSON from '../../../src/sources/GeoJSON';
-import { CartoValidationTypes as cvt } from '../../../src/errors/carto-validation-error';
+import { CartoValidationTypes } from '../../../src/errors/carto-validation-error';
 import { regExpThatContains as thatContains } from '../../../src/utils/util';
 
 describe('sources/GeoJSON', () => {
@@ -160,15 +160,15 @@ describe('sources/GeoJSON', () => {
         it('should throw an error if data is not valid', function () {
             expect(function () {
                 new GeoJSON();
-            }).toThrowError(thatContains(cvt.MISSING_REQUIRED + ' \'data\''));
+            }).toThrowError(thatContains(CartoValidationTypes.MISSING_REQUIRED + ' \'data\''));
 
             expect(function () {
                 new GeoJSON(1234);
-            }).toThrowError(thatContains(cvt.INCORRECT_TYPE + ' \'data\' property must be an object.'));
+            }).toThrowError(thatContains(CartoValidationTypes.INCORRECT_TYPE + ' \'data\' property must be an object.'));
 
             expect(function () {
                 new GeoJSON({});
-            }).toThrowError(thatContains(cvt.INCORRECT_VALUE + ' \'data\' property must be a GeoJSON object.'));
+            }).toThrowError(thatContains(CartoValidationTypes.INCORRECT_VALUE + ' \'data\' property must be a GeoJSON object.'));
         });
 
         it('should throw an error if data has different feature types', function () {
@@ -191,7 +191,7 @@ describe('sources/GeoJSON', () => {
             });
             expect(function () {
                 source.requestData();
-            }).toThrowError(thatContains(cvt.INCORRECT_TYPE + ' multiple geometry types not supported: found \'LineString\' instead of \'Point\'.'));
+            }).toThrowError(thatContains(CartoValidationTypes.INCORRECT_TYPE + ' multiple geometry types not supported: found \'LineString\' instead of \'Point\'.'));
         });
 
         describe('decodeGeometry', () => {

--- a/test/unit/source/GeoJSON.test.js
+++ b/test/unit/source/GeoJSON.test.js
@@ -1,5 +1,5 @@
 import GeoJSON from '../../../src/sources/GeoJSON';
-import { CartoValidationTypes } from '../../../src/errors/carto-validation-error';
+import { CartoValidationErrorTypes } from '../../../src/errors/carto-validation-error';
 import { regExpThatContains as thatContains } from '../../../src/utils/util';
 
 describe('sources/GeoJSON', () => {
@@ -160,15 +160,15 @@ describe('sources/GeoJSON', () => {
         it('should throw an error if data is not valid', function () {
             expect(function () {
                 new GeoJSON();
-            }).toThrowError(thatContains(CartoValidationTypes.MISSING_REQUIRED + ' \'data\''));
+            }).toThrowError(thatContains(CartoValidationErrorTypes.MISSING_REQUIRED + ' \'data\''));
 
             expect(function () {
                 new GeoJSON(1234);
-            }).toThrowError(thatContains(CartoValidationTypes.INCORRECT_TYPE + ' \'data\' property must be an object.'));
+            }).toThrowError(thatContains(CartoValidationErrorTypes.INCORRECT_TYPE + ' \'data\' property must be an object.'));
 
             expect(function () {
                 new GeoJSON({});
-            }).toThrowError(thatContains(CartoValidationTypes.INCORRECT_VALUE + ' \'data\' property must be a GeoJSON object.'));
+            }).toThrowError(thatContains(CartoValidationErrorTypes.INCORRECT_VALUE + ' \'data\' property must be a GeoJSON object.'));
         });
 
         it('should throw an error if data has different feature types', function () {
@@ -191,7 +191,7 @@ describe('sources/GeoJSON', () => {
             });
             expect(function () {
                 source.requestData();
-            }).toThrowError(thatContains(CartoValidationTypes.INCORRECT_TYPE + ' multiple geometry types not supported: found \'LineString\' instead of \'Point\'.'));
+            }).toThrowError(thatContains(CartoValidationErrorTypes.INCORRECT_TYPE + ' multiple geometry types not supported: found \'LineString\' instead of \'Point\'.'));
         });
 
         describe('decodeGeometry', () => {

--- a/test/unit/source/SQL.test.js
+++ b/test/unit/source/SQL.test.js
@@ -1,5 +1,5 @@
 import SQL from '../../../src/sources/SQL';
-import { CartoValidationTypes } from '../../../src/errors/carto-validation-error';
+import { CartoValidationErrorTypes } from '../../../src/errors/carto-validation-error';
 
 describe('sources/SQL', () => {
     const query = 'SELECT * from table0';
@@ -33,19 +33,19 @@ describe('sources/SQL', () => {
         it('should throw an error if query is not valid', function () {
             expect(function () {
                 new SQL();
-            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'query\'');
+            }).toThrowError(CartoValidationErrorTypes.MISSING_REQUIRED + ' \'query\'');
 
             expect(function () {
                 new SQL(1234);
-            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' \'query\' property must be a string.');
+            }).toThrowError(CartoValidationErrorTypes.INCORRECT_TYPE + ' \'query\' property must be a string.');
 
             expect(function () {
                 new SQL('');
-            }).toThrowError(CartoValidationTypes.INCORRECT_VALUE + ' \'query\' property must be not empty.');
+            }).toThrowError(CartoValidationErrorTypes.INCORRECT_VALUE + ' \'query\' property must be not empty.');
 
             expect(function () {
                 new SQL('ABC');
-            }).toThrowError(CartoValidationTypes.INCORRECT_VALUE + ' \'query\' property must be a SQL query.');
+            }).toThrowError(CartoValidationErrorTypes.INCORRECT_VALUE + ' \'query\' property must be a SQL query.');
         });
 
         it('should build a new Source with query having the_geom_webmercator', () => {

--- a/test/unit/source/SQL.test.js
+++ b/test/unit/source/SQL.test.js
@@ -1,5 +1,5 @@
 import SQL from '../../../src/sources/SQL';
-import { CartoValidationTypes as cvt } from '../../../src/errors/carto-validation-error';
+import { CartoValidationTypes } from '../../../src/errors/carto-validation-error';
 
 describe('sources/SQL', () => {
     const query = 'SELECT * from table0';
@@ -33,19 +33,19 @@ describe('sources/SQL', () => {
         it('should throw an error if query is not valid', function () {
             expect(function () {
                 new SQL();
-            }).toThrowError(cvt.MISSING_REQUIRED + ' \'query\'');
+            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'query\'');
 
             expect(function () {
                 new SQL(1234);
-            }).toThrowError(cvt.INCORRECT_TYPE + ' \'query\' property must be a string.');
+            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' \'query\' property must be a string.');
 
             expect(function () {
                 new SQL('');
-            }).toThrowError(cvt.INCORRECT_VALUE + ' \'query\' property must be not empty.');
+            }).toThrowError(CartoValidationTypes.INCORRECT_VALUE + ' \'query\' property must be not empty.');
 
             expect(function () {
                 new SQL('ABC');
-            }).toThrowError(cvt.INCORRECT_VALUE + ' \'query\' property must be a SQL query.');
+            }).toThrowError(CartoValidationTypes.INCORRECT_VALUE + ' \'query\' property must be a SQL query.');
         });
 
         it('should build a new Source with query having the_geom_webmercator', () => {

--- a/test/unit/source/base-windshaft.test.js
+++ b/test/unit/source/base-windshaft.test.js
@@ -1,5 +1,5 @@
 import SourceBase from '../../../src/sources/BaseWindshaft';
-import { CartoValidationTypes } from '../../../src/errors/carto-validation-error';
+import { CartoValidationErrorTypes } from '../../../src/errors/carto-validation-error';
 
 describe('sources/base-windshaft', () => {
     const auth = {
@@ -42,45 +42,45 @@ describe('sources/base-windshaft', () => {
         it('should throw an error if auth is not valid', function () {
             expect(function () {
                 source.initialize();
-            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'auth\'');
+            }).toThrowError(CartoValidationErrorTypes.MISSING_REQUIRED + ' \'auth\'');
 
             expect(function () {
                 source.initialize(1234);
-            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' \'auth\' property must be an object.');
+            }).toThrowError(CartoValidationErrorTypes.INCORRECT_TYPE + ' \'auth\' property must be an object.');
         });
 
         it('should throw an error if auth.apiKey is not valid', function () {
             expect(function () {
                 source.initialize({});
-            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'apiKey\'');
+            }).toThrowError(CartoValidationErrorTypes.MISSING_REQUIRED + ' \'apiKey\'');
 
             expect(function () {
                 source.initialize({ apiKey: 1234 });
-            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' \'apiKey\' property must be a string.');
+            }).toThrowError(CartoValidationErrorTypes.INCORRECT_TYPE + ' \'apiKey\' property must be a string.');
 
             expect(function () {
                 source.initialize({ apiKey: '' });
-            }).toThrowError(CartoValidationTypes.INCORRECT_VALUE + ' \'apiKey\' property must be not empty.');
+            }).toThrowError(CartoValidationErrorTypes.INCORRECT_VALUE + ' \'apiKey\' property must be not empty.');
         });
 
         it('should throw an error if auth.username is not valid', function () {
             expect(function () {
                 source.initialize({ apiKey: '123456789' });
-            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'username\'');
+            }).toThrowError(CartoValidationErrorTypes.MISSING_REQUIRED + ' \'username\'');
 
             expect(function () {
                 source.initialize({ username: 1234, apiKey: '123456789' });
-            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' \'username\' property must be a string.');
+            }).toThrowError(CartoValidationErrorTypes.INCORRECT_TYPE + ' \'username\' property must be a string.');
 
             expect(function () {
                 source.initialize({ username: '', apiKey: '123456789' });
-            }).toThrowError(CartoValidationTypes.INCORRECT_VALUE + ' \'username\' property must be not empty.');
+            }).toThrowError(CartoValidationErrorTypes.INCORRECT_VALUE + ' \'username\' property must be not empty.');
         });
 
         it('should throw an error if config are not valid', function () {
             expect(function () {
                 source.initialize(auth, 1234);
-            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' \'config\' property must be an object.');
+            }).toThrowError(CartoValidationErrorTypes.INCORRECT_TYPE + ' \'config\' property must be an object.');
         });
     });
 

--- a/test/unit/source/base-windshaft.test.js
+++ b/test/unit/source/base-windshaft.test.js
@@ -1,5 +1,5 @@
 import SourceBase from '../../../src/sources/BaseWindshaft';
-import { CartoValidationTypes as cvt } from '../../../src/errors/carto-validation-error';
+import { CartoValidationTypes } from '../../../src/errors/carto-validation-error';
 
 describe('sources/base-windshaft', () => {
     const auth = {
@@ -42,45 +42,45 @@ describe('sources/base-windshaft', () => {
         it('should throw an error if auth is not valid', function () {
             expect(function () {
                 source.initialize();
-            }).toThrowError(cvt.MISSING_REQUIRED + ' \'auth\'');
+            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'auth\'');
 
             expect(function () {
                 source.initialize(1234);
-            }).toThrowError(cvt.INCORRECT_TYPE + ' \'auth\' property must be an object.');
+            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' \'auth\' property must be an object.');
         });
 
         it('should throw an error if auth.apiKey is not valid', function () {
             expect(function () {
                 source.initialize({});
-            }).toThrowError(cvt.MISSING_REQUIRED + ' \'apiKey\'');
+            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'apiKey\'');
 
             expect(function () {
                 source.initialize({ apiKey: 1234 });
-            }).toThrowError(cvt.INCORRECT_TYPE + ' \'apiKey\' property must be a string.');
+            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' \'apiKey\' property must be a string.');
 
             expect(function () {
                 source.initialize({ apiKey: '' });
-            }).toThrowError(cvt.INCORRECT_VALUE + ' \'apiKey\' property must be not empty.');
+            }).toThrowError(CartoValidationTypes.INCORRECT_VALUE + ' \'apiKey\' property must be not empty.');
         });
 
         it('should throw an error if auth.username is not valid', function () {
             expect(function () {
                 source.initialize({ apiKey: '123456789' });
-            }).toThrowError(cvt.MISSING_REQUIRED + ' \'username\'');
+            }).toThrowError(CartoValidationTypes.MISSING_REQUIRED + ' \'username\'');
 
             expect(function () {
                 source.initialize({ username: 1234, apiKey: '123456789' });
-            }).toThrowError(cvt.INCORRECT_TYPE + ' \'username\' property must be a string.');
+            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' \'username\' property must be a string.');
 
             expect(function () {
                 source.initialize({ username: '', apiKey: '123456789' });
-            }).toThrowError(cvt.INCORRECT_VALUE + ' \'username\' property must be not empty.');
+            }).toThrowError(CartoValidationTypes.INCORRECT_VALUE + ' \'username\' property must be not empty.');
         });
 
         it('should throw an error if config are not valid', function () {
             expect(function () {
                 source.initialize(auth, 1234);
-            }).toThrowError(cvt.INCORRECT_TYPE + ' \'config\' property must be an object.');
+            }).toThrowError(CartoValidationTypes.INCORRECT_TYPE + ' \'config\' property must be an object.');
         });
     });
 

--- a/test/unit/source/dataset.test.js
+++ b/test/unit/source/dataset.test.js
@@ -1,5 +1,5 @@
 import Dataset from '../../../src/sources/Dataset';
-import { CartoValidationTypes } from '../../../src/errors/carto-validation-error';
+import { CartoValidationErrorTypes } from '../../../src/errors/carto-validation-error';
 import { regExpThatContains as thatContains } from '../../../src/utils/util';
 
 describe('sources/dataset', () => {
@@ -34,15 +34,15 @@ describe('sources/dataset', () => {
         it('should throw an error if tableName is not valid', function () {
             expect(function () {
                 new Dataset();
-            }).toThrowError(thatContains(CartoValidationTypes.MISSING_REQUIRED + ' \'tableName\''));
+            }).toThrowError(thatContains(CartoValidationErrorTypes.MISSING_REQUIRED + ' \'tableName\''));
 
             expect(function () {
                 new Dataset(1234);
-            }).toThrowError(thatContains(CartoValidationTypes.INCORRECT_TYPE + ' \'tableName\''));
+            }).toThrowError(thatContains(CartoValidationErrorTypes.INCORRECT_TYPE + ' \'tableName\''));
 
             expect(function () {
                 new Dataset('');
-            }).toThrowError(thatContains(CartoValidationTypes.INCORRECT_VALUE + ' \'tableName\''));
+            }).toThrowError(thatContains(CartoValidationErrorTypes.INCORRECT_VALUE + ' \'tableName\''));
         });
     });
 });

--- a/test/unit/source/dataset.test.js
+++ b/test/unit/source/dataset.test.js
@@ -1,5 +1,5 @@
 import Dataset from '../../../src/sources/Dataset';
-import { CartoValidationTypes as cvt } from '../../../src/errors/carto-validation-error';
+import { CartoValidationTypes } from '../../../src/errors/carto-validation-error';
 import { regExpThatContains as thatContains } from '../../../src/utils/util';
 
 describe('sources/dataset', () => {
@@ -34,15 +34,15 @@ describe('sources/dataset', () => {
         it('should throw an error if tableName is not valid', function () {
             expect(function () {
                 new Dataset();
-            }).toThrowError(thatContains(cvt.MISSING_REQUIRED + ' \'tableName\''));
+            }).toThrowError(thatContains(CartoValidationTypes.MISSING_REQUIRED + ' \'tableName\''));
 
             expect(function () {
                 new Dataset(1234);
-            }).toThrowError(thatContains(cvt.INCORRECT_TYPE + ' \'tableName\''));
+            }).toThrowError(thatContains(CartoValidationTypes.INCORRECT_TYPE + ' \'tableName\''));
 
             expect(function () {
                 new Dataset('');
-            }).toThrowError(thatContains(cvt.INCORRECT_VALUE + ' \'tableName\''));
+            }).toThrowError(thatContains(CartoValidationTypes.INCORRECT_VALUE + ' \'tableName\''));
         });
     });
 });

--- a/test/unit/viz.test.js
+++ b/test/unit/viz.test.js
@@ -1,5 +1,5 @@
 import { Viz, expressions as s } from '../../src/index';
-import CartoValidationError, { CartoValidationTypes as cvt } from '../../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationTypes } from '../../src/errors/carto-validation-error';
 import { regExpThatContains as thatContains } from '../../src/utils/util';
 import { SUPPORTED_VIZ_PROPERTIES } from '../../src/constants/viz';
 import CartoError from '../../src/errors/carto-error';
@@ -82,7 +82,7 @@ describe('api/viz', () => {
             it('should throw an error when parameter is not an object neither a string', function () {
                 expect(function () {
                     new Viz(1234);
-                }).toThrowError(CartoValidationError, thatContains(cvt.INCORRECT_VALUE + ' viz \'definition\' should be a vizSpec object or a valid viz string.'));
+                }).toThrowError(CartoValidationError, thatContains(CartoValidationTypes.INCORRECT_VALUE + ' viz \'definition\' should be a vizSpec object or a valid viz string.'));
             });
 
             it('should throw an error when resolution is not a number', () => {
@@ -91,7 +91,7 @@ describe('api/viz', () => {
                 };
                 expect(function () {
                     new Viz(vizSpec);
-                }).toThrowError(CartoValidationError, cvt.INCORRECT_TYPE + ' \'resolution\' property must be a number.');
+                }).toThrowError(CartoValidationError, CartoValidationTypes.INCORRECT_TYPE + ' \'resolution\' property must be a number.');
             });
 
             it('should throw an error when resolution is too small', () => {
@@ -100,7 +100,7 @@ describe('api/viz', () => {
                 };
                 expect(function () {
                     new Viz(vizSpec);
-                }).toThrowError(CartoValidationError, cvt.INCORRECT_VALUE + ' \'resolution\' is 0, must be greater than 0.');
+                }).toThrowError(CartoValidationError, CartoValidationTypes.INCORRECT_VALUE + ' \'resolution\' is 0, must be greater than 0.');
             });
 
             it('should throw an error when resolution is too big', () => {
@@ -109,7 +109,7 @@ describe('api/viz', () => {
                 };
                 expect(function () {
                     new Viz(vizSpec);
-                }).toThrowError(CartoValidationError, cvt.INCORRECT_VALUE + ' \'resolution\' is 10000, must be lower than 256.');
+                }).toThrowError(CartoValidationError, CartoValidationTypes.INCORRECT_VALUE + ' \'resolution\' is 10000, must be lower than 256.');
             });
 
             it('should throw an error when color is not a valid expression', () => {
@@ -118,7 +118,7 @@ describe('api/viz', () => {
                 };
                 expect(function () {
                     new Viz(vizSpec);
-                }).toThrowError(CartoValidationError, thatContains(cvt.INCORRECT_TYPE + ' \'color\''));
+                }).toThrowError(CartoValidationError, thatContains(CartoValidationTypes.INCORRECT_TYPE + ' \'color\''));
             });
 
             it('should throw an error when width is not a valid expression', () => {
@@ -127,7 +127,7 @@ describe('api/viz', () => {
                 };
                 expect(function () {
                     new Viz(vizSpec);
-                }).toThrowError(CartoValidationError, thatContains(cvt.INCORRECT_TYPE + ' \'width\''));
+                }).toThrowError(CartoValidationError, thatContains(CartoValidationTypes.INCORRECT_TYPE + ' \'width\''));
             });
 
             it('should throw an error when strokeColor is not a valid expression', () => {
@@ -136,7 +136,7 @@ describe('api/viz', () => {
                 };
                 expect(function () {
                     new Viz(vizSpec);
-                }).toThrowError(CartoValidationError, thatContains(cvt.INCORRECT_TYPE + ' \'strokeColor\''));
+                }).toThrowError(CartoValidationError, thatContains(CartoValidationTypes.INCORRECT_TYPE + ' \'strokeColor\''));
             });
 
             it('should throw an error when strokeWidth is not a valid expression', () => {
@@ -145,7 +145,7 @@ describe('api/viz', () => {
                 };
                 expect(function () {
                     new Viz(vizSpec);
-                }).toThrowError(CartoValidationError, thatContains(cvt.INCORRECT_TYPE + ' \'strokeWidth\''));
+                }).toThrowError(CartoValidationError, thatContains(CartoValidationTypes.INCORRECT_TYPE + ' \'strokeWidth\''));
             });
 
             it('should throw an error when order is not a valid expression', () => {
@@ -154,7 +154,7 @@ describe('api/viz', () => {
                 };
                 expect(function () {
                     new Viz(vizSpec);
-                }).toThrowError(CartoValidationError, thatContains(cvt.INCORRECT_TYPE + ' \'order\''));
+                }).toThrowError(CartoValidationError, thatContains(CartoValidationTypes.INCORRECT_TYPE + ' \'order\''));
             });
 
             it('should add a console.warn when non supported properties are included', () => {

--- a/test/unit/viz.test.js
+++ b/test/unit/viz.test.js
@@ -2,6 +2,7 @@ import { Viz, expressions as s } from '../../src/index';
 import CartoValidationError, { CartoValidationTypes as cvt } from '../../src/errors/carto-validation-error';
 import { regExpThatContains as thatContains } from '../../src/utils/util';
 import { SUPPORTED_VIZ_PROPERTIES } from '../../src/constants/viz';
+import CartoError from '../../src/errors/carto-error';
 
 // Generic Style defaults
 const DEFAULT_COLOR_EXPRESSION = s.rgb(0, 0, 0);
@@ -24,7 +25,7 @@ describe('api/viz', () => {
                 expect(actual.color.eval()).toEqual(DEFAULT_COLOR_EXPRESSION.eval());
                 expect(actual.width.eval()).toEqual(DEFAULT_WIDTH_EXPRESSION.eval());
                 expect(actual.strokeColor.eval()).toEqual(DEFAULT_STROKE_COLOR_EXPRESSION.eval());
-                expect(actual.strokeWidth.eval()).toEqual(DEFAULT_STROKE_WIDTH_EXPRESSION.eval());
+                expect(actual.strokeWidthx.eval()).toEqual(DEFAULT_STROKE_WIDTH_EXPRESSION.eval());
                 expect(actual.filter.eval()).toEqual(DEFAULT_FILTER_EXPRESSION.eval());
                 expect(actual.order.expr).toEqual(DEFAULT_ORDER_EXPRESSION.expr);
                 expect(actual.resolution.eval()).toEqual(DEFAULT_RESOLUTION.eval());
@@ -372,7 +373,7 @@ describe('api/viz', () => {
             expect(() => new Viz(`width: ramp(linear($numeric, 0, 10), [0.10,0.20,0.30]) * __cartovl_variable_ten
                 __cartovl_variable_oneHundred: __cartovl_variable_ten * __cartovl_variable_ten
                 __cartovl_variable_ten: __cartovl_variable_oneHundred / 10
-            `)).toThrowError('Viz contains a circular dependency');
+            `)).toThrowError(CartoError, thatContains('Viz contains a circular dependency'));
         });
     });
 

--- a/test/unit/viz.test.js
+++ b/test/unit/viz.test.js
@@ -25,7 +25,7 @@ describe('api/viz', () => {
                 expect(actual.color.eval()).toEqual(DEFAULT_COLOR_EXPRESSION.eval());
                 expect(actual.width.eval()).toEqual(DEFAULT_WIDTH_EXPRESSION.eval());
                 expect(actual.strokeColor.eval()).toEqual(DEFAULT_STROKE_COLOR_EXPRESSION.eval());
-                expect(actual.strokeWidthx.eval()).toEqual(DEFAULT_STROKE_WIDTH_EXPRESSION.eval());
+                expect(actual.strokeWidth.eval()).toEqual(DEFAULT_STROKE_WIDTH_EXPRESSION.eval());
                 expect(actual.filter.eval()).toEqual(DEFAULT_FILTER_EXPRESSION.eval());
                 expect(actual.order.expr).toEqual(DEFAULT_ORDER_EXPRESSION.expr);
                 expect(actual.resolution.eval()).toEqual(DEFAULT_RESOLUTION.eval());

--- a/test/unit/viz.test.js
+++ b/test/unit/viz.test.js
@@ -1,5 +1,5 @@
 import { Viz, expressions as s } from '../../src/index';
-import CartoValidationError, { CartoValidationTypes } from '../../src/errors/carto-validation-error';
+import CartoValidationError, { CartoValidationErrorTypes } from '../../src/errors/carto-validation-error';
 import { regExpThatContains as thatContains } from '../../src/utils/util';
 import { SUPPORTED_VIZ_PROPERTIES } from '../../src/constants/viz';
 import CartoError from '../../src/errors/carto-error';
@@ -82,7 +82,7 @@ describe('api/viz', () => {
             it('should throw an error when parameter is not an object neither a string', function () {
                 expect(function () {
                     new Viz(1234);
-                }).toThrowError(CartoValidationError, thatContains(CartoValidationTypes.INCORRECT_VALUE + ' viz \'definition\' should be a vizSpec object or a valid viz string.'));
+                }).toThrowError(CartoValidationError, thatContains(CartoValidationErrorTypes.INCORRECT_VALUE + ' viz \'definition\' should be a vizSpec object or a valid viz string.'));
             });
 
             it('should throw an error when resolution is not a number', () => {
@@ -91,7 +91,7 @@ describe('api/viz', () => {
                 };
                 expect(function () {
                     new Viz(vizSpec);
-                }).toThrowError(CartoValidationError, CartoValidationTypes.INCORRECT_TYPE + ' \'resolution\' property must be a number.');
+                }).toThrowError(CartoValidationError, CartoValidationErrorTypes.INCORRECT_TYPE + ' \'resolution\' property must be a number.');
             });
 
             it('should throw an error when resolution is too small', () => {
@@ -100,7 +100,7 @@ describe('api/viz', () => {
                 };
                 expect(function () {
                     new Viz(vizSpec);
-                }).toThrowError(CartoValidationError, CartoValidationTypes.INCORRECT_VALUE + ' \'resolution\' is 0, must be greater than 0.');
+                }).toThrowError(CartoValidationError, CartoValidationErrorTypes.INCORRECT_VALUE + ' \'resolution\' is 0, must be greater than 0.');
             });
 
             it('should throw an error when resolution is too big', () => {
@@ -109,7 +109,7 @@ describe('api/viz', () => {
                 };
                 expect(function () {
                     new Viz(vizSpec);
-                }).toThrowError(CartoValidationError, CartoValidationTypes.INCORRECT_VALUE + ' \'resolution\' is 10000, must be lower than 256.');
+                }).toThrowError(CartoValidationError, CartoValidationErrorTypes.INCORRECT_VALUE + ' \'resolution\' is 10000, must be lower than 256.');
             });
 
             it('should throw an error when color is not a valid expression', () => {
@@ -118,7 +118,7 @@ describe('api/viz', () => {
                 };
                 expect(function () {
                     new Viz(vizSpec);
-                }).toThrowError(CartoValidationError, thatContains(CartoValidationTypes.INCORRECT_TYPE + ' \'color\''));
+                }).toThrowError(CartoValidationError, thatContains(CartoValidationErrorTypes.INCORRECT_TYPE + ' \'color\''));
             });
 
             it('should throw an error when width is not a valid expression', () => {
@@ -127,7 +127,7 @@ describe('api/viz', () => {
                 };
                 expect(function () {
                     new Viz(vizSpec);
-                }).toThrowError(CartoValidationError, thatContains(CartoValidationTypes.INCORRECT_TYPE + ' \'width\''));
+                }).toThrowError(CartoValidationError, thatContains(CartoValidationErrorTypes.INCORRECT_TYPE + ' \'width\''));
             });
 
             it('should throw an error when strokeColor is not a valid expression', () => {
@@ -136,7 +136,7 @@ describe('api/viz', () => {
                 };
                 expect(function () {
                     new Viz(vizSpec);
-                }).toThrowError(CartoValidationError, thatContains(CartoValidationTypes.INCORRECT_TYPE + ' \'strokeColor\''));
+                }).toThrowError(CartoValidationError, thatContains(CartoValidationErrorTypes.INCORRECT_TYPE + ' \'strokeColor\''));
             });
 
             it('should throw an error when strokeWidth is not a valid expression', () => {
@@ -145,7 +145,7 @@ describe('api/viz', () => {
                 };
                 expect(function () {
                     new Viz(vizSpec);
-                }).toThrowError(CartoValidationError, thatContains(CartoValidationTypes.INCORRECT_TYPE + ' \'strokeWidth\''));
+                }).toThrowError(CartoValidationError, thatContains(CartoValidationErrorTypes.INCORRECT_TYPE + ' \'strokeWidth\''));
             });
 
             it('should throw an error when order is not a valid expression', () => {
@@ -154,7 +154,7 @@ describe('api/viz', () => {
                 };
                 expect(function () {
                     new Viz(vizSpec);
-                }).toThrowError(CartoValidationError, thatContains(CartoValidationTypes.INCORRECT_TYPE + ' \'order\''));
+                }).toThrowError(CartoValidationError, thatContains(CartoValidationErrorTypes.INCORRECT_TYPE + ' \'order\''));
             });
 
             it('should add a console.warn when non supported properties are included', () => {


### PR DESCRIPTION
Related with https://github.com/CartoDB/carto-vl/issues/1309 and https://github.com/CartoDB/carto-vl/issues/743

This PR adds a `type` parameter to our custom errors in order to display better errors from external applications.

This would be a simple example of displaying the errors in HTML:

```html
<section class="error-section">
    <span id="error-name"></span>
    <span id="error-type"></span>
    <span id="error-message"></span>
</section>
```
```js
try {
    init()
} catch (e) {
    const error$ = document.getElementById('error-container');
    const errors$ = error$.getElementsByTagName('span');

    errors$[0].innerHTML = e.name;
    errors$[1].innerHTML = e.type;
    errors$[2].innerHTML = e.message;
}
```