### PR TITLE
Add full screen control to all examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+### Changed
+
+- Add fullscreen control to all public examples
+
 ## [1.2.5] - 2019-04-25
 
 ### Changed

--- a/examples/advanced/classification-variables.html
+++ b/examples/advanced/classification-variables.html
@@ -216,6 +216,7 @@
 
     const nav = new mapboxgl.NavigationControl();
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/advanced/hurricane-harvey.html
+++ b/examples/advanced/hurricane-harvey.html
@@ -46,6 +46,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     // Define user
     carto.setDefaultAuth({

--- a/examples/advanced/ocean-bathymetry.html
+++ b/examples/advanced/ocean-bathymetry.html
@@ -42,6 +42,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     // Define user
     carto.setDefaultAuth({

--- a/examples/advanced/taxi-pickups.html
+++ b/examples/advanced/taxi-pickups.html
@@ -42,6 +42,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     // Define user
     carto.setDefaultAuth({

--- a/examples/advanced/us-population-by-county.html
+++ b/examples/advanced/us-population-by-county.html
@@ -42,6 +42,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     // Define user
     carto.setDefaultAuth({

--- a/examples/animation/add-feature-visibility.html
+++ b/examples/animation/add-feature-visibility.html
@@ -44,6 +44,7 @@
             showCompass: false
         });
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/animation/animate-and-hold.html
+++ b/examples/animation/animate-and-hold.html
@@ -46,6 +46,7 @@
 			showCompass: false
 		});
 		map.addControl(nav, 'top-left');
+		map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
 		carto.setDefaultAuth({
 			username: 'cartovl',

--- a/examples/animation/animate-by-date-range.html
+++ b/examples/animation/animate-by-date-range.html
@@ -44,6 +44,7 @@
             showCompass: false
         });
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/animation/animate-color-by-date.html
+++ b/examples/animation/animate-color-by-date.html
@@ -44,6 +44,7 @@
 			showCompass: false
 		});
 		map.addControl(nav, 'top-left');
+		map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
 		carto.setDefaultAuth({
 			username: 'cartovl',

--- a/examples/animation/animate-filtered-features.html
+++ b/examples/animation/animate-filtered-features.html
@@ -45,6 +45,7 @@
             showCompass: false
         });
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/animation/animate-width.html
+++ b/examples/animation/animate-width.html
@@ -44,6 +44,7 @@
             showCompass: false
         });
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/animation/animation-controls.html
+++ b/examples/animation/animation-controls.html
@@ -231,6 +231,7 @@
 
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/basemap/basemap-labels-on-top.html
+++ b/examples/basemap/basemap-labels-on-top.html
@@ -44,6 +44,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/basemap/basemap-labels-under.html
+++ b/examples/basemap/basemap-labels-under.html
@@ -44,6 +44,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/basemap/color-map-background.html
+++ b/examples/basemap/color-map-background.html
@@ -56,6 +56,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/basemap/pitch-bearing.html
+++ b/examples/basemap/pitch-bearing.html
@@ -48,6 +48,7 @@
       showCompass: true
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/basemap/project-layer.html
+++ b/examples/basemap/project-layer.html
@@ -56,6 +56,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/basics/add-layer.html
+++ b/examples/basics/add-layer.html
@@ -44,6 +44,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     // Define user
     carto.setDefaultAuth({

--- a/examples/basics/basic-style.html
+++ b/examples/basics/basic-style.html
@@ -42,6 +42,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     // Define user
     carto.setDefaultAuth({

--- a/examples/basics/browser-support.html
+++ b/examples/basics/browser-support.html
@@ -52,6 +52,8 @@
         scrollZoom: false
       });
 
+      map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
+
       carto.setDefaultAuth({
         username: 'cartovl',
         apiKey: 'default_public'

--- a/examples/guides/add-data-sources/step-1.html
+++ b/examples/guides/add-data-sources/step-1.html
@@ -24,6 +24,7 @@
 
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
 
         //** CARTO VL functionality begins here **//

--- a/examples/guides/add-data-sources/step-2.html
+++ b/examples/guides/add-data-sources/step-2.html
@@ -24,6 +24,7 @@
 
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
 
         //** CARTO VL functionality begins here **//

--- a/examples/guides/add-data-sources/step-3.html
+++ b/examples/guides/add-data-sources/step-3.html
@@ -24,6 +24,7 @@
 
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
 
         //** CARTO VL functionality begins here **//

--- a/examples/guides/add-interactivity/step-1.html
+++ b/examples/guides/add-interactivity/step-1.html
@@ -25,6 +25,7 @@
         // Add zoom controls
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
 
         // MAP EVENTS

--- a/examples/guides/add-interactivity/step-2.html
+++ b/examples/guides/add-interactivity/step-2.html
@@ -25,6 +25,7 @@
         // Add zoom controls
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
 
         // MAP EVENTS

--- a/examples/guides/add-interactivity/step-3.html
+++ b/examples/guides/add-interactivity/step-3.html
@@ -25,6 +25,7 @@
         // Add zoom controls
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
 
         // MAP EVENTS

--- a/examples/guides/add-legends/step-1.html
+++ b/examples/guides/add-legends/step-1.html
@@ -31,6 +31,7 @@
             center: [-96, 41],
             zoom: 3
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/add-legends/step-2.html
+++ b/examples/guides/add-legends/step-2.html
@@ -37,6 +37,7 @@
             center: [-96, 41],
             zoom: 3
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         //** CARTO VL functionality begins here **//
 

--- a/examples/guides/add-legends/step-3.html
+++ b/examples/guides/add-legends/step-3.html
@@ -37,6 +37,7 @@
             center: [-96, 41],
             zoom: 3
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/add-legends/step-4.html
+++ b/examples/guides/add-legends/step-4.html
@@ -37,6 +37,7 @@
             center: [-96, 41],
             zoom: 3
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/add-legends/step-5.html
+++ b/examples/guides/add-legends/step-5.html
@@ -37,6 +37,7 @@
             center: [-96, 41],
             zoom: 3
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/add-legends/step-6.html
+++ b/examples/guides/add-legends/step-6.html
@@ -41,6 +41,7 @@
       center: [-122.424335, 37.771521],
       zoom: 12
     });
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/guides/add-legends/step-7.html
+++ b/examples/guides/add-legends/step-7.html
@@ -41,6 +41,7 @@
       center: [-122.424335, 37.771521],
       zoom: 12
     });
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     const nav = new mapboxgl.NavigationControl({
       showCompass: false

--- a/examples/guides/add-legends/step-8.html
+++ b/examples/guides/add-legends/step-8.html
@@ -40,6 +40,7 @@
       center: [-73.954323, 40.711743],
       zoom: 15.7
     });
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/guides/add-legends/step-9.html
+++ b/examples/guides/add-legends/step-9.html
@@ -44,6 +44,7 @@
       center: [0, 43],
       zoom: 1
     });
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     const nav = new mapboxgl.NavigationControl({
       showCompass: false

--- a/examples/guides/add-widgets/step-1.html
+++ b/examples/guides/add-widgets/step-1.html
@@ -50,6 +50,7 @@
             center: [-96, 41],
             zoom: 3.5,
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/add-widgets/step-2.html
+++ b/examples/guides/add-widgets/step-2.html
@@ -41,6 +41,7 @@
             center: [-96, 41],
             zoom: 3.5,
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/add-widgets/step-3.html
+++ b/examples/guides/add-widgets/step-3.html
@@ -41,6 +41,7 @@
             center: [-96, 41],
             zoom: 3.5,
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/aggregation-and-data-summaries/step-1.html
+++ b/examples/guides/aggregation-and-data-summaries/step-1.html
@@ -21,6 +21,7 @@
         });
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/aggregation-and-data-summaries/step-2.html
+++ b/examples/guides/aggregation-and-data-summaries/step-2.html
@@ -36,6 +36,7 @@
         });
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/aggregation-and-data-summaries/step-3.html
+++ b/examples/guides/aggregation-and-data-summaries/step-3.html
@@ -36,6 +36,7 @@
         });
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/animated-viz/step-0.html
+++ b/examples/guides/animated-viz/step-0.html
@@ -34,6 +34,7 @@
 
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         //** CARTO VL functionality begins here **//
 

