### PR TITLE
Add extra test to carto.isBrowserSupported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix `value`, `eval()` and `getLegendData()` for binary operations
 - Support mixed multi geometries in GeoJSON: LineString & MultiLineString, Polygon & MultiPolygon
 - Support dates in Histogram expressions
+- Fix `carto.isBrowserSupported` adding a required check on MAX_VERTEX_TEXTURE_IMAGE_UNITS
 
 ## [1.3.1] 2019-06-17
 

--- a/docs/support/03-browser-support.md
+++ b/docs/support/03-browser-support.md
@@ -12,6 +12,9 @@ The library currently requires:
 * WebGL 1.
 * WebGL 1 `OES_texture_float` extension.
 * WebGL parameter `gl.MAX_RENDERBUFFER_SIZE` >= 1024.
+* WebGL parameter `gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS` >= 16.
+
+For a good experience, >= 8GB or RAM is recommended and also having a dedicated GPU with updated drivers.
 
 Some browsers, specially in old mobile devices, only have experimental or partial WebGL support. We cannot guarantee that CARTO VL will work on those cases.
 

--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -36,7 +36,7 @@ export const FILTERING_THRESHOLD = 0.5;
  */
 export const RTT_WIDTH = 1024;
 
-export const VERTEX_TEXTURE_IMAGE_UNITS = 16;
+export const MIN_VERTEX_TEXTURE_IMAGE_UNITS_NEEDED = 16;
 
 /**
  * @description Renderer constructor. Use it to create a new renderer bound to the provided canvas.
@@ -462,10 +462,10 @@ export function unsupportedBrowserReasons (canvas, gl, early = false) {
     }
 
     const vertexTextureImageUnits = gl.getParameter(gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS);
-    if (vertexTextureImageUnits < VERTEX_TEXTURE_IMAGE_UNITS) {
+    if (vertexTextureImageUnits < MIN_VERTEX_TEXTURE_IMAGE_UNITS_NEEDED) {
         reasons.push(
             new CartoRuntimeError(
-                `WebGL parameter 'gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS' is below the requirement: ${vertexTextureImageUnits} < ${VERTEX_TEXTURE_IMAGE_UNITS}`,
+                `WebGL parameter 'gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS' is below the requirement: ${vertexTextureImageUnits} < ${MIN_VERTEX_TEXTURE_IMAGE_UNITS_NEEDED}`,
                 CartoRuntimeErrorTypes.WEB_GL
             )
         );

--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -36,6 +36,8 @@ export const FILTERING_THRESHOLD = 0.5;
  */
 export const RTT_WIDTH = 1024;
 
