### PR TITLE
Added noindex to examples used in the dev center

### DIFF
--- a/examples/advanced/classification-variables.html
+++ b/examples/advanced/classification-variables.html
@@ -5,6 +5,7 @@
   <title>Classification using variables | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/advanced/hurricane-harvey.html
+++ b/examples/advanced/hurricane-harvey.html
@@ -5,6 +5,7 @@
   <title>Hurricane Harvey | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/advanced/ocean-bathymetry.html
+++ b/examples/advanced/ocean-bathymetry.html
@@ -4,6 +4,7 @@
   <title>Ocean bathymetry | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/advanced/taxi-pickups.html
+++ b/examples/advanced/taxi-pickups.html
@@ -4,6 +4,7 @@
   <title>Taxi pickups | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/advanced/us-population-by-county.html
+++ b/examples/advanced/us-population-by-county.html
@@ -4,6 +4,7 @@
   <title>US Population by County | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/animation/add-feature-visibility.html
+++ b/examples/animation/add-feature-visibility.html
@@ -5,6 +5,7 @@
     <title>Add feature visibility | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <meta name="robots" content="noindex">
     <script src="../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/animation/animate-and-hold.html
+++ b/examples/animation/animate-and-hold.html
@@ -5,6 +5,7 @@
 	<title>Hold animated features | CARTO</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta charset="UTF-8">
+	<meta name="robots" content="noindex">
 	<script src="../../dist/carto-vl.js"></script>
 	<script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
 	<link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/animation/animate-by-date-range.html
+++ b/examples/animation/animate-by-date-range.html
@@ -5,6 +5,7 @@
     <title>Animate by date range | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <meta name="robots" content="noindex">
     <script src="../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/animation/animate-color-by-date.html
+++ b/examples/animation/animate-color-by-date.html
@@ -5,6 +5,7 @@
 	<title>Animate and color by date | CARTO</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta charset="UTF-8">
+	<meta name="robots" content="noindex">
 	<script src="../../dist/carto-vl.js"></script>
 	<script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
 	<link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/animation/animate-filtered-features.html
+++ b/examples/animation/animate-filtered-features.html
@@ -5,6 +5,7 @@
     <title>Animate and filter | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <meta name="robots" content="noindex">
     <script src="../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/animation/animate-width.html
+++ b/examples/animation/animate-width.html
@@ -5,6 +5,7 @@
     <title>Animate feature width | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <meta name="robots" content="noindex">
     <script src="../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/animation/animation-controls.html
+++ b/examples/animation/animation-controls.html
@@ -5,6 +5,7 @@
     <title>Animation | CARTO VL</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <meta name="robots" content="noindex">
     <script src="../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/basemap/basemap-labels-on-top.html
+++ b/examples/basemap/basemap-labels-on-top.html
@@ -5,6 +5,7 @@
   <title>Basemap labels on top | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/basemap/basemap-labels-under.html
+++ b/examples/basemap/basemap-labels-under.html
@@ -5,6 +5,7 @@
   <title>Basemap labels under | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/basemap/color-map-background.html
+++ b/examples/basemap/color-map-background.html
@@ -5,6 +5,7 @@
   <title>Color map background | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/basemap/pitch-bearing.html
+++ b/examples/basemap/pitch-bearing.html
@@ -5,6 +5,7 @@
   <title>Set pitch and bearing | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/basemap/project-layer.html
+++ b/examples/basemap/project-layer.html
@@ -5,6 +5,7 @@
   <title>Project layer | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/basics/add-layer.html
+++ b/examples/basics/add-layer.html
@@ -5,6 +5,7 @@
   <title>Add layer | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/basics/basic-style.html
+++ b/examples/basics/basic-style.html
@@ -4,6 +4,7 @@
   <title>Basic style | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/basics/browser-support.html
+++ b/examples/basics/browser-support.html
@@ -5,6 +5,7 @@
   <title>Check for browser support | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/interactivity/click.html
+++ b/examples/interactivity/click.html
@@ -4,6 +4,7 @@
   <title>Click | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/interactivity/hover.html