--- a/examples/guides/animated-viz/step-1.html
+++ b/examples/guides/animated-viz/step-1.html
@@ -23,6 +23,7 @@
 
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         //** CARTO VL functionality begins here **//
 

--- a/examples/guides/animated-viz/step-2.html
+++ b/examples/guides/animated-viz/step-2.html
@@ -23,6 +23,7 @@
 
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         //** CARTO VL functionality begins here **//
 

--- a/examples/guides/animated-viz/step-3.html
+++ b/examples/guides/animated-viz/step-3.html
@@ -23,6 +23,7 @@
 
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         //** CARTO VL functionality begins here **//
 

--- a/examples/guides/animated-viz/step-4.html
+++ b/examples/guides/animated-viz/step-4.html
@@ -23,6 +23,7 @@
 
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         //** CARTO VL functionality begins here **//
 

--- a/examples/guides/animated-viz/step-5.html
+++ b/examples/guides/animated-viz/step-5.html
@@ -193,6 +193,7 @@
 
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         //** CARTO VL functionality begins here **//
 

--- a/examples/guides/animated-viz/step-6.html
+++ b/examples/guides/animated-viz/step-6.html
@@ -24,6 +24,7 @@
 
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         //** CARTO VL functionality begins here **//
 

--- a/examples/guides/animated-viz/step-7.html
+++ b/examples/guides/animated-viz/step-7.html
@@ -227,6 +227,7 @@
 
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         //** CARTO VL functionality begins here **//
 