+export const VERTEX_TEXTURE_IMAGE_UNITS = 16;
+
 /**
  * @description Renderer constructor. Use it to create a new renderer bound to the provided canvas.
  * Initialization will be done synchronously.
@@ -454,6 +456,16 @@ export function unsupportedBrowserReasons (canvas, gl, early = false) {
         reasons.push(
             new CartoRuntimeError(
                 `WebGL parameter 'gl.MAX_RENDERBUFFER_SIZE' is below the requirement: ${supportedRTT} < ${RTT_WIDTH}`,
+                CartoRuntimeErrorTypes.WEB_GL
+            )
+        );
+    }
+
+    const vertexTextureImageUnits = gl.getParameter(gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS);
+    if (vertexTextureImageUnits < VERTEX_TEXTURE_IMAGE_UNITS) {
+        reasons.push(
+            new CartoRuntimeError(
+                `WebGL parameter 'gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS' is below the requirement: ${vertexTextureImageUnits} < ${VERTEX_TEXTURE_IMAGE_UNITS}`,
                 CartoRuntimeErrorTypes.WEB_GL
             )
         );

--- a/test/unit/renderer/renderer.test.js
+++ b/test/unit/renderer/renderer.test.js
@@ -1,25 +1,38 @@
 import Renderer from '../../../src/renderer/Renderer';
-import { RTT_WIDTH, isBrowserSupported, unsupportedBrowserReasons } from '../../../src/renderer/Renderer';
+import { RTT_WIDTH, MIN_VERTEX_TEXTURE_IMAGE_UNITS_NEEDED, isBrowserSupported, unsupportedBrowserReasons } from '../../../src/renderer/Renderer';
 
 describe('src/renderer/Renderer', () => {
     describe('WebGL errors', () => {
         const webGLWithNoExtensions = {
+            MAX_RENDERBUFFER_SIZE: RTT_WIDTH,
+            MAX_VERTEX_TEXTURE_IMAGE_UNITS: MIN_VERTEX_TEXTURE_IMAGE_UNITS_NEEDED,
             getExtension: () => null,
-            getParameter: () => RTT_WIDTH
+            getParameter
         };
         const webGLWithInvalidParameter = {
+            MAX_RENDERBUFFER_SIZE: RTT_WIDTH - 1,
+            MAX_VERTEX_TEXTURE_IMAGE_UNITS: MIN_VERTEX_TEXTURE_IMAGE_UNITS_NEEDED,
             getExtension: () => ({}),
-            getParameter: () => RTT_WIDTH - 1
+            getParameter
         };
         const webGLWithNoExtensionsAndInvalidParameter = {
+            MAX_RENDERBUFFER_SIZE: RTT_WIDTH - 1,
+            MAX_VERTEX_TEXTURE_IMAGE_UNITS: MIN_VERTEX_TEXTURE_IMAGE_UNITS_NEEDED,
             getExtension: () => null,
-            getParameter: () => RTT_WIDTH - 1
+            getParameter
         };
         const webGLValidContext = {
+            MAX_RENDERBUFFER_SIZE: RTT_WIDTH,
+            MAX_VERTEX_TEXTURE_IMAGE_UNITS: MIN_VERTEX_TEXTURE_IMAGE_UNITS_NEEDED,
             getExtension: () => ({}),
-            getParameter: () => RTT_WIDTH
+            getParameter
         };
-
+        const webGLInvalidImageTextureUnits = {
+            MAX_RENDERBUFFER_SIZE: RTT_WIDTH,
+            MAX_VERTEX_TEXTURE_IMAGE_UNITS: 8,
+            getExtension: () => ({}),
+            getParameter
+        };
         const canvasWithNoWebGL = { getContext: () => null };
         const canvasWithNoExtensions = {
             getContext: () => webGLWithNoExtensions
@@ -111,6 +124,11 @@ describe('src/renderer/Renderer', () => {
                         /WebGL extension 'OES_texture_float' is unsupported/,
                         /WebGL parameter 'gl\.MAX_RENDERBUFFER_SIZE' is below the requirement.*/
                     ]
+                }, {
+                    ctx: webGLInvalidImageTextureUnits,
+                    errors: [
+                        /WebGL parameter 'gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS' is below the requirement*/
+                    ]
                 }
             ];
             invalidWebGLContextScenarios.forEach((scenario, i) => {
@@ -125,3 +143,7 @@ describe('src/renderer/Renderer', () => {
         });
     });
 });
+
+const getParameter = (parameter) => {
+    return parameter;
+};

--- a/test/unit/renderer/renderer.test.js
+++ b/test/unit/renderer/renderer.test.js
@@ -2,6 +2,10 @@ import Renderer from '../../../src/renderer/Renderer';
 import { RTT_WIDTH, MIN_VERTEX_TEXTURE_IMAGE_UNITS_NEEDED, isBrowserSupported, unsupportedBrowserReasons } from '../../../src/renderer/Renderer';
 
 describe('src/renderer/Renderer', () => {
+    const getParameter = (parameter) => {
+        return parameter;
+    };
+
     describe('WebGL errors', () => {
         const webGLWithNoExtensions = {
             MAX_RENDERBUFFER_SIZE: RTT_WIDTH,
@@ -143,7 +147,3 @@ describe('src/renderer/Renderer', () => {
         });
     });
 });
-
-const getParameter = (parameter) => {
-    return parameter;
-};


### PR DESCRIPTION
This adds a specific test to carto.isBrowserSupported, regarding to the WebGL MAX_VERTEX_TEXTURE_IMAGE_UNITS parameter.

### Related to: https://github.com/CartoDB/support/issues/2119