### PR TITLE
Fix classifiers legend data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## UNRELEASED
 
+### Fixed
+- Remove Infinity numbers from Classifiers `getLegendData()` method
+
 ## [1.3.0] 2019-06-03
 
 ## Added

--- a/src/renderer/viz/expressions/classification/Classifier.js
+++ b/src/renderer/viz/expressions/classification/Classifier.js
@@ -113,9 +113,13 @@ export default class Classifier extends BaseExpression {
         const breakpointsLength = breakpoints.length;
         const data = [];
 
+        const legendMin = this.min ? this.min.value : Number.NEGATIVE_INFINITY;
+        const legendMax = this.max ? this.max.value : Number.POSITIVE_INFINITY;
+
         for (let i = 0; i <= breakpointsLength; i++) {
-            const min = breakpoints[i - 1] || Number.NEGATIVE_INFINITY;
-            const max = breakpoints[i] || Number.POSITIVE_INFINITY;
+            const min = breakpoints[i - 1] === 0 ? 0 : breakpoints[i - 1] || legendMin;
+            const max = breakpoints[i] === 0 ? 0 : breakpoints[i] || legendMax;
+
             const key = [min, max];
             const value = i / breakpointsLength;
             data.push({ key, value });

--- a/src/renderer/viz/expressions/classification/Classifier.js
+++ b/src/renderer/viz/expressions/classification/Classifier.js
@@ -111,15 +111,13 @@ export default class Classifier extends BaseExpression {
     getLegendData () {
         const breakpoints = this._getBreakpointList();
         const breakpointsLength = breakpoints.length;
+        const legendMin = this.min.value;
+        const legendMax = this.max.value;
         const data = [];
-
-        const legendMin = this.min ? this.min.value : Number.NEGATIVE_INFINITY;
-        const legendMax = this.max ? this.max.value : Number.POSITIVE_INFINITY;
 
         for (let i = 0; i <= breakpointsLength; i++) {
             const min = breakpoints[i - 1] === 0 ? 0 : breakpoints[i - 1] || legendMin;
             const max = breakpoints[i] === 0 ? 0 : breakpoints[i] || legendMax;
-
             const key = [min, max];
             const value = i / breakpointsLength;
             data.push({ key, value });

--- a/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
@@ -2,7 +2,7 @@ import Classifier from './Classifier';
 import { checkExactNumberOfArguments } from '../utils';
 import { CLUSTER_FEATURE_COUNT } from '../../../../constants/metadata';
 import CartoValidationError, { CartoValidationErrorTypes } from '../../../../errors/carto-validation-error';
-import { globalMin, globalMax } from '../../expressions';
+import { number } from '../../expressions';
 
 /**
  * Classify `input` by using the equal intervals method with `n` buckets.
@@ -32,27 +32,12 @@ import { globalMin, globalMax } from '../../expressions';
 export default class GlobalEqIntervals extends Classifier {
     constructor (input, buckets) {
         checkExactNumberOfArguments(arguments, 2, 'globalEqIntervals');
-
         super({ input, buckets });
     }
 
     _bindMetadata (metadata) {
         super._bindMetadata(metadata);
-
         this._updateBreakpointsWith(metadata);
-    }
-
-    _resolveAliases (aliases) {
-        super._resolveAliases(aliases);
-
-        this._minMaxInitialization();
-    }
-
-    _minMaxInitialization () {
-        const input = this.input;
-        const children = { min: globalMin(input), max: globalMax(input) };
-
-        this._initializeChildren(children);
     }
 
     _updateBreakpointsWith (metadata) {
@@ -65,8 +50,8 @@ export default class GlobalEqIntervals extends Classifier {
 
         const name = this.input.name;
         const { min, max } = metadata.stats(name);
-        this.min = min;
-        this.max = max;
+        this.min = number(min);
+        this.max = number(max);
 
         this.breakpoints.map((breakpoint, index) => {
             const p = (index + 1) / this.numCategories;

--- a/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/GlobalEqIntervals.js
@@ -2,6 +2,7 @@ import Classifier from './Classifier';
 import { checkExactNumberOfArguments } from '../utils';
 import { CLUSTER_FEATURE_COUNT } from '../../../../constants/metadata';
 import CartoValidationError, { CartoValidationErrorTypes } from '../../../../errors/carto-validation-error';
+import { globalMin, globalMax } from '../../expressions';
 
 /**
  * Classify `input` by using the equal intervals method with `n` buckets.
@@ -31,6 +32,7 @@ import CartoValidationError, { CartoValidationErrorTypes } from '../../../../err
 export default class GlobalEqIntervals extends Classifier {
     constructor (input, buckets) {
         checkExactNumberOfArguments(arguments, 2, 'globalEqIntervals');
+
         super({ input, buckets });
     }
 
@@ -38,6 +40,19 @@ export default class GlobalEqIntervals extends Classifier {
         super._bindMetadata(metadata);
 
         this._updateBreakpointsWith(metadata);
+    }
+
+    _resolveAliases (aliases) {
+        super._resolveAliases(aliases);
+
+        this._minMaxInitialization();
+    }
+
+    _minMaxInitialization () {
+        const input = this.input;
+        const children = { min: globalMin(input), max: globalMax(input) };
+
+        this._initializeChildren(children);
     }
 
     _updateBreakpointsWith (metadata) {

--- a/src/renderer/viz/expressions/classification/GlobalStandardDev.js
+++ b/src/renderer/viz/expressions/classification/GlobalStandardDev.js
@@ -5,6 +5,7 @@ import CartoRuntimeError, { CartoRuntimeErrorTypes } from '../../../../errors/ca
 
 import { average, standardDeviation } from '../stats';
 import { CLUSTER_FEATURE_COUNT } from '../../../../constants/metadata';
+import { globalMin, globalMax } from '../../expressions';
 
 /**
  * Classify `input` by using the Mean-Standard Deviation method with `n` buckets.
@@ -61,6 +62,14 @@ export default class GlobalStandardDev extends Classifier {
         super._resolveAliases(aliases);
 
         this._validateClassSizeIsProperNumber();
+        this._minMaxInitialization();
+    }
+
+    _minMaxInitialization () {
+        const input = this.input;
+        const children = { min: globalMin(input), max: globalMax(input) };
+
+        this._initializeChildren(children);
     }
 
     _validateClassSizeIsProperNumber () {

--- a/src/renderer/viz/expressions/classification/GlobalStandardDev.js
+++ b/src/renderer/viz/expressions/classification/GlobalStandardDev.js
@@ -5,7 +5,7 @@ import CartoRuntimeError, { CartoRuntimeErrorTypes } from '../../../../errors/ca
 
 import { average, standardDeviation } from '../stats';
 import { CLUSTER_FEATURE_COUNT } from '../../../../constants/metadata';
-import { globalMin, globalMax } from '../../expressions';
+import { number } from '../../expressions';
 
 /**
  * Classify `input` by using the Mean-Standard Deviation method with `n` buckets.
@@ -62,14 +62,6 @@ export default class GlobalStandardDev extends Classifier {
         super._resolveAliases(aliases);
 
         this._validateClassSizeIsProperNumber();
-        this._minMaxInitialization();
-    }
-
-    _minMaxInitialization () {
-        const input = this.input;
-        const children = { min: globalMin(input), max: globalMax(input) };
-
-        this._initializeChildren(children);
     }
 
     _validateClassSizeIsProperNumber () {
@@ -100,6 +92,9 @@ export default class GlobalStandardDev extends Classifier {
         const sample = metadata.sample.map(s => s[name]);
         const avg = average(sample);
         const standardDev = standardDeviation(sample);
+        const { min, max } = metadata.stats(name);
+        this.min = number(min);
+        this.max = number(max);
 
         const breaks = calculateBreakpoints(avg, standardDev, this.numCategories, this._classSize.value);
         this.breakpoints.forEach((breakpoint, index) => {

--- a/src/renderer/viz/expressions/classification/ViewportEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/ViewportEqIntervals.js
@@ -42,7 +42,7 @@ export default class ViewportEqIntervals extends Classifier {
 
     _minMaxInitialization () {
         const input = this.input;
-        const children = { _min: viewportMin(input), _max: viewportMax(input) };
+        const children = { min: viewportMin(input), max: viewportMax(input) };
         this._initializeChildren(children);
     }
 
@@ -55,8 +55,8 @@ export default class ViewportEqIntervals extends Classifier {
     _validateInputIsNumericProperty () { /* noop */ }
 
     _genBreakpoints () {
-        const min = this._min.eval();
-        const max = this._max.eval();
+        const min = this.min.value;
+        const max = this.max.value;
 
         this.breakpoints.map((breakpoint, index) => {
             const p = (index + 1) / this.numCategories;

--- a/src/renderer/viz/expressions/classification/ViewportEqIntervals.js
+++ b/src/renderer/viz/expressions/classification/ViewportEqIntervals.js
@@ -43,6 +43,7 @@ export default class ViewportEqIntervals extends Classifier {
     _minMaxInitialization () {
         const input = this.input;
         const children = { min: viewportMin(input), max: viewportMax(input) };
+
         this._initializeChildren(children);
     }
 

--- a/src/renderer/viz/expressions/classification/ViewportQuantiles.js
+++ b/src/renderer/viz/expressions/classification/ViewportQuantiles.js
@@ -2,7 +2,7 @@ import Classifier from './Classifier';
 import { checkNumber, checkType, checkMaxArguments, checkMinArguments, implicitCast } from '../utils';
 import CartoValidationError, { CartoValidationErrorTypes } from '../../../../errors/carto-validation-error';
 
-import { viewportHistogram } from '../../expressions';
+import { viewportHistogram, viewportMin, viewportMax } from '../../expressions';
 import { DEFAULT_HISTOGRAM_SIZE } from './Classifier';
 
 /**
@@ -36,6 +36,7 @@ export default class ViewportQuantiles extends Classifier {
         checkMinArguments(arguments, 2, 'viewportQuantiles');
         checkMaxArguments(arguments, 3, 'viewportQuantiles');
         input = implicitCast(input);
+
         super({ input, buckets, _histogramSize: histogramSize });
     }
 
@@ -50,7 +51,11 @@ export default class ViewportQuantiles extends Classifier {
 
         const input = this.input;
         const histogramSize = this._histogramSize.value;
-        const children = { _histogram: viewportHistogram(input, histogramSize) };
+        const min = viewportMin(input);
+        const max = viewportMax(input);
+        const _histogram = viewportHistogram(input, histogramSize);
+
+        const children = { min, max, _histogram };
         this._initializeChildren(children);
     }
 

--- a/src/renderer/viz/expressions/classification/ViewportStandardDev.js
+++ b/src/renderer/viz/expressions/classification/ViewportStandardDev.js
@@ -2,7 +2,7 @@ import Classifier from './Classifier';
 import { checkNumber, checkType, checkMaxArguments, checkMinArguments } from '../utils';
 import CartoValidationError, { CartoValidationErrorTypes } from '../../../../errors/carto-validation-error';
 
-import { viewportHistogram } from '../../expressions';
+import { viewportHistogram, viewportMin, viewportMax } from '../../expressions';
 import { calculateBreakpoints } from './GlobalStandardDev';
 import { DEFAULT_HISTOGRAM_SIZE } from './Classifier';
 
@@ -63,7 +63,6 @@ export default class ViewportStandardDev extends Classifier {
     _resolveAliases (aliases) {
         super._resolveAliases(aliases);
 
-        this._validateClassSizeIsProperNumber();
         this._histogramInitialization();
     }
 
@@ -72,7 +71,11 @@ export default class ViewportStandardDev extends Classifier {
 
         const input = this.input;
         const histogramSize = this._histogramSize.value;
-        const children = { _histogram: viewportHistogram(input, histogramSize) };
+        const min = viewportMin(input);
+        const max = viewportMax(input);
+        const _histogram = viewportHistogram(input, histogramSize);
+
+        const children = { min, max, _histogram };
         this._initializeChildren(children);
     }
 

--- a/src/renderer/viz/expressions/classification/ViewportStandardDev.js
+++ b/src/renderer/viz/expressions/classification/ViewportStandardDev.js
@@ -63,6 +63,7 @@ export default class ViewportStandardDev extends Classifier {
     _resolveAliases (aliases) {
         super._resolveAliases(aliases);
 
+        this._validateClassSizeIsProperNumber();
         this._histogramInitialization();
     }
 

--- a/test/unit/renderer/viz/expressions/ramp.test.js
+++ b/test/unit/renderer/viz/expressions/ramp.test.js
@@ -1039,11 +1039,11 @@ describe('src/renderer/viz/expressions/ramp', () => {
                     actual = r.getLegendData().data;
                     expected = [
                         {
-                            key: [Number.NEGATIVE_INFINITY, 2.5],
+                            key: [1, 2.5],
                             value: red.value
                         },
                         {
-                            key: [2.5, Number.POSITIVE_INFINITY],
+                            key: [2.5, 4],
                             value: blue.value
                         }
                     ];


### PR DESCRIPTION
Related issue https://github.com/CartoDB/carto-vl/issues/1370

1) Added min/max values to the following _classifier_ expressions:

* viewportQuantiles
* viewportEqIntervals
* viewportStandardDev
* globalQuantiles
* globalEqIntervals
* globalStandardDev

2) Modified `getLegendData()` for Classifier parent class