--- a/examples/guides/build-custom-charts/step-1.html
+++ b/examples/guides/build-custom-charts/step-1.html
@@ -46,6 +46,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/guides/build-custom-charts/step-2.html
+++ b/examples/guides/build-custom-charts/step-2.html
@@ -46,6 +46,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/guides/build-custom-charts/step-3.html
+++ b/examples/guides/build-custom-charts/step-3.html
@@ -46,6 +46,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/guides/build-custom-charts/step-4.html
+++ b/examples/guides/build-custom-charts/step-4.html
@@ -46,6 +46,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/guides/build-custom-charts/step-5.html
+++ b/examples/guides/build-custom-charts/step-5.html
@@ -46,6 +46,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/guides/build-custom-charts/step-6.html
+++ b/examples/guides/build-custom-charts/step-6.html
@@ -46,6 +46,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/guides/data-driven-viz-1/step-1.html
+++ b/examples/guides/data-driven-viz-1/step-1.html
@@ -33,6 +33,7 @@
             center: [60, 19],
             zoom: 2,
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/data-driven-viz-1/step-2.html
+++ b/examples/guides/data-driven-viz-1/step-2.html
@@ -57,6 +57,7 @@
             center: [60, 19],
             zoom: 2,
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/data-driven-viz-1/step-3.html
+++ b/examples/guides/data-driven-viz-1/step-3.html
@@ -58,6 +58,7 @@
             center: [60, 19],
             zoom: 2,
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/data-driven-viz-1/step-4.html
+++ b/examples/guides/data-driven-viz-1/step-4.html
@@ -66,6 +66,7 @@
             center: [60, 19],
             zoom: 2,
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/data-driven-viz-1/step-5.html
+++ b/examples/guides/data-driven-viz-1/step-5.html
@@ -48,6 +48,7 @@
             center: [60, 19],
             zoom: 2,
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/data-driven-viz-1/step-6.html
+++ b/examples/guides/data-driven-viz-1/step-6.html
@@ -24,6 +24,7 @@
             center: [-0.815850, 52.087124],
             zoom: 6,
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/data-driven-viz-1/step-7.html
+++ b/examples/guides/data-driven-viz-1/step-7.html
@@ -24,6 +24,7 @@
             center: [-0.815850, 52.087124],
             zoom: 6,
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/data-driven-viz-1/step-8.html
+++ b/examples/guides/data-driven-viz-1/step-8.html
@@ -44,6 +44,7 @@
             center: [-96, 41],
             zoom: 2.75,
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/data-driven-viz-1/step-9.html
+++ b/examples/guides/data-driven-viz-1/step-9.html
@@ -44,6 +44,7 @@
             center: [-96, 41],
             zoom: 2.75,
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/data-driven-viz-2/step-1.html
+++ b/examples/guides/data-driven-viz-2/step-1.html
@@ -66,6 +66,7 @@
             center: [60, 19],
             zoom: 2,
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/data-driven-viz-2/step-2.html
+++ b/examples/guides/data-driven-viz-2/step-2.html
@@ -75,6 +75,7 @@
             center: [-96, 41],
             zoom: 3.5,
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/guides/data-driven-viz-2/step-3.html
+++ b/examples/guides/data-driven-viz-2/step-3.html
@@ -41,6 +41,7 @@
       center: [-73.954323, 40.711743],
       zoom: 15.7
     });
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/guides/data-driven-viz-2/step-4.html
+++ b/examples/guides/data-driven-viz-2/step-4.html
@@ -41,6 +41,7 @@
       center: [-73.954323, 40.711743],
       zoom: 15.7
     });
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/guides/getting-started/step-1.html
+++ b/examples/guides/getting-started/step-1.html
@@ -21,6 +21,7 @@
             center: [0, 30],
             zoom: 2
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
     </script>
 </body>
 