+++ b/examples/interactivity/hover.html
@@ -5,6 +5,7 @@
   <title>Hover | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/interactivity/interact-multiple-layers.html
+++ b/examples/interactivity/interact-multiple-layers.html
@@ -4,6 +4,7 @@
   <title>Interact with multiple layers | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/interactivity/interactive-based-styling.html
+++ b/examples/interactivity/interactive-based-styling.html
@@ -4,6 +4,7 @@
   <title>Interactive based styling | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/interactivity/interactive-filter.html
+++ b/examples/interactivity/interactive-filter.html
@@ -5,6 +5,7 @@
     <title>Interactive Filter | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <meta name="robots" content="noindex">
     <script src="../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/interactivity/pop-up-on-click.html
+++ b/examples/interactivity/pop-up-on-click.html
@@ -5,6 +5,7 @@
     <title>Add pop-ups on click | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <meta name="robots" content="noindex">
     <script src="../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/interactivity/pop-up-on-hover.html
+++ b/examples/interactivity/pop-up-on-hover.html
@@ -5,6 +5,7 @@
     <title>Add pop-ups on hover | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <meta name="robots" content="noindex">
     <script src="../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/labeling/cluster-labels-average.html
+++ b/examples/labeling/cluster-labels-average.html
@@ -4,6 +4,7 @@
 <head>
     <title>Label clusters by count | CARTO VL</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex">
     <script src="../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/labeling/cluster-labels-count.html
+++ b/examples/labeling/cluster-labels-count.html
@@ -4,6 +4,7 @@
 <head>
     <title>Label clusters by count | CARTO VL</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex">
     <script src="../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/labeling/point-labels-conditional-style.html
+++ b/examples/labeling/point-labels-conditional-style.html
@@ -5,6 +5,7 @@
   <title>Point labels conditional style | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/labeling/point-labels-size-zoom.html
+++ b/examples/labeling/point-labels-size-zoom.html
@@ -5,6 +5,7 @@
   <title>Point labels text size by zoom | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/labeling/point-labels.html
+++ b/examples/labeling/point-labels.html
@@ -5,6 +5,7 @@
   <title>Point labels | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/labeling/polygon-labels.html
+++ b/examples/labeling/polygon-labels.html
@@ -5,6 +5,7 @@
   <title>Label polygons | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/legends/category-line-legend.html
+++ b/examples/legends/category-line-legend.html
@@ -5,6 +5,7 @@
   <title>Line legend | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/legends/category-point-legend.html
+++ b/examples/legends/category-point-legend.html
@@ -5,6 +5,7 @@
     <title>Legend categories | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <meta name="robots" content="noindex">
     <script src="../../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/legends/choropleth-legend.html
+++ b/examples/legends/choropleth-legend.html
@@ -5,6 +5,7 @@
     <title>Legend classification | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <meta name="robots" content="noindex">
     <script src="../../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/legends/feature-and-legend-opacity.html
+++ b/examples/legends/feature-and-legend-opacity.html
@@ -5,6 +5,7 @@
     <title>Transparent Legend | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <meta name="robots" content="noindex">
     <script src="../../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/legends/image-legend.html
+++ b/examples/legends/image-legend.html
@@ -5,6 +5,7 @@
   <title>Image legend | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/legends/unclassed-point-legend.html
+++ b/examples/legends/unclassed-point-legend.html
@@ -5,6 +5,7 @@
   <title>Legend unclassed | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/sources/external-geojson.html
+++ b/examples/sources/external-geojson.html
@@ -4,6 +4,7 @@
   <title>External GeoJSON layer | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/sources/geojson-source-layer.html
+++ b/examples/sources/geojson-source-layer.html
@@ -5,6 +5,7 @@
     <title>Add GeoJSON layer | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <meta name="robots" content="noindex">
     <script src="../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/sources/multiple-layers.html
+++ b/examples/sources/multiple-layers.html
@@ -4,6 +4,7 @@
   <title>Add multiple layers | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/sources/select-layer.html
