### PR TITLE
Remove layer from interactivity when layer is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Next
 
+## Added
+- `removed` event for Layer instances
+
 ### Changed
 - Internal refactor regarding data sources (GeoJSON and Windshaft)
 - Unify `.value`, `.eval()` and `.getLegendData()` methods to get expression values
+
+### Fixed
+- Deregister removed layers in interactivity
+- Remove map listeners when there are no layers remaining in interactivity
 
 ## [1.2.5] - 2019-04-25
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ We use [SemVer](http://semver.org/) for versioning. For the versions available, 
 - [Mamata Akella](https://github.com/makella)
 - [Víctor Velarde](https://github.com/VictorVelarde)
 - [Ariana Escobar](https://github.com/arianaescobar)
+- [Jesús Botella](https://github.com/jesusbotella)
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "Raúl Ochoa <rochoa@carto.com>",
     "Ariana Escobar <ariana@carto.com>",
     "Elena Torro <elena@carto.com>",
-    "Víctor Velarde <victor@carto.com>"
+    "Víctor Velarde <victor@carto.com>",
+    "Jesús Botella <jbotella@carto.com>"
   ],
   "license": "BSD-3-Clause",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/carto-vl",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "sideEffects": false,
   "description": "CARTO Vector library",
   "repository": {

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -441,6 +441,7 @@ export default class Layer {
      * Custom Layer API: `onRemove` function
      */
     onRemove (map, gl) {
+        this._fire('removed');
     }
 
     /**

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -127,7 +127,7 @@ export default class Layer {
     /**
      * Register an event handler for the given event name.
      *
-     * @param {String} eventName - Type of event to listen for. Valid names are: `loaded`, `updated`.
+     * @param {String} eventName - Type of event to listen for. Valid names are: `loaded`, `updated`, and `removed`.
      * @param {function} callback - Function to call in response to given event
      * @memberof carto.Layer
      * @instance
@@ -140,7 +140,7 @@ export default class Layer {
     /**
      * Remove an event handler for the given type.
      *
-     * @param {String} eventName - Type of event to unregister. Valid names are: `loaded`, `updated`.
+     * @param {String} eventName - Type of event to unregister. Valid names are: `loaded`, `updated`, and `removed`.
      * @param {function} callback - Handler function to unregister
      * @memberof carto.Layer
      * @instance

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -441,7 +441,7 @@ export default class Layer {
      * Custom Layer API: `onRemove` function
      */
     onRemove (map, gl) {
-        this._fire('removed');
+        this._fire('removed', this);
     }
 
     /**

--- a/src/interactivity/Interactivity.js
+++ b/src/interactivity/Interactivity.js
@@ -128,6 +128,7 @@ export default class Interactivity {
         this._prevHoverFeatures = [];
         this._prevClickFeatures = [];
         this._numListeners = {};
+        this._isAutoChangePointerEnabled = options.autoChangePointer;
 
         const allLayersReadyPromises = layerList.map(layer => layer._context);
         return Promise.all(allLayersReadyPromises)
@@ -135,8 +136,8 @@ export default class Interactivity {
                 postCheckLayerList(layerList);
                 this._subscribeToLayerEvents(layerList);
                 this._subscribeToMapEvents(layerList[0].map);
-            }).then(() => {
-                if (options.autoChangePointer) {
+
+                if (this._isAutoChangePointerEnabled) {
                     this._setInteractiveCursor();
                 }
             });
@@ -164,7 +165,7 @@ export default class Interactivity {
         this._onMouseMoveBound = this._onMouseMove.bind(this);
         map.on('mousemove', this._onMouseMoveBound);
 
-        this._onClickBound = this._onMouseMove.bind(this);
+        this._onClickBound = this._onClick.bind(this);
         map.on('click', this._onClickBound);
 
         this._disableWhileMovingMap(map);
@@ -204,7 +205,10 @@ export default class Interactivity {
         const map = this._layerList[0].map;
 
         this._removeLayerFromInteractivity(layer);
-        this._onFeatureHoverBound({ features: [] });
+
+        if (this._isAutoChangePointerEnabled) {
+            this._onFeatureHoverBound({ features: [] });
+        }
 
         if (!this._layerList.length) {
             this._unsubscribeToMapEvents(map);

--- a/src/interactivity/Interactivity.js
+++ b/src/interactivity/Interactivity.js
@@ -147,14 +147,17 @@ export default class Interactivity {
         if (!map.__carto_interactivities) {
             map.__carto_interactivities = new Set();
         }
-        this.on('featureHover', event => {
-            if (event.features.length) {
-                map.__carto_interactivities.add(this);
-            } else {
-                map.__carto_interactivities.delete(this);
-            }
-            map.getCanvas().style.cursor = (map.__carto_interactivities.size > 0) ? 'pointer' : '';
-        });
+        this._onFeatureHoverBound = this._onFeatureHover.bind(this, map);
+        this.on('featureHover', this._onFeatureHoverBound);
+    }
+
+    _onFeatureHover (map, event) {
+        if (event.features.length) {
+            map.__carto_interactivities.add(this);
+        } else {
+            map.__carto_interactivities.delete(this);
+        }
+        map.getCanvas().style.cursor = (map.__carto_interactivities.size > 0) ? 'pointer' : '';
     }
 
     _subscribeToMapEvents (map) {
@@ -198,10 +201,13 @@ export default class Interactivity {
     }
 
     _onLayerRemoved (layer) {
+        const map = this._layerList[0].map;
+
         this._removeLayerFromInteractivity(layer);
+        this._onFeatureHoverBound({ features: [] });
 
         if (!this._layerList.length) {
-            this._unsubscribeToMapEvents();
+            this._unsubscribeToMapEvents(map);
         }
     }
 

--- a/src/interactivity/Interactivity.js
+++ b/src/interactivity/Interactivity.js
@@ -134,8 +134,10 @@ export default class Interactivity {
         return Promise.all(allLayersReadyPromises)
             .then(() => {
                 postCheckLayerList(layerList);
+                this._map = layerList[0].map;
+
                 this._subscribeToLayerEvents(layerList);
-                this._subscribeToMapEvents(layerList[0].map);
+                this._subscribeToMapEvents(this._map);
 
                 if (this._isAutoChangePointerEnabled) {
                     this._setInteractiveCursor();
@@ -144,15 +146,13 @@ export default class Interactivity {
     }
 
     _setInteractiveCursor () {
-        const map = this._layerList[0].map; // All layers belong to the same map
-        if (!map.__carto_interactivities) {
-            map.__carto_interactivities = new Set();
+        if (!this._map.__carto_interactivities) {
+            this._map.__carto_interactivities = new Set();
         }
-        this._onFeatureHoverBound = this._onFeatureHover.bind(this, map);
-        this.on('featureHover', this._onFeatureHoverBound);
+        this.on('featureHover', event => this._onFeatureHover(event, this._map));
     }
 
-    _onFeatureHover (map, event) {
+    _onFeatureHover (event, map) {
         if (event.features.length) {
             map.__carto_interactivities.add(this);
         } else {
@@ -205,11 +205,11 @@ export default class Interactivity {
         this._removeLayerFromInteractivity(layer);
 
         if (this._isAutoChangePointerEnabled) {
-            this._onFeatureHoverBound({ features: [] });
+            this._onFeatureHover({ features: [] }, this._map);
         }
 
         if (!this._layerList.length) {
-            this._unsubscribeToMapEvents(this._layerList[0].map);
+            this._unsubscribeToMapEvents(this._map);
         }
     }
 

--- a/src/interactivity/Interactivity.js
+++ b/src/interactivity/Interactivity.js
@@ -202,8 +202,6 @@ export default class Interactivity {
     }
 
     _onLayerRemoved (layer) {
-        const map = this._layerList[0].map;
-
         this._removeLayerFromInteractivity(layer);
 
         if (this._isAutoChangePointerEnabled) {
@@ -211,7 +209,7 @@ export default class Interactivity {
         }
 
         if (!this._layerList.length) {
-            this._unsubscribeToMapEvents(map);
+            this._unsubscribeToMapEvents(this._layerList[0].map);
         }
     }
 

--- a/src/interactivity/Interactivity.js
+++ b/src/interactivity/Interactivity.js
@@ -158,9 +158,18 @@ export default class Interactivity {
     }
 
     _subscribeToMapEvents (map) {
-        map.on('mousemove', this._onMouseMove.bind(this));
-        map.on('click', this._onClick.bind(this));
+        this._onMouseMoveBound = this._onMouseMove.bind(this);
+        map.on('mousemove', this._onMouseMoveBound);
+
+        this._onClickBound = this._onMouseMove.bind(this);
+        map.on('click', this._onClickBound);
+
         this._disableWhileMovingMap(map);
+    }
+
+    _unsubscribeToMapEvents (map) {
+        map.off('mousemove', this._onMouseMoveBound);
+        map.off('click', this._onClickBound);
     }
 
     _disableWhileMovingMap (map) {
@@ -180,11 +189,30 @@ export default class Interactivity {
     _subscribeToLayerEvents (layers) {
         layers.forEach(layer => {
             layer.on('updated', this._onLayerUpdated.bind(this));
+            layer.on('removed', this._onLayerRemoved.bind(this));
         });
     }
 
     _onLayerUpdated () {
         this._onMouseMove(this._mouseEvent, true);
+    }
+
+    _onLayerRemoved (layer) {
+        this._removeLayerFromInteractivity(layer);
+
+        if (!this._layerList.length) {
+            this._unsubscribeToMapEvents();
+        }
+    }
+
+    _removeLayerFromInteractivity (layer) {
+        const layerIndex = this._layerList.indexOf(layer);
+
+        if (layerIndex === -1) {
+            return;
+        }
+
+        this._layerList.splice(layerIndex, 1);
     }
 
     _onMouseMove (event, emulated) {

--- a/test/integration/user/test/interactivity.test.js
+++ b/test/integration/user/test/interactivity.test.js
@@ -456,16 +456,19 @@ describe('Interactivity', () => {
 });
 
 describe('Interactivity with multiple layers', () => {
-    let map, source1, viz1, layer1, source2, viz2, layer2, interactivity;
+    let map, div, source1, viz1, layer1, source2, viz2, layer2, interactivity;
 
     beforeEach(() => {
         const setup = util.createMap('map');
         map = setup.map;
-
-        const layers = {};
+        div = setup.div;
 
         map.addLayer = layer => { layer.onAdd(map); };
-        map.removeLayer = layerId => { layers[layerId].onRemove(map); };
+        map.removeLayer = layerId => {
+            interactivity && interactivity._layerList
+                .find(layer => layer.id === layerId)
+                .onRemove(map);
+        };
 
         source1 = new carto.source.GeoJSON(feature1);
         viz1 = new carto.Viz(`
@@ -474,7 +477,6 @@ describe('Interactivity with multiple layers', () => {
         `);
         layer1 = new carto.Layer('layer1', source1, viz1);
         layer1.onAdd = map => { layer1.map = map; };
-        layers.layer1 = layer1;
 
         source2 = new carto.source.GeoJSON(feature2);
         viz2 = new carto.Viz(`
@@ -482,7 +484,6 @@ describe('Interactivity with multiple layers', () => {
         `);
         layer2 = new carto.Layer('layer2', source2, viz2);
         layer2.onAdd = map => { layer2.map = map; };
-        layers.layer2 = layer2;
 
         layer1.addTo(map);
         layer2.addTo(map);
@@ -541,6 +542,11 @@ describe('Interactivity with multiple layers', () => {
                     });
             });
         });
+    });
+
+    afterEach(() => {
+        map.remove();
+        document.body.removeChild(div);
     });
 });
 

--- a/test/integration/user/test/interactivity.test.js
+++ b/test/integration/user/test/interactivity.test.js
@@ -455,6 +455,95 @@ describe('Interactivity', () => {
     });
 });
 
+describe('Interactivity with multiple layers', () => {
+    let map, source1, viz1, layer1, source2, viz2, layer2, interactivity;
+
+    beforeEach(() => {
+        const setup = util.createMap('map');
+        map = setup.map;
+
+        const layers = {};
+
+        map.addLayer = layer => { layer.onAdd(map); };
+        map.removeLayer = layerId => { layers[layerId].onRemove(map); };
+
+        source1 = new carto.source.GeoJSON(feature1);
+        viz1 = new carto.Viz(`
+            color: red
+            @wadus: 123
+        `);
+        layer1 = new carto.Layer('layer1', source1, viz1);
+        layer1.onAdd = map => { layer1.map = map; };
+        layers.layer1 = layer1;
+
+        source2 = new carto.source.GeoJSON(feature2);
+        viz2 = new carto.Viz(`
+            color: opacity(green, 0.7)
+        `);
+        layer2 = new carto.Layer('layer2', source2, viz2);
+        layer2.onAdd = map => { layer2.map = map; };
+        layers.layer2 = layer2;
+
+        layer1.addTo(map);
+        layer2.addTo(map);
+
+        interactivity = new carto.Interactivity([layer1, layer2]);
+    });
+
+    describe('when a layer is removed', () => {
+        it('should be removed from layer list', done => {
+            const waitForLayersInitialization = Promise.all([
+                layer1._context,
+                layer2._context
+            ]);
+
+            layer1._contextInitialize();
+            layer2._contextInitialize();
+
+            waitForLayersInitialization
+                .then(() => {
+                    const layerListLength = interactivity._layerList.length;
+
+                    layer1.remove();
+
+                    expect(interactivity._layerList.length).toBe(layerListLength - 1);
+                    expect(interactivity._layerList.indexOf(layer1)).toBe(-1);
+                    done();
+                });
+        });
+
+        describe('and it is the last layer with interactivity', () => {
+            it('should unsubscribe from map events', done => {
+                const waitForLayersInitialization = Promise.all([
+                    layer1._context,
+                    layer2._context
+                ]);
+
+                spyOn(interactivity, '_unsubscribeToMapEvents').and.callThrough();
+                spyOn(map, 'off');
+
+                layer1._contextInitialize();
+                layer2._contextInitialize();
+
+                waitForLayersInitialization
+                    .then(() => {
+                        layer1.remove();
+                        layer2.remove();
+
+                        expect(interactivity._layerList.length).toBe(0);
+                        expect(interactivity._unsubscribeToMapEvents).toHaveBeenCalledWith(map);
+
+                        expect(map.off).toHaveBeenCalledTimes(2);
+                        expect(map.off).toHaveBeenCalledWith('mousemove', interactivity._onMouseMoveBound);
+                        expect(map.off).toHaveBeenCalledWith('click', interactivity._onClickBound);
+
+                        done();
+                    });
+            });
+        });
+    });
+});
+
 describe('Cursor', () => {
     let map, source1, viz1, layer1, setup;
 

--- a/test/unit/layer.test.js
+++ b/test/unit/layer.test.js
@@ -167,6 +167,25 @@ describe('api/layer', () => {
             layer.remove();
             expect(mapMock.removeLayer).toHaveBeenCalledWith(layer.id);
         });
+
+        it('should fire removed event', () => {
+            const layer = new Layer('layer1', source, viz);
+            layer.onAdd = map => { layer.map = map; };
+
+            const mapMock = {
+                addLayer: layer => { layer.onAdd(mapMock); },
+                removeLayer: () => { layer.onRemove(mapMock); },
+                once: () => { }
+            };
+            layer.addTo(mapMock);
+
+            const removedSpy = jasmine.createSpy();
+            layer.on('removed', removedSpy);
+
+            layer.remove();
+
+            expect(removedSpy).toHaveBeenCalledWith(layer);
+        });
     });
 
     describe('.getFeaturesAtPosition', () => {


### PR DESCRIPTION
This PR solves a bug caused by interactivity with multiple layers whenever any of those layers is removed.

The bug is present whenever a layer with features is removed from the map and you move the mouse over any of the features that were previously there.

Interactivity calculates diff points using the layers within its layers' list, and as the layer removed is not actually removed from interactivity, it still gets points from that removed layer.

![featureghost](https://user-images.githubusercontent.com/4319728/58091994-4b18ba00-7bcb-11e9-9e62-e97029461269.gif)

So this PR:
- Fires `removed` event for layer objects whenever they're removed.
- Listens to that event in Interactivity and removes layer from Interactivity layers' list.
- If layers in interactivity are empty, removes listeners for `mousemove` and `click` in map instance.
