### PR TITLE
Update MAX_VERTEX_TEXTURE_IMAGE_UNITS parameter at browser support doc

### DIFF
--- a/docs/support/03-browser-support.md
+++ b/docs/support/03-browser-support.md
@@ -12,7 +12,7 @@ The library currently requires:
 * WebGL 1.
 * WebGL 1 `OES_texture_float` extension.
 * WebGL parameter `gl.MAX_RENDERBUFFER_SIZE` >= 1024.
-* WebGL parameter `gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS` >= 16.
+* WebGL parameter `gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS` >= 8.
 
 For a good experience, >= 8GB or RAM is recommended and also having a dedicated GPU with updated drivers.
 


### PR DESCRIPTION
### Related issue
https://github.com/CartoDB/carto-vl/issues/1408