### PR TITLE
Change getLegendData opacity method and colors

### DIFF
--- a/src/renderer/viz/expressions/Image.js
+++ b/src/renderer/viz/expressions/Image.js
@@ -65,6 +65,16 @@ export default class Image extends Base {
         return this.value;
     }
 
+    getLegendData (options) {
+        return {
+            name: 'image',
+            data: [{
+                key: 'url',
+                value: this.url
+            }]
+        };
+    }
+
     _free (gl) {
         if (this.texture) {
             gl.deleteTexture(this.texture);

--- a/src/renderer/viz/expressions/color/CIELab.js
+++ b/src/renderer/viz/expressions/color/CIELab.js
@@ -1,6 +1,7 @@
 import BaseExpression from '../base';
 import { implicitCast, checkType, checkExpression, checkMaxArguments } from '../utils';
 import CIELabGLSL from './CIELab.glsl';
+import { cielabToSRGB } from '../../colorspaces';
 
 /**
  * Evaluates to a CIELab color.
@@ -47,19 +48,24 @@ export default class CIELab extends BaseExpression {
     }
 
     get value () {
-        return {
-            l: this.l.value,
-            a: this.a.value,
-            b: this.b.value
-        };
+        return this.eval(null);
     }
 
     eval (feature) {
-        return {
+        return cielabToSRGB({
             l: this.l.eval(feature),
             a: this.a.eval(feature),
             b: this.b.eval(feature)
-        };
+        });
+    }
+
+    getLegendData () {
+        const name = 'color';
+        const value = this.value;
+        const key = `rgba(${value.r}, ${value.g}, ${value.b}, ${value.a})`;
+        const data = [{ key, value }];
+
+        return { name, data };
     }
 
     _bindMetadata (meta) {

--- a/src/renderer/viz/expressions/color/NamedColor.js
+++ b/src/renderer/viz/expressions/color/NamedColor.js
@@ -52,6 +52,15 @@ export default class NamedColor extends BaseExpression {
     toString () {
         return this.expressionName;
     }
+
+    getLegendData () {
+        const name = 'color';
+        const value = this.color;
+        const key = `rgba(${value.r}, ${value.g}, ${value.b}, ${value.a})`;
+        const data = [{ key, value }];
+
+        return { name, data };
+    }
 }
 
 const nameToRGBACache = {};

--- a/src/renderer/viz/expressions/color/Opacity.js
+++ b/src/renderer/viz/expressions/color/Opacity.js
@@ -56,7 +56,6 @@ export default class Opacity extends BaseExpression {
     getLegendData (options) {
         const legend = this.input.getLegendData(options);
         const alpha = this.alpha.value;
-        const name = legend.name;
 
         if (this.input.type === 'color') {
             const data = legend.data.map(({ key, value }) => {
@@ -69,10 +68,10 @@ export default class Opacity extends BaseExpression {
                 };
             });
 
-            return { name, data };
+            return { ...legend, data };
         } else {
             const data = legend.data;
-            return { name, data, alpha };
+            return { ...legend, data, alpha };
         }
     }
 

--- a/src/renderer/viz/expressions/color/Opacity.js
+++ b/src/renderer/viz/expressions/color/Opacity.js
@@ -53,6 +53,29 @@ export default class Opacity extends BaseExpression {
         return input;
     }
 
+    getLegendData (options) {
+        const legend = this.input.getLegendData(options);
+        const alpha = this.alpha.value;
+        const name = legend.name;
+
+        if (this.input.type === 'color') {
+            const data = legend.data.map(({ key, value }) => {
+                const { r, g, b } = value;
+                const a = alpha;
+
+                return {
+                    key: `rgba(${r}, ${g}, ${b}, ${a})`,
+                    value: { r, g, b, a }
+                };
+            });
+
+            return { name, data };
+        } else {
+            const data = legend.data;
+            return { name, data, alpha };
+        }
+    }
+
     _bindMetadata (meta) {
         super._bindMetadata(meta);
         checkType('opacity', 'input', 0, ['color', 'image'], this.input);

--- a/src/renderer/viz/expressions/color/hex.js
+++ b/src/renderer/viz/expressions/color/hex.js
@@ -55,4 +55,13 @@ export default class Hex extends BaseExpression {
     eval () {
         return this.value;
     }
+
+    getLegendData () {
+        const name = 'color';
+        const value = this.value;
+        const key = `rgba(${value.r}, ${value.g}, ${value.b}, ${value.a})`;
+        const data = [{ key, value }];
+
+        return { name, data };
+    }
 }

--- a/src/renderer/viz/expressions/color/hsl.js
+++ b/src/renderer/viz/expressions/color/hsl.js
@@ -93,6 +93,14 @@ function genHSL (name, alpha = null) {
             return hslToRgb(h, s, l, a, alpha, feature);
         }
 
+        getLegendData () {
+            const name = 'color';
+            const value = this.value;
+            const key = `rgba(${value.r}, ${value.g}, ${value.b}, ${value.a})`;
+            const data = [{ key, value }];
+
+            return { name, data };
+        }
         _bindMetadata (meta) {
             super._bindMetadata(meta);
             hslCheckType('h', 0, this.h);

--- a/src/renderer/viz/expressions/color/hsv.js
+++ b/src/renderer/viz/expressions/color/hsv.js
@@ -83,7 +83,7 @@ function genHSV (name, alpha) {
         }
 
         get value () {
-            return this.eval();
+            return this.eval(null);
         }
 
         eval (feature) {
@@ -117,6 +117,15 @@ function genHSV (name, alpha) {
             };
 
             return hsvToRgb(h, s, v);
+        }
+
+        getLegendData () {
+            const name = 'color';
+            const value = this.value;
+            const key = `rgba(${value.r}, ${value.g}, ${value.b}, ${value.a})`;
+            const data = [{ key, value }];
+
+            return { name, data };
         }
 
         _bindMetadata (metadata) {

--- a/src/renderer/viz/expressions/color/rgb.js
+++ b/src/renderer/viz/expressions/color/rgb.js
@@ -85,13 +85,17 @@ function genRGB (name, alpha) {
             };
         }
 
-        eval (feature) {
-            return {
-                r: this.r.eval(feature),
-                g: this.g.eval(feature),
-                b: this.b.eval(feature),
-                a: alpha ? this.a.eval(feature) : 1
-            };
+        eval () {
+            return this.value;
+        }
+
+        getLegendData () {
+            const name = 'color';
+            const value = this.value;
+            const key = `rgba(${value.r}, ${value.g}, ${value.b}, ${value.a})`;
+            const data = [{ key, value }];
+
+            return { name, data };
         }
 
         _bindMetadata (meta) {

--- a/test/unit/renderer/viz/expressions/color/Opacity.test.js
+++ b/test/unit/renderer/viz/expressions/color/Opacity.test.js
@@ -1,10 +1,11 @@
 import { validateMaxArgumentsError, validateTypeErrors, validateDynamicType } from '../utils';
-import { opacity, rgba, mul, variable, rgb } from '../../../../../../src/renderer/viz/expressions';
+import { opacity, rgba, mul, variable, rgb, hsl, hsv, cielab, namedColor, hex } from '../../../../../../src/renderer/viz/expressions';
 
 describe('src/renderer/viz/expressions/opacity', () => {
     describe('error control', () => {
         validateTypeErrors('opacity', []);
         validateTypeErrors('opacity', ['number']);
+        validateTypeErrors('opacity', ['image']);
         validateTypeErrors('opacity', ['number', 'number']);
         validateTypeErrors('opacity', ['color', 'category']);
         validateMaxArgumentsError('opacity', ['red', 'number', 'number']);
@@ -12,7 +13,6 @@ describe('src/renderer/viz/expressions/opacity', () => {
 
     describe('type', () => {
         validateDynamicType('opacity', ['color', 'number'], 'color');
-        validateDynamicType('opacity', ['image', 'number'], 'image');
     });
 
     describe('.value', () => {
@@ -24,6 +24,116 @@ describe('src/renderer/viz/expressions/opacity', () => {
     describe('.eval', () => {
         it('should override the alpha channel', () => {
             expect(opacity(rgba(255, 255, 255, 0.5), 0.7).eval()).toEqual({ r: 255, g: 255, b: 255, a: 0.7 });
+        });
+    });
+
+    describe('.getLegendData', () => {
+        it('should override the alpha channel when using a named color', () => {
+            const actual = opacity(namedColor('blue'), 0.5).getLegendData();
+            const expected = {
+                name: 'color',
+                data: [{
+                    key: 'rgba(0, 0, 255, 0.5)',
+                    value: {
+                        r: 0,
+                        g: 0,
+                        b: 255,
+                        a: 0.5
+                    }
+                }]
+            };
+
+            expect(actual).toEqual(expected);
+        });
+
+        it('should override the alpha channel when using a rgba color', () => {
+            const actual = opacity(rgba(255, 1, 255, 0.5), 0.5).getLegendData();
+            const expected = {
+                name: 'color',
+                data: [{
+                    key: 'rgba(255, 1, 255, 0.5)',
+                    value: {
+                        r: 255,
+                        g: 1,
+                        b: 255,
+                        a: 0.5
+                    }
+                }]
+            };
+
+            expect(actual).toEqual(expected);
+        });
+
+        it('should override the alpha channel when using a CIELab color', () => {
+            const actual = opacity(cielab(87.73, -86.18, 83.18), 0.5).getLegendData();
+            const expected = {
+                name: 'color',
+                data: [{
+                    key: 'rgba(0, 0.9999316244751483, 0, 0.5)',
+                    value: {
+                        r: 0,
+                        g: 0.9999316244751483,
+                        b: 0,
+                        a: 0.5
+                    }
+                }]
+            };
+
+            expect(actual).toEqual(expected);
+        });
+
+        it('should override the alpha channel when using a hsv color', () => {
+            const actual = opacity(hsv(0.66, 1, 1), 0.5).getLegendData();
+            const expected = {
+                name: 'color',
+                data: [{
+                    key: 'rgba(0, 10.20000000000001, 255, 0.5)',
+                    value: {
+                        r: 0,
+                        g: 10.20000000000001,
+                        b: 255,
+                        a: 0.5
+                    }
+                }]
+            };
+
+            expect(actual).toEqual(expected);
+        });
+
+        it('should override the alpha channel when using a hsl color', () => {
+            const actual = opacity(hsl(0.66, 1, 1), 0.5).getLegendData();
+            const expected = {
+                name: 'color',
+                data: [{
+                    key: 'rgba(255, 255, 255, 0.5)',
+                    value: {
+                        r: 255,
+                        g: 255,
+                        b: 255,
+                        a: 0.5
+                    }
+                }]
+            };
+
+            expect(actual).toEqual(expected);
+        });
+
+        it('should override the alpha channel when using a hex color', () => {
+            const actual = opacity(hex('#FABADA'), 0.5).getLegendData();
+            const expected = {
+                name: 'color',
+                data: [{
+                    key: 'rgba(250, 186, 218, 0.5)',
+                    value: {
+                        r: 250,
+                        g: 186,
+                        b: 218,
+                        a: 0.5
+                    }
+                }]
+            };
+
+            expect(actual).toEqual(expected);
         });
     });
 

--- a/test/unit/renderer/viz/expressions/color/Opacity.test.js
+++ b/test/unit/renderer/viz/expressions/color/Opacity.test.js
@@ -1,5 +1,6 @@
 import { validateMaxArgumentsError, validateTypeErrors, validateDynamicType } from '../utils';
-import { opacity, rgba, mul, variable, rgb, hsl, hsv, cielab, namedColor, hex } from '../../../../../../src/renderer/viz/expressions';
+import { opacity, rgba, mul, variable, rgb, hsl, hsv, cielab, namedColor, hex, property, ramp } from '../../../../../../src/renderer/viz/expressions';
+import Metadata from '../../../../../../src/renderer/Metadata';
 
 describe('src/renderer/viz/expressions/opacity', () => {
     describe('error control', () => {
@@ -128,6 +129,47 @@ describe('src/renderer/viz/expressions/opacity', () => {
                         r: 250,
                         g: 186,
                         b: 218,
+                        a: 0.5
+                    }
+                }]
+            };
+
+            expect(actual).toEqual(expected);
+        });
+
+        it('should override the alpha channel when using a color ramp', () => {
+            const METADATA = new Metadata({
+                properties: {
+                    grade: {
+                        type: 'category',
+                        categories: [
+                            { name: 'A' },
+                            { name: 'B' }
+                        ]
+                    }
+                }
+            });
+
+            const color = opacity(ramp(property('grade'), [namedColor('blue'), namedColor('red')]), 0.5);
+            color._bindMetadata(METADATA);
+            const actual = color.getLegendData();
+
+            const expected = {
+                type: 'category',
+                data: [{
+                    key: 'rgba(0, 0, 255, 0.5)',
+                    value: {
+                        r: 0,
+                        g: 0,
+                        b: 255,
+                        a: 0.5
+                    }
+                }, {
+                    key: 'rgba(255, 0, 0, 0.5)',
+                    value: {
+                        r: 255,
+                        g: 0,
+                        b: 0,
                         a: 0.5
                     }
                 }]


### PR DESCRIPTION
Related issue: https://github.com/CartoDB/carto-vl/issues/1353

This PR fixes the getLegendData method when used with color and nested expressions with a color output (as, for instance, ramps).

It can be tested locally by using this [editor](http://localhost:8080/examples/editor/#eyJhIjoic3BlbmRfZGF0YSIsImIiOiIiLCJjIjoiY2FydG92bCIsImQiOiJodHRwczovL3t1c2VyfS5jYXJ0by5jb20iLCJlIjoid2lkdGg6IDE1XG5zdHJva2VXaWR0aDogMFxuLy8gY29sb3I6IG9wYWNpdHkocmdiYSgyNTUsIDEsIDI1NSwgMC43KSwgMC41KVxuLy8gY29sb3I6IG9wYWNpdHkoY2llbGFiKDg3LjczLCAtODYuMTgsIDgzLjE4KSwgMC41KVxuLy8gY29sb3I6IG9wYWNpdHkoaHN2KDAuNjYsMSwxKSwgMC41KVxuLy8gY29sb3I6IG9wYWNpdHkoaHNsKDAuNjYsMSwxKSwgMC41KVxuLy8gY29sb3I6IG9wYWNpdHkoYmx1ZSwgMC41KVxuLy8gY29sb3I6IG9wYWNpdHkoaGV4KCcjRkFCQURBJyksIDAuNSlcbi8vIGNvbG9yOiBvcGFjaXR5KHJhbXAoJGNhdGVnb3J5LCBbYmx1ZSwgcmVkXSksIDAuNSkiLCJmIjp7ImxuZyI6Mi4xNzM5NjQ0Nzc1NTg0NTY2LCJsYXQiOjQxLjYwMzMwNDI0NDg4OTQxNX0sImciOjguNjgzMTU1MTI1MDQxNTU5LCJoIjoiRGFya01hdHRlciIsImkiOiJkYXRhc2V0In0=) link, with the following viz style (dataset = spend_data):

```
width: 15
strokeWidth: 0
// color: opacity(rgba(255, 1, 255, 0.7), 0.5)
// color: opacity(cielab(87.73, -86.18, 83.18), 0.5)
// color: opacity(hsv(0.66,1,1), 0.5)
// color: opacity(hsl(0.66,1,1), 0.5)
// color: opacity(blue, 0.5)
// color: opacity(hex('#FABADA'), 0.5)
// color: opacity(ramp($category, [blue, red]), 0.5)
```