--- a/examples/guides/getting-started/step-2.html
+++ b/examples/guides/getting-started/step-2.html
@@ -21,6 +21,7 @@
             center: [0, 30],
             zoom: 2
         });
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         //** CARTO VL functionality begins here **//
 

--- a/examples/guides/style-with-expressions/step-1.html
+++ b/examples/guides/style-with-expressions/step-1.html
@@ -57,6 +57,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     //** CARTO VL functionality begins here **//
 

--- a/examples/guides/style-with-expressions/step-2.html
+++ b/examples/guides/style-with-expressions/step-2.html
@@ -76,6 +76,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/guides/style-with-expressions/step-3.html
+++ b/examples/guides/style-with-expressions/step-3.html
@@ -49,6 +49,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     //** CARTO VL functionality begins here **//
 

--- a/examples/guides/zoom-based-styles/step-1.html
+++ b/examples/guides/zoom-based-styles/step-1.html
@@ -36,6 +36,7 @@
         });
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         function updateZoom() {
             const zoom = map.getZoom().toFixed(2);

--- a/examples/guides/zoom-based-styles/step-2.html
+++ b/examples/guides/zoom-based-styles/step-2.html
@@ -36,6 +36,7 @@
         });
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         function updateZoom() {
             const zoom = map.getZoom().toFixed(2);

--- a/examples/guides/zoom-based-styles/step-3.html
+++ b/examples/guides/zoom-based-styles/step-3.html
@@ -36,6 +36,7 @@
         });
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         function updateZoom() {
             const zoom = map.getZoom().toFixed(2);

--- a/examples/guides/zoom-based-styles/step-4.html
+++ b/examples/guides/zoom-based-styles/step-4.html
@@ -36,6 +36,7 @@
         });
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         function updateZoom() {
             const zoom = map.getZoom().toFixed(2);

--- a/examples/guides/zoom-based-styles/step-5.html
+++ b/examples/guides/zoom-based-styles/step-5.html
@@ -36,6 +36,7 @@
         });
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         function updateZoom() {
             const zoom = map.getZoom().toFixed(2);

--- a/examples/guides/zoom-based-styles/step-6.html
+++ b/examples/guides/zoom-based-styles/step-6.html
@@ -36,6 +36,7 @@
         });
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         function updateZoom() {
             const zoom = map.getZoom().toFixed(2);

--- a/examples/guides/zoom-based-styles/step-7.html
+++ b/examples/guides/zoom-based-styles/step-7.html
@@ -36,6 +36,7 @@
         });
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         function updateZoom() {
             const zoom = map.getZoom().toFixed(2);

--- a/examples/guides/zoom-based-styles/step-8.html
+++ b/examples/guides/zoom-based-styles/step-8.html
@@ -36,6 +36,7 @@
         });
         const nav = new mapboxgl.NavigationControl();
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         function updateZoom() {
             const zoom = map.getZoom().toFixed(2);

--- a/examples/interactivity/click.html
+++ b/examples/interactivity/click.html
@@ -45,6 +45,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     // Define user
     carto.setDefaultAuth({

--- a/examples/interactivity/hover.html
+++ b/examples/interactivity/hover.html
@@ -46,6 +46,7 @@
 
     const nav = new mapboxgl.NavigationControl();
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     // Log some basic map events
     const events = ['mousedown', 'click', 'mousemove', 'mouseup', 'dragstart', 'dragend', 'movestart', 'moveend'];

--- a/examples/interactivity/interact-multiple-layers.html
+++ b/examples/interactivity/interact-multiple-layers.html
@@ -50,6 +50,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     // Define user
     carto.setDefaultAuth({

--- a/examples/interactivity/interactive-based-styling.html
+++ b/examples/interactivity/interactive-based-styling.html
@@ -47,6 +47,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     // Define user
     carto.setDefaultAuth({

--- a/examples/interactivity/interactive-filter.html
+++ b/examples/interactivity/interactive-filter.html
@@ -59,6 +59,7 @@
         });
 
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/interactivity/pop-up-on-click.html
+++ b/examples/interactivity/pop-up-on-click.html
@@ -44,6 +44,7 @@
             showCompass: false
         });
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         // Define pop-up
         const popup = new mapboxgl.Popup({

--- a/examples/interactivity/pop-up-on-hover.html
+++ b/examples/interactivity/pop-up-on-hover.html
@@ -44,6 +44,7 @@
             showCompass: false
         });
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         // Define pop-up
         const popup = new mapboxgl.Popup({

--- a/examples/labeling/cluster-labels-average.html
+++ b/examples/labeling/cluster-labels-average.html
@@ -37,6 +37,7 @@
             showCompass: false
         });
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultConfig({
             serverURL: 'https://{user}.carto.com'

--- a/examples/labeling/cluster-labels-count.html
+++ b/examples/labeling/cluster-labels-count.html
@@ -37,6 +37,7 @@
             showCompass: false
         });
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
 
         carto.setDefaultConfig({

--- a/examples/labeling/point-labels-conditional-style.html
+++ b/examples/labeling/point-labels-conditional-style.html
@@ -38,6 +38,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       user: 'cartovl',

--- a/examples/labeling/point-labels-size-zoom.html
+++ b/examples/labeling/point-labels-size-zoom.html
@@ -38,6 +38,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       user: 'cartovl',

--- a/examples/labeling/point-labels.html
+++ b/examples/labeling/point-labels.html
@@ -38,6 +38,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       user: 'cartovl',

--- a/examples/labeling/polygon-labels.html
+++ b/examples/labeling/polygon-labels.html
@@ -38,6 +38,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       user: 'cartovl',

--- a/examples/legends/category-line-legend.html
+++ b/examples/legends/category-line-legend.html
@@ -46,6 +46,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/legends/category-point-legend.html
+++ b/examples/legends/category-point-legend.html
@@ -39,6 +39,7 @@
             showCompass: false
         });
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/legends/choropleth-legend.html
+++ b/examples/legends/choropleth-legend.html
@@ -47,6 +47,7 @@
             showCompass: false
         });
       map.addControl(nav, 'top-left');
+      map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
       carto.setDefaultAuth({
         username: 'cartovl',

--- a/examples/legends/feature-and-legend-opacity.html
+++ b/examples/legends/feature-and-legend-opacity.html
@@ -39,6 +39,7 @@
             showCompass: false
         });
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/legends/image-legend.html
+++ b/examples/legends/image-legend.html
@@ -46,6 +46,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/legends/unclassed-point-legend.html
+++ b/examples/legends/unclassed-point-legend.html
@@ -46,6 +46,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/sources/external-geojson.html
+++ b/examples/sources/external-geojson.html
@@ -42,6 +42,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     fetch('https://libs.cartocdn.com/carto-vl/assets/stations.geojson')
       .then(response => response.json())

--- a/examples/sources/geojson-source-layer.html
+++ b/examples/sources/geojson-source-layer.html
@@ -44,6 +44,7 @@
             showCompass: false
         });
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         const geojson = {
             "type": "FeatureCollection",

--- a/examples/sources/multiple-layers.html
+++ b/examples/sources/multiple-layers.html
@@ -42,6 +42,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     // Define user
     carto.setDefaultAuth({

--- a/examples/sources/select-layer.html
+++ b/examples/sources/select-layer.html
@@ -61,6 +61,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     // Define user
     carto.setDefaultAuth({

--- a/examples/sources/sql-source-layer.html
+++ b/examples/sources/sql-source-layer.html
@@ -44,6 +44,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/styling/color-schemes.html
+++ b/examples/styling/color-schemes.html
@@ -68,6 +68,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/styling/color-spaces.html
+++ b/examples/styling/color-spaces.html
@@ -72,6 +72,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/styling/draw-order.html
+++ b/examples/styling/draw-order.html
@@ -60,6 +60,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/styling/filter.html
+++ b/examples/styling/filter.html
@@ -44,6 +44,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/styling/image-external.html
+++ b/examples/styling/image-external.html
@@ -44,6 +44,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/styling/image-multiple.html
+++ b/examples/styling/image-multiple.html
@@ -44,6 +44,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/styling/image-single.html
+++ b/examples/styling/image-single.html
@@ -44,6 +44,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/styling/scaled.html
+++ b/examples/styling/scaled.html
@@ -44,6 +44,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/styling/style-by-category.html
+++ b/examples/styling/style-by-category.html
@@ -60,6 +60,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/styling/style-by-number.html
+++ b/examples/styling/style-by-number.html
@@ -68,6 +68,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/styling/style-with-variables.html
+++ b/examples/styling/style-with-variables.html
@@ -43,6 +43,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/styling/viewport.html
+++ b/examples/styling/viewport.html
@@ -44,6 +44,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/styling/zoom-range-filter.html
+++ b/examples/styling/zoom-range-filter.html
@@ -44,6 +44,7 @@
             showCompass: false
         });
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/styling/zoom-range-style.html
+++ b/examples/styling/zoom-range-style.html
@@ -44,6 +44,7 @@
             showCompass: false
         });
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/widgets/category-chart.html
+++ b/examples/widgets/category-chart.html
@@ -46,6 +46,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/widgets/category-widget-viewport.html
+++ b/examples/widgets/category-widget-viewport.html
@@ -48,6 +48,7 @@
             showCompass: false
         });
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/widgets/histogram-widget-viewport.html
+++ b/examples/widgets/histogram-widget-viewport.html
@@ -48,6 +48,7 @@
             showCompass: false
         });
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/widgets/numeric-chart.html
+++ b/examples/widgets/numeric-chart.html
@@ -46,6 +46,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       username: 'cartovl',

--- a/examples/widgets/viewport-summary.html
+++ b/examples/widgets/viewport-summary.html
@@ -53,6 +53,7 @@
             showCompass: false
         });
         map.addControl(nav, 'top-left');
+        map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
         carto.setDefaultAuth({
             username: 'cartovl',

--- a/examples/widgets/weighted-histogram-table.html
+++ b/examples/widgets/weighted-histogram-table.html
@@ -62,6 +62,7 @@
       showCompass: false
     });
     map.addControl(nav, 'top-left');
+    map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
 
     carto.setDefaultAuth({
       user: 'cartovl',


### PR DESCRIPTION
Fix https://github.com/CartoDB/developers/issues/585

Add mapbox's full screen control to all public examples.

We'll need to release a new version to update the dev center, so we should decide whether it's worth it just for this or if we wait until there's more fixes on the way.