+++ b/examples/sources/select-layer.html
@@ -5,6 +5,7 @@
   <title>Select layer | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/sources/sql-source-layer.html
+++ b/examples/sources/sql-source-layer.html
@@ -5,6 +5,7 @@
   <title>SQL Source Layer | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/styling/color-schemes.html
+++ b/examples/styling/color-schemes.html
@@ -5,6 +5,7 @@
   <title>Color schemes | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/styling/color-spaces.html
+++ b/examples/styling/color-spaces.html
@@ -5,6 +5,7 @@
   <title>Color spaces | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/styling/draw-order.html
+++ b/examples/styling/draw-order.html
@@ -5,6 +5,7 @@
   <title>Draw order | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/styling/filter.html
+++ b/examples/styling/filter.html
@@ -5,6 +5,7 @@
   <title>Filter based styling | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/styling/image-external.html
+++ b/examples/styling/image-external.html
@@ -5,6 +5,7 @@
   <title>External Image | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/styling/image-multiple.html
+++ b/examples/styling/image-multiple.html
@@ -5,6 +5,7 @@
   <title>Multiple Images | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/styling/image-single.html
+++ b/examples/styling/image-single.html
@@ -5,6 +5,7 @@
   <title>Single Image | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/styling/scaled.html
+++ b/examples/styling/scaled.html
@@ -5,6 +5,7 @@
   <title>Scaled width | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/styling/style-by-category.html
+++ b/examples/styling/style-by-category.html
@@ -5,6 +5,7 @@
   <title>Style by category | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/styling/style-by-number.html
+++ b/examples/styling/style-by-number.html
@@ -5,6 +5,7 @@
   <title>Style by number | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/styling/style-with-variables.html
+++ b/examples/styling/style-with-variables.html
@@ -5,6 +5,7 @@
   <title>Style with variables | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/styling/viewport.html
+++ b/examples/styling/viewport.html
@@ -5,6 +5,7 @@
   <title>Viewport based styling | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/styling/zoom-range-filter.html
+++ b/examples/styling/zoom-range-filter.html
@@ -5,6 +5,7 @@
     <title>Filter by zoom range | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <meta name="robots" content="noindex">
     <script src="../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/styling/zoom-range-style.html
+++ b/examples/styling/zoom-range-style.html
@@ -5,6 +5,7 @@
     <title>Style by zoom range | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <meta name="robots" content="noindex">
     <script src="../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/widgets/category-chart.html
+++ b/examples/widgets/category-chart.html
@@ -5,6 +5,7 @@
   <title>Category chart | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/widgets/category-widget-viewport.html
+++ b/examples/widgets/category-widget-viewport.html
@@ -5,6 +5,7 @@
     <title>Viewport category widget | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <meta name="robots" content="noindex">
     <script src="../../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/widgets/histogram-widget-viewport.html
+++ b/examples/widgets/histogram-widget-viewport.html
@@ -5,6 +5,7 @@
     <title>Viewport histogram widget | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <meta name="robots" content="noindex">
     <script src="../../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/widgets/numeric-chart.html
+++ b/examples/widgets/numeric-chart.html
@@ -5,6 +5,7 @@
   <title>Numeric chart | CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/widgets/viewport-summary.html
+++ b/examples/widgets/viewport-summary.html
@@ -5,6 +5,7 @@
     <title>Viewport summary | CARTO</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
+    <meta name="robots" content="noindex">
     <script src="../../../dist/carto-vl.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css" rel="stylesheet" />

--- a/examples/widgets/weighted-histogram-table.html
+++ b/examples/widgets/weighted-histogram-table.html
@@ -5,6 +5,7 @@
   <title>Weighted histograms | CARTO VL</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
   <script src="../../dist/carto-vl.js"></script>
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />


### PR DESCRIPTION
Hello,
per request from @Julien-Hennico we prefer to don't index the pages that only contain a map (those that appear embedded in an iframe into the dev center). Let me know if like this is correct or I should do something else. Thanks!