### PR TITLE
Remove default 'key' color

### DIFF
--- a/src/renderer/viz/expressions/color/CIELab.js
+++ b/src/renderer/viz/expressions/color/CIELab.js
@@ -62,7 +62,7 @@ export default class CIELab extends BaseExpression {
     getLegendData () {
         const name = 'color';
         const value = this.value;
-        const key = 'color';
+        const key = '';
         const data = [{ key, value }];
 
         return { name, data };

--- a/src/renderer/viz/expressions/color/NamedColor.js
+++ b/src/renderer/viz/expressions/color/NamedColor.js
@@ -56,7 +56,7 @@ export default class NamedColor extends BaseExpression {
     getLegendData () {
         const name = 'color';
         const value = this.color;
-        const key = 'color';
+        const key = '';
         const data = [{ key, value }];
 
         return { name, data };

--- a/src/renderer/viz/expressions/color/hex.js
+++ b/src/renderer/viz/expressions/color/hex.js
@@ -59,7 +59,7 @@ export default class Hex extends BaseExpression {
     getLegendData () {
         const name = 'color';
         const value = this.value;
-        const key = 'color';
+        const key = '';
         const data = [{ key, value }];
 
         return { name, data };

--- a/src/renderer/viz/expressions/color/hsl.js
+++ b/src/renderer/viz/expressions/color/hsl.js
@@ -96,7 +96,7 @@ function genHSL (name, alpha = null) {
         getLegendData () {
             const name = 'color';
             const value = this.value;
-            const key = 'color';
+            const key = '';
             const data = [{ key, value }];
 
             return { name, data };

--- a/src/renderer/viz/expressions/color/hsv.js
+++ b/src/renderer/viz/expressions/color/hsv.js
@@ -122,7 +122,7 @@ function genHSV (name, alpha) {
         getLegendData () {
             const name = 'color';
             const value = this.value;
-            const key = 'color';
+            const key = '';
             const data = [{ key, value }];
 
             return { name, data };

--- a/src/renderer/viz/expressions/color/rgb.js
+++ b/src/renderer/viz/expressions/color/rgb.js
@@ -92,7 +92,7 @@ function genRGB (name, alpha) {
         getLegendData () {
             const name = 'color';
             const value = this.value;
-            const key = 'color';
+            const key = '';
             const data = [{ key, value }];
 
             return { name, data };

--- a/test/unit/renderer/viz/expressions/color/Opacity.test.js
+++ b/test/unit/renderer/viz/expressions/color/Opacity.test.js
@@ -34,7 +34,7 @@ describe('src/renderer/viz/expressions/opacity', () => {
             const expected = {
                 name: 'color',
                 data: [{
-                    key: 'color',
+                    key: '',
                     value: {
                         r: 0,
                         g: 0,
@@ -52,7 +52,7 @@ describe('src/renderer/viz/expressions/opacity', () => {
             const expected = {
                 name: 'color',
                 data: [{
-                    key: 'color',
+                    key: '',
                     value: {
                         r: 255,
                         g: 1,
@@ -70,7 +70,7 @@ describe('src/renderer/viz/expressions/opacity', () => {
             const expected = {
                 name: 'color',
                 data: [{
-                    key: 'color',
+                    key: '',
                     value: {
                         r: 0,
                         g: 0.9999316244751483,
@@ -88,7 +88,7 @@ describe('src/renderer/viz/expressions/opacity', () => {
             const expected = {
                 name: 'color',
                 data: [{
-                    key: 'color',
+                    key: '',
                     value: {
                         r: 0,
                         g: 10.20000000000001,
@@ -106,7 +106,7 @@ describe('src/renderer/viz/expressions/opacity', () => {
             const expected = {
                 name: 'color',
                 data: [{
-                    key: 'color',
+                    key: '',
                     value: {
                         r: 255,
                         g: 255,
@@ -124,7 +124,7 @@ describe('src/renderer/viz/expressions/opacity', () => {
             const expected = {
                 name: 'color',
                 data: [{
-                    key: 'color',
+                    key: '',
                     value: {
                         r: 250,
                         g: 186,


### PR DESCRIPTION
Related issue https://github.com/CartoDB/airship/issues/657

Although it seemed to be an Airship issue, this should be fixed in CARTO VL. This change doesn't have backwards compatibility issues, and it will be fixed in both Airship and CARTOframes once we release a patch with this change